### PR TITLE
54 add a workflow or jobs that run all tests before a merge is done

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,3 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# Github: https://github.com/btschwertfeger
+#
+# Template workflow to test the python-kraken-sdk.
+# Runs all non-trade endpoints and methods for:
+#   * Spot REST clients
+#   * Spot websocket client
+#   * Futures REST clients
+#   * Futures websocket client
+#
+
 name: Test
 
 on:
@@ -32,6 +44,9 @@ jobs:
       - name: Install package
         run: python -m pip install .
 
+      ##    Unittests of the Spot REST clients and endpoints
+      ##    Only non-trade endpoints are tested
+      ##
       - name: Testing Spot REST endpoints
         env:
           SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
@@ -39,6 +54,8 @@ jobs:
         run: |
           pytest tests/test_spot_rest.py
 
+      ##    Unittests of the Spot websocket client
+      ##
       - name: Testing Spot websocket client
         env:
           SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
@@ -46,6 +63,9 @@ jobs:
         run: |
           pytest tests/test_spot_websocket.py
 
+      ##    Unittests of the Futures REST clients and endpoints
+      ##    Only non-trade endpoints are tested
+      ##
       - name: Testing Futures REST endpoints
         env:
           FUTURES_API_KEY: ${{ secrets.FUTURES_API_KEY }}
@@ -55,6 +75,8 @@ jobs:
         run: |
           pytest tests/test_futures_rest.py
 
+      ##    Unittests of the Futures websocket client
+      ##
       - name: Testing Futures websocket client
         env:
           FUTURES_API_KEY: ${{ secrets.FUTURES_API_KEY }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -58,7 +58,7 @@ jobs:
   ##
   UploadTestPyPI:
     if: success() && github.ref == 'refs/heads/master'
-    needs: [Test-Py<3.11]
+    needs: [Test]
     name: Upload current development version to Test PyPI
     uses: ./.github/workflows/_pypi_publish.yml
     with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,9 +17,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ##    Checks the code logic, style and more
+  ##
   Pre-Commit:
     uses: ./.github/workflows/_pre_commit.yml
 
+  ##    Builds the package on multiple OS for multiple
+  ##    Python versions
+  ##
   Build:
     needs: [Pre-Commit]
     uses: ./.github/workflows/_build.yml
@@ -32,6 +37,8 @@ jobs:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
 
+  ##    Run the unittests for Python 3.7 until Pyrthon 3.11
+  ##
   Test:
     needs: [Build]
     uses: ./.github/workflows/_test.yml
@@ -40,15 +47,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
+  ##    Uploads the package to test.pypi.org on master if triggered by
+  ##    a regular commit/push.
+  ##
   UploadTestPyPI:
     if: success() && github.ref == 'refs/heads/master'
-    needs: [Test]
+    needs: [Test-Py<3.11]
     name: Upload current development version to Test PyPI
     uses: ./.github/workflows/_pypi_publish.yml
     with:
@@ -56,6 +66,8 @@ jobs:
     secrets:
       API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
+  ##    Generates and uploads the coverage statistics to codecov
+  ##
   CodeCov:
     needs: [Test]
     uses: ./.github/workflows/_codecov.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,14 @@ on:
     types: [created]
 
 jobs:
+  ##    Run pre-commit - just to make shure that the code is still
+  ##    in the proper format
+  ##
   Pre-Commit:
     uses: ./.github/workflows/_pre_commit.yml
 
+  ##    Build the package - for all Python versions
+  ##
   Build:
     uses: ./.github/workflows/_build.yml
     strategy:
@@ -28,6 +33,8 @@ jobs:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
 
+  ##    Run all tests to validate the package
+  ##
   Test:
     name: Test the package
     needs: [Build]
@@ -43,6 +50,8 @@ jobs:
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
+  ##    Upload the python-kraken-sdk to PyPI
+  ##
   UploadPyPI:
     needs: [Test]
     if: success() && github.ref == 'refs/heads/master'


### PR DESCRIPTION
# Summary

Tests now run for all supported Python versions. Previously the ran only for Python 3.11 - just for time reasons. The mentioned documentations of #54 only work for organisations and since I don't want to move this repository out of my namespace, the only option to ensure that the module runs for all supported Python versions is to run the tests on each commit.

As long there is no free solution (or for user-owned repositories) to run a specific workflow before a merge, this is the only solution I see for now. 
 
Closes #54 