### PR TITLE
Apply kraken api changelog until mar 27 2023

### DIFF
--- a/kraken/spot/funding/funding.py
+++ b/kraken/spot/funding/funding.py
@@ -25,9 +25,11 @@ class FundingClient(KrakenBaseSpotAPI):
             params={"asset": asset, "method": method, "new": new},
         )
 
-    def get_recend_deposits_status(self, asset: str, method: str = None) -> dict:
+    def get_recend_deposits_status(self, asset: str = None, method: str = None) -> dict:
         """https://docs.kraken.com/rest/#operation/getStatusRecentDeposits"""
-        params = {"asset": asset}
+        params = {}
+        if asset is not None:
+            params["asset"] = asset
         if method is not None:
             params["method"] = method
         return self._request(method="POST", uri="/private/DepositStatus", params=params)
@@ -48,9 +50,11 @@ class FundingClient(KrakenBaseSpotAPI):
             params={"asset": asset, "key": str(key), "amount": str(amount)},
         )
 
-    def get_recend_withdraw_status(self, asset: str, method: str = None) -> dict:
+    def get_recend_withdraw_status(self, asset: str = None, method: str = None) -> dict:
         """https://docs.kraken.com/rest/#operation/getStatusRecentWithdrawals"""
-        params = {"asset": asset}
+        params = {}
+        if asset is not None:
+            params["asset"] = asset
         if method is not None:
             params["method"] = method
         return self._request(

--- a/kraken/spot/trade/trade.py
+++ b/kraken/spot/trade/trade.py
@@ -23,6 +23,7 @@ class TradeClient(KrakenBaseSpotAPI):
         price2: str = None,
         trigger: str = None,
         leverage: str = None,
+        reduce_only: bool = False,
         stp_type: str = "cancel-newest",
         oflags: List[str] = None,
         timeinforce: str = None,
@@ -45,6 +46,7 @@ class TradeClient(KrakenBaseSpotAPI):
             "stp_type": stp_type,
             "starttm": starttm,
             "validate": validate,
+            "reduce_only": reduce_only,
         }
         if trigger is not None:
             if ordertype in [

--- a/kraken/spot/user/user.py
+++ b/kraken/spot/user/user.py
@@ -80,9 +80,19 @@ class UserClient(KrakenBaseSpotAPI):
 
         return self._request(method="POST", uri="/private/ClosedOrders", params=params)
 
-    def get_orders_info(self, txid, trades: bool = False, userref: int = None) -> dict:
+    def get_orders_info(
+        self,
+        txid,
+        trades: bool = False,
+        userref: int = None,
+        consolidate_taker: bool = True,
+    ) -> dict:
         """https://docs.kraken.com/rest/#tag/User-Data/operation/getOrdersInfo"""
-        params = {"txid": txid, "trades": trades}
+        params = {
+            "txid": txid,
+            "trades": trades,
+            "consolidate_taker": consolidate_taker,
+        }
         if isinstance(txid, list):
             params["txid"] = self._to_str_list(txid)
         if userref is not None:
@@ -117,7 +127,10 @@ class UserClient(KrakenBaseSpotAPI):
         return self._request(
             method="POST",
             uri="/private/QueryTrades",
-            params={"trades": trades, "txid": self._to_str_list(txid)},
+            params={
+                "trades": trades,
+                "txid": self._to_str_list(txid),
+            },
         )
 
     def get_open_positions(

--- a/kraken/spot/user/user.py
+++ b/kraken/spot/user/user.py
@@ -237,3 +237,11 @@ class UserClient(KrakenBaseSpotAPI):
             uri="/private/RemoveExport",
             params={"id": id_, "type": type_},
         )
+
+    def create_subaccount(self, username: str, email: str) -> dict:
+        """https://docs.kraken.com/rest/#tag/User-Subaccounts"""
+        return self._request(
+            method="POST",
+            uri="/private/CreateSubaccount",
+            params={"username": username, "email": email},
+        )

--- a/tests/test_spot_rest.py
+++ b/tests/test_spot_rest.py
@@ -67,6 +67,28 @@ class UserTests(unittest.TestCase):
             )
         )
 
