### PR TITLE
Fix bug/typo: "recend" -> recent throughout kraken.spot

### DIFF
--- a/examples/spot_examples.py
+++ b/examples/spot_examples.py
@@ -83,7 +83,7 @@ def market_examples() -> None:
     print(market.get_ohlc(pair="XBTUSD", interval=5))
     print(market.get_order_book(pair="XBTUSD", count=10))
     print(market.get_recent_trades(pair="XBTUSD"))
-    print(market.get_recend_spreads(pair="XBTUSD"))
+    print(market.get_recent_spreads(pair="XBTUSD"))
     print(market.get_system_status())
     time.sleep(2)
 
@@ -159,7 +159,7 @@ def funding_examples() -> None:
     funding = Funding(key=key, secret=secret)
     print(funding.get_deposit_methods(asset="DOT"))
     # print(funding.get_deposit_address(asset='DOT', method='Polkadot'))
-    # print(funding.get_recend_deposits_status(asset='DOT'))
+    # print(funding.get_recent_deposits_status(asset='DOT'))
     print(
         funding.get_withdrawal_info(asset="DOT", key="MyPolkadotWallet", amount="200")
     )
@@ -170,7 +170,7 @@ def funding_examples() -> None:
     if False:
         time.sleep(2)
         print(funding.withdraw_funds(asset="DOT", key="MyPolkadotWallet", amount=200))
