### PR TITLE
Removed raising exception when currency not found in portfolio

### DIFF
--- a/kraken/spot/user/user.py
+++ b/kraken/spot/user/user.py
@@ -24,8 +24,6 @@ class UserClient(KrakenBaseSpotAPI):
             if symbol in curr_opts:
                 balance = float(value)
                 break
-        if balance == float(0):
-            raise ValueError("Currency not found!")
 
         available_balance = balance
         for order in self.get_open_orders()["open"].values():


### PR DESCRIPTION
As described in #46 the forced raising of an exception was removed since it makes more sense to return zero balances when the currency is not found in the actual portfolio than raising an error. 

This has occurred when calling the `get_balances` function of the `kraken.spot.client.User` client.  