### PR TITLE
examples now use os.getenv instead of python-dotenv

### DIFF
--- a/examples/futures_examples.py
+++ b/examples/futures_examples.py
@@ -6,9 +6,8 @@
 
 """Module that implements some example usage for the Kraken Futures REST clients"""
 import logging
+import os
 import time
-
-from dotenv import dotenv_values
 
 from kraken.futures.client import Funding, Market, Trade, User
 
@@ -21,8 +20,8 @@ logging.getLogger().setLevel(logging.INFO)
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
-key = dotenv_values(".env")["Futures_SANDBOX_KEY"]
-secret = dotenv_values(".env")["Futures_SANDBOX_SECRET"]
+key = os.getenv("Futures_SANDBOX_KEY")
+secret = os.getenv("Futures_SANDBOX_SECRET")
 
 #  _   _  ___ _____ _____
 # | \ | |/ _ \_   _| ____|_

--- a/examples/futures_trading_bot_template.py
+++ b/examples/futures_trading_bot_template.py
@@ -8,12 +8,12 @@
 import asyncio
 import logging
 import logging.config
+import os
 import sys
 import traceback
 
 import requests
 import urllib3
-from dotenv import dotenv_values
 
 from kraken.exceptions.exceptions import KrakenExceptions
 from kraken.futures.client import Funding, KrakenFuturesWSClient, Market, Trade, User
@@ -185,8 +185,8 @@ class ManagedBot:
 def main() -> None:
     """Main"""
     bot_config = {
-        "key": dotenv_values(".env")["Futures_API_KEY"],
-        "secret": dotenv_values(".env")["Futures_SECRET_KEY"],
+        "key": os.getenv("Futures_API_KEY"),
+        "secret": os.getenv("Futures_SECRET_KEY"),
         "products": ["PI_XBTUSD", "PF_SOLUSD"],
     }
     managed_bot = ManagedBot(config=bot_config)

--- a/examples/futures_ws_examples.py
+++ b/examples/futures_ws_examples.py
@@ -8,9 +8,8 @@
 import asyncio
 import logging
 import logging.config
+import os
 import time
-
-from dotenv import dotenv_values
 
 from kraken.futures.client import KrakenFuturesWSClient
 
@@ -27,8 +26,8 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 async def main() -> None:
     """Create bot and subscribe to topics/feeds"""
 
-    key = dotenv_values(".env")["Futures_API_KEY"]
-    secret = dotenv_values(".env")["Futures_SECRET_KEY"]
+    key = os.getenv("Futures_API_KEY")
+    secret = os.getenv("Futures_SECRET_KEY")
 
     # ___Custom_Trading_Bot__________
     class Bot(KrakenFuturesWSClient):

--- a/examples/spot_examples.py
+++ b/examples/spot_examples.py
@@ -7,9 +7,8 @@
 """Module that implements some example usage for the Kraken Futures REST clients"""
 import logging
 import logging.config
+import os
 import time
-
-from dotenv import dotenv_values
 
 from kraken.spot.client import Funding, Market, Staking, Trade, User
 
@@ -23,8 +22,8 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
-key = dotenv_values(".env")["API_KEY"]
-secret = dotenv_values(".env")["SECRET_KEY"]
+key = os.getenv("API_KEY")
+secret = os.getenv("SECRET_KEY")
 
 #  _   _  ___ _____ _____
 # | \ | |/ _ \_   _| ____|_
@@ -173,7 +172,7 @@ def funding_examples() -> None:
         print(funding.cancel_widthdraw(asset="DOT", refid="12345"))
         print(
             funding.wallet_transfer(
-                asset="ETH", amount=0.100, from_="Spot Wallet", to="Futures Wallet"
+                asset="ETH", amount=0.100, from_="Spot Wallet", to_="Futures Wallet"
             )
         )
 

--- a/examples/spot_trading_bot_template.py
+++ b/examples/spot_trading_bot_template.py
@@ -8,12 +8,12 @@
 import asyncio
 import logging
 import logging.config
+import os
 import sys
 import traceback
 
 import requests
 import urllib3
-from dotenv import dotenv_values
 
 from kraken.exceptions.exceptions import KrakenExceptions
 from kraken.spot.client import Funding, KrakenSpotWSClient, Market, Staking, Trade, User
@@ -207,8 +207,8 @@ class ManagedBot:
 def main() -> None:
     """Main"""
     bot_config = {
-        "key": dotenv_values(".env")["API_KEY"],
-        "secret": dotenv_values(".env")["SECRET_KEY"],
+        "key": os.getenv("API_KEY"),
+        "secret": os.getenv("SECRET_KEY"),
         "pairs": ["DOT/EUR", "XBT/USD"],
     }
     managed_bot = ManagedBot(config=bot_config)

--- a/examples/spot_ws_examples.py
+++ b/examples/spot_ws_examples.py
@@ -8,9 +8,8 @@
 import asyncio
 import logging
 import logging.config
+import os
 import time
-
-from dotenv import dotenv_values
 
 from kraken.spot.client import KrakenSpotWSClient
 
@@ -27,8 +26,8 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 async def main() -> None:
     """Create bot and subscribe to topics/feeds"""
 
-    key = dotenv_values(".env")["API_KEY"]
-    secret = dotenv_values(".env")["SECRET_KEY"]
+    key = os.getenv("API_KEY")
+    secret = os.getenv("SECRET_KEY")
 
     # ___Custom_Trading_Bot______________
     class Bot(KrakenSpotWSClient):


### PR DESCRIPTION
The provided examples now use the `os.getenv` method to access environment variables instead of the python-dotenv module.

Closes #33 