+    def test_get_trades_info(self) -> None:
+        for params, method in zip(
+            [
+                {"txid": "OXBBSK-EUGDR-TDNIEQ"},
+                {"txid": "OXBBSK-EUGDR-TDNIEQ", "trades": True},
+                {"txid": "OQQYNL-FXCFA-FBFVD7"},
+                {"txid": ["OE3B4A-NSIEQ-5L6HW3", "O23GOI-WZDVD-XWGC3R"]},
+            ],
+            [
+                self.__auth_user.get_trades_info,
+                self.__auth_user.get_trades_info,
+                self.__auth_user.get_trades_info,
+                self.__auth_user.get_trades_info,
+            ],
+        ):
+            try:
+                assert is_not_error(method(**params))
+            except KrakenExceptions.KrakenInvalidOrderError:
+                pass
+            finally:
+                time.sleep(2)
+
     def test_get_orders_info(self) -> None:
         for params, method in zip(
             [
@@ -78,8 +100,8 @@ class UserTests(unittest.TestCase):
             [
                 self.__auth_user.get_orders_info,
                 self.__auth_user.get_orders_info,
-                self.__auth_user.get_trades_info,
-                self.__auth_user.get_trades_info,
+                self.__auth_user.get_orders_info,
+                self.__auth_user.get_orders_info,
             ],
         ):
             try:
@@ -87,9 +109,11 @@ class UserTests(unittest.TestCase):
             except KrakenExceptions.KrakenInvalidOrderError:
                 pass
             finally:
-                time.sleep(1.5)
+                time.sleep(2)
 
     def test_get_trades_history(self) -> None:
+        time.sleep(3)
+
         assert is_not_error(
             self.__auth_user.get_trades_history(type_="all", trades=True)
         )
@@ -228,6 +252,13 @@ class UserTests(unittest.TestCase):
         except ValueError:
             pass
 
+    def test_create_subaccount(self) -> None:
+        # creating subaccounts is only availablle for institutional clients
+        with pytest.raises(KrakenExceptions.KrakenPermissionDeniedError):
+            self.__auth_user.create_subaccount(
+                email="abc@welt.de", username="tomtucker"
+            )
+
     def tearDown(self) -> None:
         return super().tearDown()
 
@@ -341,7 +372,7 @@ class TradeTests(unittest.TestCase):
             assert isinstance(
                 self.__auth_trade.create_order(
                     ordertype="stop-loss",
-                    side="buy",
+                    side="sell",
                     volume="1000",
                     trigger="last",
                     pair="XBTUSD",
@@ -430,12 +461,9 @@ class TradeTests(unittest.TestCase):
             pass
 
     def test_cancel_order(self) -> None:
-        try:
-            assert isinstance(
-                self.__auth_trade.cancel_order(txid="O2JLFP-VYFIW-35ZAAE"), dict
-            )
-        except KrakenExceptions.KrakenPermissionDeniedError:
-            pass
+        # because testing keys are not allowd to trade
+        with pytest.raises(KrakenExceptions.KrakenPermissionDeniedError):
+            self.__auth_trade.cancel_order(txid="OB6JJR-7NZ5P-N5SKCB")
 
     @unittest.skip("Skipping Spot test_cancel_all_orders endpoint")
     def test_cancel_all_orders(self) -> None:

--- a/tests/test_spot_rest.py
+++ b/tests/test_spot_rest.py
@@ -312,7 +312,6 @@ class TradeTests(unittest.TestCase):
                     pair="BTC/EUR",
                     price=0.01,
                     timeinforce="GTC",
-                    reduce_only=True,
                     validate=True,  # important to just test this endpoint without risking money
                 ),
                 dict,
@@ -349,6 +348,7 @@ class TradeTests(unittest.TestCase):
                     price="100",
                     price2="120",
                     leverage="2",
+                    reduce_only=True,
                     userref="12345",
                     close_ordertype="limit",
                     close_price="123",

--- a/tests/test_spot_rest.py
+++ b/tests/test_spot_rest.py
@@ -72,7 +72,7 @@ class UserTests(unittest.TestCase):
             [
                 {"txid": "OXBBSK-EUGDR-TDNIEQ"},
                 {"txid": "OXBBSK-EUGDR-TDNIEQ", "trades": True},
-                {"txid": "OQQYNL-FXCFA-FBFVD7"},
+                {"txid": "OQQYNL-FXCFA-FBFVD7", "consolidate_taker": True},
                 {"txid": ["OE3B4A-NSIEQ-5L6HW3", "O23GOI-WZDVD-XWGC3R"]},
             ],
             [
@@ -312,6 +312,7 @@ class TradeTests(unittest.TestCase):
                     pair="BTC/EUR",
                     price=0.01,
                     timeinforce="GTC",
+                    reduce_only=True,
                     validate=True,  # important to just test this endpoint without risking money
                 ),
                 dict,
@@ -531,8 +532,12 @@ class FundingTests(unittest.TestCase):
         )
 
     def test_get_recend_deposits_status(self) -> None:
+        assert isinstance(self.__auth_funding.get_recend_deposits_status(), list)
         assert isinstance(
             self.__auth_funding.get_recend_deposits_status(asset="XLM"), list
+        )
+        assert isinstance(
+            self.__auth_funding.get_recend_deposits_status(method="Stellar XLM"), list
         )
         assert isinstance(
             self.__auth_funding.get_recend_deposits_status(
@@ -565,8 +570,12 @@ class FundingTests(unittest.TestCase):
 
     @unittest.skip("Skipping Spot test_get_recend_withdraw_status endpoint")
     def test_get_recend_withdraw_status(self) -> None:
+        assert isinstance(self.__auth_funding.get_recend_withdraw_status(), list)
         assert isinstance(
             self.__auth_funding.get_recend_withdraw_status(asset="XLM"), list
+        )
+        assert isinstance(
+            self.__auth_funding.get_recend_withdraw_status(method="Stellar XLM"), list
         )
         try:
             assert is_not_error(


### PR DESCRIPTION
# Summary

* Added `create_subaccount` endpoint to `kraken.spot.client.User`(only for institutional cleints).
* `get_recend_deposits_status` and `get_recend_withdraw_status` in `kraken.spot.client.Funding` do not require the `asset` parameter anymore.
* The `reduce_only` parameter was added to the `kraken.spot.client.Trade.create_order` method.
* The `consolidate_trades` parameter was added to  `kraken.spot.client.User.get_orders_info`

Closes #37 
Closes #38 
Closes #39 