### PR TITLE
Fixed bug where `spot.user.get_balances` floats to periodic X.9999...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,9 @@
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # Github: https://github.com/btschwertfeger
 
-VENV := venv
-PYTHON := $(VENV)/bin/python3
+PYTHON := python
 
-.PHONY := build dev install test test_upload live_upload clean
+.PHONY := build dev install test tests doc doctests clean
 
 help:
 	@grep "^##" Makefile | sed -e "s/##//"
@@ -20,7 +19,7 @@ build:
 ## dev		Installs the package in edit mode
 ##
 dev:
-	$(PYTHON) -m pip install -e .[dev]
+	$(PYTHON) -m pip install -e ".[dev]"
 
 ## doc		Build the documentation
 ##
@@ -37,7 +36,9 @@ install:
 ## test		Run the unittests
 ##
 test:
-	$(PYTHON) -m pytest tests/
+	$(PYTHON) -m pytest -v tests/
+
+tests: test
 
 ## doctest	Run the documentation tests
 ##
@@ -65,8 +66,14 @@ changelog:
 ## clean		Clean the workspace
 ##
 clean:
-	rm -rf .pytest_cache build/ dist/ python_kraken_sdk.egg-info docs/_build
-	rm -f .coverage kraken/_version.py *.log *.csv *.zip tests/*.zip tests/.csv
+	rm -rf .pytest_cache build/ dist/ \
+		python_kraken_sdk.egg-info \
+		docs/_build \
+		.vscode
+	rm -f .coverage coverage.xml \
+		kraken/_version.py \
+		*.log *.csv *.zip \
+		tests/*.zip tests/.csv
 
 	find tests -name "__pycache__" | xargs rm -rf
 	find kraken -name "__pycache__" | xargs rm -rf

--- a/kraken/spot/user/__init__.py
+++ b/kraken/spot/user/__init__.py
@@ -5,6 +5,7 @@
 #
 
 """ Module that implements the Kraken Spot User client"""
+from decimal import Decimal
 from typing import List, Union
 
 from kraken.base_api import KrakenBaseSpotAPI
@@ -89,28 +90,28 @@ class User(KrakenBaseSpotAPI):
             }
         """
 
-        balance = float(0)
+        balance = Decimal(0)
         curr_opts = (currency, f"Z{currency}", f"X{currency}")
         for symbol, value in self.get_account_balance().items():
             if symbol in curr_opts:
-                balance = float(value)
+                balance = Decimal(value)
                 break
 
         available_balance = balance
         for order in self.get_open_orders()["open"].values():
             if currency in order["descr"]["pair"][0 : len(currency)]:
                 if order["descr"]["type"] == "sell":
-                    available_balance -= float(order["vol"])
+                    available_balance -= Decimal(order["vol"])
             elif currency in order["descr"]["pair"][-len(currency) :]:
                 if order["descr"]["type"] == "buy":
-                    available_balance -= float(order["vol"]) * float(
+                    available_balance -= Decimal(order["vol"]) * Decimal(
                         order["descr"]["price"]
                     )
 
         return {
             "currency": currency,
-            "balance": balance,
-            "available_balance": available_balance,
+            "balance": float(balance),
+            "available_balance": float(available_balance),
         }
 
     def get_trade_balance(self, asset: str = "ZUSD") -> dict:


### PR DESCRIPTION
# Summary
When calculating the available balance of a currency, the regular float data type cant handle some values. Experiments has shown that some values ended up like 51.5879999999999... but the actual value was 51.5878. This was fixed by using `decimal.Decumal` during the calculation. The return values are still floats.