-        print(funding.get_recend_withdraw_status(asset="DOT"))
+        print(funding.get_recent_withdraw_status(asset="DOT"))
         print(funding.cancel_widthdraw(asset="DOT", refid="12345"))
         print(
             funding.wallet_transfer(

--- a/kraken/futures/trade/__init__.py
+++ b/kraken/futures/trade/__init__.py
@@ -55,7 +55,7 @@ class Trade(KrakenBaseFuturesAPI):
 
         .. code-block:: python
             :linenos:
-            :caption: Futures Trade: Get the recend fills
+            :caption: Futures Trade: Get the recent fills
 
             >>> from kraken.futures import Trade
             >>> trade = Trade(key="api-key", secret="secret-key")

--- a/kraken/spot/funding/__init__.py
+++ b/kraken/spot/funding/__init__.py
@@ -113,11 +113,11 @@ class Funding(KrakenBaseSpotAPI):
             params={"asset": asset, "method": method, "new": new},
         )
 
-    def get_recend_deposits_status(
+    def get_recent_deposits_status(
         self, asset: Union[str, None] = None, method: Union[str, None] = None
     ) -> List[dict]:
         """
-        Get information about the recend deposit status. The lookback period is 90 days and
+        Get information about the recent deposit status. The lookback period is 90 days and
         only the last 25 deposits will be returned.
 
         Requires the ``Query funds`` and ``Deposit funds`` API key permissions.
@@ -133,11 +133,11 @@ class Funding(KrakenBaseSpotAPI):
 
         .. code-block:: python
             :linenos:
-            :caption: Spot Funding: Get the recend deposit status
+            :caption: Spot Funding: Get the recent deposit status
 
             >>> from kraken.spot import Funding
             >>> funding = Funding(key="api-key", secret="secret-key")
-            >>> funding.get_recend_deposits_status()
+            >>> funding.get_recent_deposits_status()
             [
                 {
                     'method': 'Bank Frick (SEPA)',
@@ -267,11 +267,11 @@ class Funding(KrakenBaseSpotAPI):
             params={"asset": asset, "key": str(key), "amount": str(amount)},
         )
 
-    def get_recend_withdraw_status(
+    def get_recent_withdraw_status(
         self, asset: Union[str, None] = None, method: Union[str, None] = None
     ) -> List[dict]:
         """
-        Get information about the recend withdraw status, including withdraws of the
+        Get information about the recent withdraw status, including withdraws of the
         past 90 days but at max 500 results.
 
         - https://docs.kraken.com/rest/#operation/getStatusRecentWithdrawals
@@ -285,11 +285,11 @@ class Funding(KrakenBaseSpotAPI):
 
         .. code-block:: python
             :linenos:
-            :caption: Get the recend withdraw status
+            :caption: Get the recent withdraw status
 
             >>> from kraken.spot import Funding
             >>> funding = Funding(key="api-key", secret="secret-key")
-            >>> funding.get_recend_withdraw_status()
+            >>> funding.get_recent_withdraw_status()
             [
                 {
                     'method': 'Polkadot',

--- a/kraken/spot/market/__init__.py
+++ b/kraken/spot/market/__init__.py
@@ -299,7 +299,7 @@ class Market(KrakenBaseSpotAPI):
 
         - https://docs.kraken.com/rest/#operation/getRecentTrades
 
-        :param pair: Pair to get the recend trades
+        :param pair: Pair to get the recent trades
         :type pair: str
         :param since: Filter trades since given timestamp (default: ``None``)
         :type since: str | int | None, optional
@@ -308,7 +308,7 @@ class Market(KrakenBaseSpotAPI):
 
         .. code-block:: python
             :linenos:
-            :caption: Spot Market: Get the recend trades
+            :caption: Spot Market: Get the recent trades
 
             >>> from kraken.spot import Market
             >>> Market().get_recent_trades(pair="XBTUSD")
@@ -329,7 +329,7 @@ class Market(KrakenBaseSpotAPI):
             method="GET", uri="/public/Trades", params=params, auth=False
         )
 
-    def get_recend_spreads(
+    def get_recent_spreads(
         self, pair: str, since: Union[str, int, None] = None
     ) -> dict:
         """
@@ -337,7 +337,7 @@ class Market(KrakenBaseSpotAPI):
 
         - https://docs.kraken.com/rest/#operation/getRecentSpreads
 
-        :param pair: Pair to get the recend spreads
+        :param pair: Pair to get the recent spreads
         :type pair: str
         :param since: Filter trades since given timestamp (default: ``None``)
         :type since: str | int | None, optional
@@ -346,10 +346,10 @@ class Market(KrakenBaseSpotAPI):
 
         .. code-block:: python
             :linenos:
-            :caption: Spot Market: Get the recend spreads
+            :caption: Spot Market: Get the recent spreads
 
             >>> from kraken.spot import Market
-            >>> Market().get_recend_spreads(pair="XBTUSD")
+            >>> Market().get_recent_spreads(pair="XBTUSD")
             {
                 "XXBTZUSD": [
                     [1680714601, "28015.00000", "28019.40000"],

--- a/tests/spot/test_spot_funding.py
+++ b/tests/spot/test_spot_funding.py
@@ -21,14 +21,14 @@ def test_get_deposit_address(spot_auth_funding) -> None:
     )
 
 
-def test_get_recend_deposits_status(spot_auth_funding) -> None:
-    assert isinstance(spot_auth_funding.get_recend_deposits_status(), list)
-    assert isinstance(spot_auth_funding.get_recend_deposits_status(asset="XLM"), list)
+def test_get_recent_deposits_status(spot_auth_funding) -> None:
+    assert isinstance(spot_auth_funding.get_recent_deposits_status(), list)
+    assert isinstance(spot_auth_funding.get_recent_deposits_status(asset="XLM"), list)
     assert isinstance(
-        spot_auth_funding.get_recend_deposits_status(method="Stellar XLM"), list
+        spot_auth_funding.get_recent_deposits_status(method="Stellar XLM"), list
     )
     assert isinstance(
-        spot_auth_funding.get_recend_deposits_status(asset="XLM", method="Stellar XLM"),
+        spot_auth_funding.get_recent_deposits_status(asset="XLM", method="Stellar XLM"),
         list,
     )
 
@@ -55,12 +55,12 @@ def test_get_withdrawal_info(spot_auth_funding) -> None:
         )
 
 
-@pytest.mark.skip(reason="Skipping Spot test_get_recend_withdraw_status endpoint")
-def test_get_recend_withdraw_status(spot_auth_funding) -> None:
-    assert isinstance(spot_auth_funding.get_recend_withdraw_status(), list)
-    assert isinstance(spot_auth_funding.get_recend_withdraw_status(asset="XLM"), list)
+@pytest.mark.skip(reason="Skipping Spot test_get_recent_withdraw_status endpoint")
+def test_get_recent_withdraw_status(spot_auth_funding) -> None:
+    assert isinstance(spot_auth_funding.get_recent_withdraw_status(), list)
+    assert isinstance(spot_auth_funding.get_recent_withdraw_status(asset="XLM"), list)
     assert isinstance(
-        spot_auth_funding.get_recend_withdraw_status(method="Stellar XLM"), list
+        spot_auth_funding.get_recent_withdraw_status(method="Stellar XLM"), list
     )
 
 

--- a/tests/spot/test_spot_market.py
+++ b/tests/spot/test_spot_market.py
@@ -63,8 +63,8 @@ def test_get_recent_trades(spot_auth_market) -> None:
     )
 
 
-def test_get_recend_spreads(spot_auth_market) -> None:
-    assert is_not_error(spot_auth_market.get_recend_spreads(pair="XBTUSD"))
+def test_get_recent_spreads(spot_auth_market) -> None:
+    assert is_not_error(spot_auth_market.get_recent_spreads(pair="XBTUSD"))
     assert is_not_error(
-        spot_auth_market.get_recend_spreads(pair="XBTUSD", since="1616663618")
+        spot_auth_market.get_recent_spreads(pair="XBTUSD", since="1616663618")
     )


### PR DESCRIPTION
# Summary 

Within kraken.spot, there are numerous incidences where both the method and documentation mis-spells "recent" as "recend".  This is inconsistent within the module (eg get_recent_trades is spelled properly, while get_recend_spreads is not).

Most importantly, the typo makes this package less consistent with the Kraken REST API, where these calls all use "recent" instead of "recend".

This PR corrects the typo, in the:
* kraken.spot.market and kraken.spot.funding modules
* the associated tests
* the examples
* any comments throughout the repo
* etc

-----------

As an aside- I'm not sure if you are accepting outside PRs yet, so I apologize if not!

 Closes #77