### PR TITLE
Use workflow_dispatch to only trigger tests with python<python3.11 manually

### DIFF
--- a/.github/workflows/additional_tests.yml
+++ b/.github/workflows/additional_tests.yml
@@ -1,0 +1,75 @@
+#
+# * Runs unittests for pyhton3.7,python3.8,...,pyhton3.10 using manual trigger
+#
+
+name: Additional Test Jobs - Manual Trigger
+
+on:
+  workflow_dispatch:
+    branches:
+      - "**"
+
+concurrency:
+  group: ADDITIONAL_TESTS-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1 # to avoid failing tests because of API Rate limits
+      matrix:
+        os: [ubuntu-latest] #, macos-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install -r requirements.txt
+
+      - name: Install package
+        run: python setup.py install
+
+      - name: Testing Spot REST endpoints
+        env:
+          SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
+          SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
+        run: |
+          pytest tests/test_spot_rest.py
+
+      - name: Testing Spot websocket client
+        env:
+          SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
+          SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
+        run: |
+          pytest tests/test_spot_websocket.py
+
+      - name: Testing Futures REST endpoints
+        env:
+          FUTURES_API_KEY: ${{ secrets.FUTURES_API_KEY }}
+          FUTURES_SECRET_KEY: ${{ secrets.FUTURES_SECRET_KEY }}
+          FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
+          FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
+        run: |
+          pytest tests/test_futures_rest.py
+
+      - name: Testing Futures websocket client
+        env:
+          FUTURES_API_KEY: ${{ secrets.FUTURES_API_KEY }}
+          FUTURES_SECRET_KEY: ${{ secrets.FUTURES_SECRET_KEY }}
+          FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
+          FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
+        run: |
+          pytest tests/test_futures_websocket.py

--- a/.github/workflows/additional_tests.yml
+++ b/.github/workflows/additional_tests.yml
@@ -6,8 +6,6 @@ name: Additional Test Jobs - Manual Trigger
 
 on:
   workflow_dispatch:
-    branches:
-      - "**"
 
 concurrency:
   group: ADDITIONAL_TESTS-${{ github.ref }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,3 +1,9 @@
+#
+# * Builds the package on different os
+# * Tests the package for Python 3.11
+# * Generate coverage report
+#
+
 name: CI/CD
 
 on:
@@ -61,7 +67,7 @@ jobs:
       max-parallel: 1 # to avoid failing tests because of API Rate limits
       matrix:
         os: [ubuntu-latest] #, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Summary
* Outsourced some tests to speed up the CI 
* Outsourced tests can be run manually

Closes #42 