### PR TITLE
Add API rate limit exception; extend test doc strings

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: Build the package
-        run: python -m pip wheel -w dist --no-deps .
+        run: python -m pip wheel --no-deps .
 
       - name: Install the package
-        run: python3 -m pip install dist/python_kraken_sdk*.whl
+        run: python -m pip install python_kraken_sdk*.whl

--- a/.github/workflows/_codecov.yml
+++ b/.github/workflows/_codecov.yml
@@ -66,7 +66,7 @@ jobs:
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
         run: |
-          pytest -v -s --cov-report=xml
+          pytest -vv -s --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/_test_futures.yml
+++ b/.github/workflows/_test_futures.yml
@@ -59,7 +59,7 @@ jobs:
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
         run: |
-          pytest -vv -m "futures not futures_websocket" tests
+          pytest -vv -m "futures and not futures_websocket" tests
 
       ##    Unit tests of the Futures websocket client
       ##
@@ -70,4 +70,4 @@ jobs:
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
         run: |
-          pytest -vv -m "futures_websocket" tests
+          pytest -vv -m futures_websocket tests

--- a/.github/workflows/_test_futures.yml
+++ b/.github/workflows/_test_futures.yml
@@ -59,7 +59,7 @@ jobs:
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
         run: |
-          pytest `grep "websocket" -L tests/futures/test_futures_*.py`
+          pytest -vv -m "futures not futures_websocket" tests
 
       ##    Unit tests of the Futures websocket client
       ##
@@ -70,4 +70,4 @@ jobs:
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
         run: |
-          pytest tests/futures/test_futures_websocket.py
+          pytest -vv -m "futures_websocket" tests

--- a/.github/workflows/_test_futures_private.yml
+++ b/.github/workflows/_test_futures_private.yml
@@ -2,7 +2,8 @@
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # Github: https://github.com/btschwertfeger
 #
-# Template workflow to test the Futures endpoints of the python-kraken-sdk.
+# Template workflow to test the private Futures endpoints
+# of the python-kraken-sdk.
 # Runs tests for:
 #   * Futures REST clients
 #   * Futures websocket client
@@ -50,7 +51,7 @@ jobs:
       - name: Install package
         run: python -m pip install .
 
-      ##    Unit tests of the Futures REST clients and endpoints
+      ##    Unit tests of the private Futures REST clients and endpoints
       ##
       - name: Testing Futures REST endpoints
         env:
@@ -59,7 +60,7 @@ jobs:
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
         run: |
-          pytest -vv -m "futures and not futures_websocket" tests
+          pytest -vv -m "futures_auth and not futures_websocket" tests
 
       ##    Unit tests of the Futures websocket client
       ##

--- a/.github/workflows/_test_futures_public.yml
+++ b/.github/workflows/_test_futures_public.yml
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# Github: https://github.com/btschwertfeger
+#
+# Template workflow to test the public Futures endpoints
+# of the python-kraken-sdk.
+# Runs tests for:
+#   * Futures REST clients
+#
+
+name: Test Futures
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+      python-version:
+        type: string
+        required: true
+
+jobs:
+  Test-Futures:
+    name: Test ${{ inputs.os }} ${{ inputs.python-version }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Install package
+        run: python -m pip install .
+
+      ##    Unit tests of the public Futures REST clients and endpoints
+      ##
+      - name: Testing Futures REST endpoints
+        run: |
+          pytest -vv -m "futures and not futures_auth and not futures_websocket" tests

--- a/.github/workflows/_test_spot.yml
+++ b/.github/workflows/_test_spot.yml
@@ -53,7 +53,7 @@ jobs:
           SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
           SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
         run: |
-          pytest `grep "websocket" -L tests/spot/test_spot_*.py`
+          pytest -vv -m "spot not spot_websocket" tests
 
       ##    Unit tests of the Spot websocket client
       ##
@@ -62,4 +62,4 @@ jobs:
           SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
           SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
         run: |
-          pytest tests/spot/test_spot_websocket.py
+          pytest -vv -m "spot_websocket" tests

--- a/.github/workflows/_test_spot.yml
+++ b/.github/workflows/_test_spot.yml
@@ -53,7 +53,7 @@ jobs:
           SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
           SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
         run: |
-          pytest -vv -m "spot not spot_websocket" tests
+          pytest -vv -m "spot and not spot_websocket" tests
 
       ##    Unit tests of the Spot websocket client
       ##
@@ -62,4 +62,4 @@ jobs:
           SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
           SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
         run: |
-          pytest -vv -m "spot_websocket" tests
+          pytest -vv -m spot_websocket tests

--- a/.github/workflows/_test_spot_private.yml
+++ b/.github/workflows/_test_spot_private.yml
@@ -2,7 +2,8 @@
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # Github: https://github.com/btschwertfeger
 #
-# Template workflow to test the Spot endpoints python-kraken-sdk.
+# Template workflow to test the private Spot endpoints
+# of the python-kraken-sdk.
 # Runs tests for:
 #   * Spot REST clients
 #   * Spot websocket client
@@ -46,14 +47,14 @@ jobs:
       - name: Install package
         run: python -m pip install .
 
-      ##    Unit tests of the Spot REST clients and endpoints
+      ##    Unit tests of the private Spot REST clients and endpoints
       ##
       - name: Testing Spot REST endpoints
         env:
           SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
           SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
         run: |
-          pytest -vv -m "spot and not spot_websocket" tests
+          pytest -vv -m "spot_auth and not spot_websocket" tests
 
       ##    Unit tests of the Spot websocket client
       ##

--- a/.github/workflows/_test_spot_public.yml
+++ b/.github/workflows/_test_spot_public.yml
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# Github: https://github.com/btschwertfeger
+#
+# Template workflow to test the public Spot endpoints
+# of the python-kraken-sdk.
+# Runs tests for:
+#   * Spot REST clients
+#
+
+name: Test Spot
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+      python-version:
+        type: string
+        required: true
+
+jobs:
+  Test-Spot:
+    name: Test ${{ inputs.os }} ${{ inputs.python-version }}
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Install package
+        run: python -m pip install .
+
+      ##    Unit tests of the public Spot REST clients and endpoints
+      ##
+      - name: Testing Spot REST endpoints
+        run: |
+          pytest -vv -m "spot and not spot_auth and not spot_websocket" tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest] #, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest] # todo: windows-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,16 +17,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ## ==========================================================================
   ##    Checks the code logic, style and more
   ##
   Pre-Commit:
     uses: ./.github/workflows/_pre_commit.yml
 
+  ## ==========================================================================
   ##  Discover vulnerabilities
   ##
   CodeQL:
     uses: ./.github/workflows/_codeql.yml
 
+  ## ==========================================================================
   ##    Builds the package on multiple OS for multiple
   ##    Python versions
   ##
@@ -42,6 +45,7 @@ jobs:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
 
+  ## ==========================================================================
   ##    Build the documentation
   ##
   Build-Doc:
@@ -51,11 +55,27 @@ jobs:
       os: "ubuntu-latest"
       python-version: "3.11"
 
-  ##    Run the Spot tests for Python 3.7 until 3.11
+  ## ==========================================================================
+  ##          Run the Spot tests for Python 3.7 until 3.11
   ##
-  Test-Spot:
+  ##  (public endpoints)
+  ##
+  Test-Spot-Public:
     needs: [Build]
-    uses: ./.github/workflows/_test_spot.yml
+    uses: ./.github/workflows/_test_spot_public.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+  ##
+  ##  (private endpoints)
+  Test-Spot-Private:
+    needs: [Build]
+    uses: ./.github/workflows/_test_spot_private.yml
     strategy:
       max-parallel: 1 # to avoid failing tests because of API Rate limits
       fail-fast: false
@@ -65,15 +85,28 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-    secrets:
-      SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
-      SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
+    secrets: inherit
 
-  ##    Run the Futures tests for Python 3.7 until 3.11
+  ## ==========================================================================
+  ##        Run the Futures tests for Python 3.7 until 3.11
   ##
-  Test-Futures:
+  ##  (public endpoints)
+  Test-Futures-Public:
     needs: [Build]
-    uses: ./.github/workflows/_test_futures.yml
+    uses: ./.github/workflows/_test_futures_public.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+  ##
+  ##  (private endpoints)
+  Test-Futures-Private:
+    needs: [Build]
+    uses: ./.github/workflows/_test_futures_private.yml
     strategy:
       max-parallel: 1 # to avoid failing tests because of API Rate limits
       fail-fast: false
@@ -83,18 +116,21 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-    secrets:
-      FUTURES_API_KEY: ${{ secrets.FUTURES_API_KEY }}
-      FUTURES_SECRET_KEY: ${{ secrets.FUTURES_SECRET_KEY }}
-      FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
-      FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
+    secrets: inherit
 
+  ## ==========================================================================
   ##    Uploads the package to test.pypi.org on master if triggered by
   ##    a regular commit/push.
   ##
   UploadTestPyPI:
     if: success() && github.ref == 'refs/heads/master'
-    needs: [Test-Spot, Test-Futures]
+    needs:
+      [
+        Test-Spot-Public,
+        Test-Spot-Private,
+        Test-Futures-Public,
+        Test-Futures-Private,
+      ]
     name: Upload current development version to Test PyPI
     uses: ./.github/workflows/_pypi_publish.yml
     with:
@@ -102,19 +138,19 @@ jobs:
     secrets:
       API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
+  ## ==========================================================================
   ##    Generates and uploads the coverage statistics to codecov
   ##
   CodeCov:
-    needs: [Test-Spot, Test-Futures]
+    needs:
+      [
+        Test-Spot-Public,
+        Test-Spot-Private,
+        Test-Futures-Public,
+        Test-Futures-Private,
+      ]
     uses: ./.github/workflows/_codecov.yml
     with:
       os: "ubuntu-latest"
       python-version: "3.11"
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
-      SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
-      FUTURES_API_KEY: ${{ secrets.FUTURES_API_KEY }}
-      FUTURES_SECRET_KEY: ${{ secrets.FUTURES_SECRET_KEY }}
-      FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
-      FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,20 @@ on:
     types: [created]
 
 jobs:
+  ## ==========================================================================
   ##    Run pre-commit - just to make shure that the code is still
   ##    in the proper format
   ##
   Pre-Commit:
     uses: ./.github/workflows/_pre_commit.yml
 
+  ## ==========================================================================
   ##  Discover vulnerabilities
   ##
   CodeQL:
     uses: ./.github/workflows/_codeql.yml
 
+  ## ==========================================================================
   ##    Build the package - for all Python versions
   ##
   Build:
@@ -39,6 +42,7 @@ jobs:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
 
+  ## ==========================================================================
   ##    Build the documentation
   ##
   Build-Doc:
@@ -48,11 +52,27 @@ jobs:
       os: "ubuntu-latest"
       python-version: "3.11"
 
-  ##    Run the Spot tests for Python 3.7 until 3.11
+  ## ==========================================================================
+  ##          Run the Spot tests for Python 3.7 until 3.11
   ##
-  Test-Spot:
+  ##  (public endpoints)
+  ##
+  Test-Spot-Public:
     needs: [Build]
-    uses: ./.github/workflows/_test_spot.yml
+    uses: ./.github/workflows/_test_spot_public.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+  ##
+  ##  (private endpoints)
+  Test-Spot-Private:
+    needs: [Build]
+    uses: ./.github/workflows/_test_spot_private.yml
     strategy:
       max-parallel: 1 # to avoid failing tests because of API Rate limits
       fail-fast: false
@@ -64,11 +84,26 @@ jobs:
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
-  ##    Run the Futures tests for Python 3.7 until 3.11
+  ## ==========================================================================
+  ##        Run the Futures tests for Python 3.7 until 3.11
   ##
-  Test-Futures:
+  ##  (public endpoints)
+  Test-Futures-Public:
     needs: [Build]
-    uses: ./.github/workflows/_test_futures.yml
+    uses: ./.github/workflows/_test_futures_public.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+  ##
+  ##  (private endpoints)
+  Test-Futures-Private:
+    needs: [Build]
+    uses: ./.github/workflows/_test_futures_private.yml
     strategy:
       max-parallel: 1 # to avoid failing tests because of API Rate limits
       fail-fast: false
@@ -80,10 +115,17 @@ jobs:
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
+  ## ==========================================================================
   ##    Upload the python-kraken-sdk to Test PyPI
   ##
   UploadTestPyPI:
-    needs: [Test-Spot, Test-Futures]
+    needs:
+      [
+        Test-Spot-Public,
+        Test-Spot-Private,
+        Test-Futures-Public,
+        Test-Futures-Private,
+      ]
     name: Upload the current release to Test PyPI
     uses: ./.github/workflows/_pypi_publish.yml
     with:
@@ -91,10 +133,11 @@ jobs:
     secrets:
       API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
+  ## ==========================================================================
   ##    Upload the python-kraken-sdk to Production PyPI
   ##
   UploadPyPI:
-    needs: [Test]
+    needs: [UploadTestPyPI]
     name: Upload the current release to PyPI
     uses: ./.github/workflows/_pypi_publish.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest] #, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*whl
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+pytest.xml
 *.cover
 *.py,cover
 .hypothesis/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,23 @@
 
 [Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v1.1.0...HEAD)
 
+**Breaking changes:**
+
+- \(inconsistent spelling/typo\) recend --\> recent in kraken.spot [\#77](https://github.com/btschwertfeger/python-kraken-sdk/issues/77)
+- Fix bug/typo: "recend" -\> recent throughout kraken.spot [\#76](https://github.com/btschwertfeger/python-kraken-sdk/pull/76) ([jcr-jeff](https://github.com/jcr-jeff))
+
 **Fixed bugs:**
 
 - Release workflow skips the PyPI publish [\#67](https://github.com/btschwertfeger/python-kraken-sdk/issues/67)
+- Fixed bug where `spot.user.get_balances` floats to periodic X.9999... [\#78](https://github.com/btschwertfeger/python-kraken-sdk/pull/78) ([btschwertfeger](https://github.com/btschwertfeger))
 - Fix PyPI upload job + extend disclaimer [\#70](https://github.com/btschwertfeger/python-kraken-sdk/pull/70) ([btschwertfeger](https://github.com/btschwertfeger))
 - Fix and extend release workflow [\#68](https://github.com/btschwertfeger/python-kraken-sdk/pull/68) ([btschwertfeger](https://github.com/btschwertfeger))
+
+**Merged pull requests:**
+
+- Split the unit tests into individual files [\#75](https://github.com/btschwertfeger/python-kraken-sdk/pull/75) ([btschwertfeger](https://github.com/btschwertfeger))
+- Removed matrix from CodeQL job [\#74](https://github.com/btschwertfeger/python-kraken-sdk/pull/74) ([btschwertfeger](https://github.com/btschwertfeger))
+- Add a Changelog [\#73](https://github.com/btschwertfeger/python-kraken-sdk/pull/73) ([btschwertfeger](https://github.com/btschwertfeger))
 
 ## [v1.1.0](https://github.com/btschwertfeger/python-kraken-sdk/tree/v1.1.0) (2023-04-08)
 
@@ -32,7 +44,7 @@
 **Fixed bugs:**
 
 - Cannot access private historical events of the Futures Market client [\#62](https://github.com/btschwertfeger/python-kraken-sdk/issues/62)
-- Avoid raising ValueError in get_balance if currency is not found in the portfolio [\#46](https://github.com/btschwertfeger/python-kraken-sdk/issues/46)
+- Avoid raising ValueError in `get_balance` if currency is not found in the portfolio [\#46](https://github.com/btschwertfeger/python-kraken-sdk/issues/46)
 
 **Closed issues:**
 
@@ -74,8 +86,8 @@
 
 **Merged pull requests:**
 
-- Release v1.0.1 [\#44](https://github.com/btschwertfeger/python-kraken-sdk/pull/44) ([btschwertfeger](https://github.com/btschwertfeger))
 - examples now use os.getenv instead of python-dotenv [\#34](https://github.com/btschwertfeger/python-kraken-sdk/pull/34) ([btschwertfeger](https://github.com/btschwertfeger))
+- Release v1.0.1 [\#44](https://github.com/btschwertfeger/python-kraken-sdk/pull/44) ([btschwertfeger](https://github.com/btschwertfeger))
 
 ## [v1.0.0](https://github.com/btschwertfeger/python-kraken-sdk/tree/v1.0.0) (2023-03-04)
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ help:
 build:
 	$(PYTHON) -m pip wheel -w dist --no-deps .
 
+rebuild: clean build
+
 ## dev		Installs the package in edit mode
 ##
 dev:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@
 
 PYTHON := python
 
-.PHONY := build dev install test tests doc doctests clean
+PYTEST_OPTS := -vv --junit-xml=pytest.xml
+PYTEST_COV_OPTS := $(PYTEST_OPTS) --cov --cov-report=xml:coverage.xml --cov-report=term
+TEST_DIR := tests
+
+.PHONY := build dev install test tests coverage doc doctest clean changelog pre-commit
 
 help:
 	@grep "^##" Makefile | sed -e "s/##//"
@@ -38,9 +42,12 @@ install:
 ## test		Run the unittests
 ##
 test:
-	$(PYTHON) -m pytest -v tests/
+	$(PYTHON) -m pytest $(PYTEST_OPTS) $(TEST_DIR)
 
 tests: test
+
+coverage:
+	$(PYTHON) -m pytest $(PYTEST_COV_OPTS) $(TEST_DIR)
 
 ## doctest	Run the documentation tests
 ##
@@ -72,7 +79,7 @@ clean:
 		python_kraken_sdk.egg-info \
 		docs/_build \
 		.vscode
-	rm -f .coverage coverage.xml \
+	rm -f .coverage coverage.xml pytest.xml \
 		kraken/_version.py \
 		*.log *.csv *.zip \
 		tests/*.zip tests/.csv

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ pre-commit:
 ##
 changelog:
 	docker run -it --rm \
-		-v "$(pwd)":/usr/local/src/pksdk \
+		-v $(PWD):/usr/local/src/your-app \
 		githubchangeloggenerator/github-changelog-generator \
 		-u btschwertfeger \
 		-p python-kraken-sdk \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![CodeQL](https://github.com/btschwertfeger/python-kraken-sdk/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/btschwertfeger/python-kraken-sdk/actions/workflows/codeql.yml)
 [![CI/CD](https://github.com/btschwertfeger/python-kraken-sdk/actions/workflows/cicd.yml/badge.svg?branch=master)](https://github.com/btschwertfeger/python-kraken-sdk/actions/workflows/cicd.yml)
-![codecov](https://codecov.io/gh/btschwertfeger/python-kraken-sdk/branch/master/badge.svg)
+[![codecov](https://codecov.io/gh/btschwertfeger/python-kraken-sdk/branch/master/badge.svg)](https://app.codecov.io/gh/btschwertfeger/python-kraken-sdk)
 
 ![release](https://shields.io/github/release-date/btschwertfeger/python-kraken-sdk)
 ![release](https://shields.io/github/v/release/btschwertfeger/python-kraken-sdk?display_name=tag)

--- a/kraken/exceptions/__init__.py
+++ b/kraken/exceptions/__init__.py
@@ -31,6 +31,7 @@ class KrakenException:
             "EAPI:Invalid key": self.KrakenInvalidAPIKeyError,
             "EAPI:Invalid signature": self.KrakenInvalidSignatureError,
             "EAPI:Invalid nonce": self.KrakenInvalidNonceError,
+            "EAPI:Rate limit exceeded": self.KrakenApiLimitExceededError,
             "EOrder:Invalid order": self.KrakenInvalidOrderError,
             "EOrder:Invalid price": self.KrakenInvalidPriceError,
             "EOrder:Cannot open position": self.KrakenCannotOpenPositionError,

--- a/kraken/exceptions/__init__.py
+++ b/kraken/exceptions/__init__.py
@@ -57,6 +57,7 @@ class KrakenException:
             "EFunding:Unknown asset": self.KrakenUnknownAssetError,
             "EQuery:Unknown asset": self.KrakenUnknownAssetError,
             "EQuery:Unknown asset pair": self.KrakenUnknownAssetPairError,
+            # "WDatabase:No change": ,
             ##      Futures Trading Errors
             ##
             "authenticationError": self.KrakenAuthenticationError,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,14 @@ classifiers = [
 "Bug Tracker" = "https://github.com/btschwertfeger/python-kraken-sdk/issues"
 "Documentation" = "https://python-kraken-sdk.readthedocs.io/en/stable/"
 
+[project.optional-dependencies]
+dev = [
+  "pytest", "pytest-cov",
+  "sphinx", "sphinx-rtd-theme",
+  "black"
+]
+examples = ["matplotlib"]
+
 [tool.setuptools]
 include-package-data = false
 
@@ -58,9 +66,21 @@ local_scheme = "no-local-version"
 junit_family = "xunit2"
 testpaths = ["tests"]
 
-[project.optional-dependencies]
-dev = [
-  "pytest", "pytest-cov",
-  "sphinx", "sphinx-rtd-theme"
+[tool.pytest.ini_options]
+markers = [
+    "spot: mark a test that tests a Spot endpoint.",
+    "spot_auth: mark a test that tests a authenticaed Spot endpoint.",
+    "spot_trade: mark a test that tests a Spot Trade endpoint.",
+    "spot_user: mark a test that tests a Spot User endpoint.",
+    "spot_market: mark a test that tests a Spot Market endpoint.",
+    "spot_funding: mark a test that tests a Spot Funding endpoint.",
+    "spot_staking: mark a test that tests a Spot Staking endpoint.",
+    "spot_websocket: mark a test that tests a Spot Websocket endpoint.",
+    "futures: mark a test that tests a Futures endpoint.",
+    "futures_auth: mark a test that tests a authenticated Futures endpoint.",
+    "futures_market: mark a test that tests a Futures Market endpoint.",
+    "futures_user: mark a test that tests a Futures User endpoint.",
+    "futures_trade: mark a test that tests a Futures Trade endpoint.",
+    "futures_funding: mark a test that tests a Futures Funding endpoint.",
+    "futures_websocket: mark a test that tests a Futures Websocket endpoint.",
 ]
-examples = ["matplotlib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "python-kraken-sdk"
 dynamic = ["version"]
 authors = [
-  { name="Benjamin Thomas Schwertfeger", email="development@b-schwertfeger.de" },
+  { name="Benjamin Thomas Schwertfeger", email="contact@b-schwertfeger.de" },
 ]
 description = "Collection of REST and websocket clients to interact with the Kraken cryptocurrency exchange."
 readme = "README.md"

--- a/tests/futures/conftest.py
+++ b/tests/futures/conftest.py
@@ -12,19 +12,19 @@ from kraken.futures import Funding, Market, Trade, User
 
 
 @pytest.fixture
-def futures_market() -> None:
+def futures_market() -> Market:
     return Market()
 
 
 @pytest.fixture
-def futures_auth_market() -> None:
+def futures_auth_market() -> Market:
     return Market(
         key=os.getenv("FUTURES_API_KEY"), secret=os.getenv("FUTURES_SECRET_KEY")
     )
 
 
 @pytest.fixture
-def futures_demo_market() -> None:
+def futures_demo_market() -> Market:
     return Market(
         key=os.getenv("FUTURES_SANDBOX_KEY"),
         secret=os.getenv("FUTURES_SANDBOX_SECRET"),
@@ -33,19 +33,19 @@ def futures_demo_market() -> None:
 
 
 @pytest.fixture
-def futures_user() -> None:
+def futures_user() -> User:
     return User()
 
 
 @pytest.fixture
-def futures_auth_user() -> None:
+def futures_auth_user() -> User:
     return User(
         key=os.getenv("FUTURES_API_KEY"), secret=os.getenv("FUTURES_SECRET_KEY")
     )
 
 
 @pytest.fixture
-def futures_demo_user() -> None:
+def futures_demo_user() -> User:
     return User(
         key=os.getenv("FUTURES_SANDBOX_KEY"),
         secret=os.getenv("FUTURES_SANDBOX_SECRET"),
@@ -54,19 +54,19 @@ def futures_demo_user() -> None:
 
 
 @pytest.fixture
-def futures_trade() -> None:
+def futures_trade() -> Trade:
     return Trade()
 
 
 @pytest.fixture
-def futures_auth_trade() -> None:
+def futures_auth_trade() -> Trade:
     return Trade(
         key=os.getenv("FUTURES_API_KEY"), secret=os.getenv("FUTURES_SECRET_KEY")
     )
 
 
 @pytest.fixture
-def futures_demo_trade() -> None:
+def futures_demo_trade() -> Trade:
     return Trade(
         key=os.getenv("FUTURES_SANDBOX_KEY"),
         secret=os.getenv("FUTURES_SANDBOX_SECRET"),
@@ -75,19 +75,19 @@ def futures_demo_trade() -> None:
 
 
 @pytest.fixture
-def futures_funding() -> None:
+def futures_funding() -> Funding:
     return Funding()
 
 
 @pytest.fixture
-def futures_auth_funding() -> None:
+def futures_auth_funding() -> Funding:
     return Funding(
         key=os.getenv("FUTURES_API_KEY"), secret=os.getenv("FUTURES_SECRET_KEY")
     )
 
 
 @pytest.fixture
-def futures_demo_funding() -> None:
+def futures_demo_funding() -> Funding:
     return Funding(
         key=os.getenv("FUTURES_SANDBOX_KEY"),
         secret=os.getenv("FUTURES_SANDBOX_SECRET"),

--- a/tests/futures/test_futures_funding.py
+++ b/tests/futures/test_futures_funding.py
@@ -7,15 +7,30 @@ import pytest
 
 from .helper import is_not_error, is_success
 
+# todo: Mocking? Or is this to dangerous?
 
+
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_funding
 def test_get_historical_funding_rates(futures_demo_funding) -> None:
+    """
+    Checks the ``get_historical_funding_rates`` function.
+    """
     assert is_success(
         futures_demo_funding.get_historical_funding_rates(symbol="PF_SOLUSD")
     )
 
 
-@pytest.mark.skip(reason="Skipping Futures initiate_wallet_transfer endpoint")
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_funding
+@pytest.mark.skip(reason="CI does not have withdraw permission")
 def test_initiate_wallet_transfer(futures_demo_funding) -> None:
+    """
+    Checks the ``initiate_wallet_transfer`` function - skipped since
+    a transfer in testing is not desired.
+    """
     # accounts must exist..
     # print(futures_demo_funding.initiate_wallet_transfer(
     #     amount=200, fromAccount='Futures Wallet', toAccount='Spot Wallet', unit='XBT'
@@ -23,8 +38,14 @@ def test_initiate_wallet_transfer(futures_demo_funding) -> None:
     pass
 
 
-@pytest.mark.skip(reason="Skipping Futures initiate_subaccount_transfer endpoint")
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_funding
+@pytest.mark.skip(reason="CI does not have withdraw permission")
 def test_initiate_subccount_transfer(futures_demo_funding) -> None:
+    """
+    Checks the ``initiate_subaccount_transfer`` function.
+    """
     # print(futures_demo_funding.initiate_subccount_transfer(
     #     amount=200,
     #     fromAccount='The wallet (cash or margin account) from which funds should be debited',
@@ -36,8 +57,14 @@ def test_initiate_subccount_transfer(futures_demo_funding) -> None:
     pass
 
 
-@pytest.mark.skip(reason="Skipping Futures withdrawal_to_spot_wallet endpoint")
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_funding
+@pytest.mark.skip(reason="CI does not have withdraw permission")
 def test_initiate_withdrawal_to_spot_wallet(futures_demo_funding) -> None:
+    """
+    Checks the ``initiate_withdrawal_to_spot_wallet`` function.
+    """
     # print(futures_demo_funding.initiate_withdrawal_to_spot_wallet(
     #     amount=200,
     #     currency='XBT',

--- a/tests/futures/test_futures_market.py
+++ b/tests/futures/test_futures_market.py
@@ -150,6 +150,7 @@ def test_get_historical_funding_rates(futures_market) -> None:
 
 
 @pytest.mark.futures
+@pytest.mark.futures_auth
 @pytest.mark.futures_market
 def test_get_leverage_preference(futures_auth_market) -> None:
     """

--- a/tests/futures/test_futures_market.py
+++ b/tests/futures/test_futures_market.py
@@ -9,7 +9,12 @@ import pytest
 from .helper import is_not_error, is_success
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_ohlc(futures_market) -> None:
+    """
+    Checks the ``get_ohlc`` endpoint.
+    """
     assert isinstance(
         futures_market.get_ohlc(
             tick_type="trade",
@@ -21,70 +26,146 @@ def test_get_ohlc(futures_market) -> None:
         dict,
     )
 
-    with pytest.raises(ValueError):  # wrong tick type
+
+@pytest.mark.futures
+@pytest.mark.futures_market
+def test_get_ohlc_failing_wrong_tick_type(futures_market) -> None:
+    """
+    Checks the ``get_ohlc`` function by passig an invalid tick type.
+    """
+    with pytest.raises(ValueError):
         futures_market.get_ohlc(symbol="XBTUSDT", resolution="240", tick_type="fail")
 
-    with pytest.raises(ValueError):  # wrong resolution
+
+@pytest.mark.futures
+@pytest.mark.futures_market
+def test_get_ohlc_failing_wrong_resolution(futures_market) -> None:
+    """
+    Checks the ``get_ohlc`` function by passing an invalid resolution.
+    """
+    with pytest.raises(ValueError):
         futures_market.get_ohlc(symbol="XBTUSDT", resolution="1234", tick_type="trade")
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_tick_types(futures_market) -> None:
     assert isinstance(futures_market.get_tick_types(), list)
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_tradeable_products(futures_market) -> None:
+    """
+    Checks the ``get_tradeable_products`` endpoint.
+    """
     assert isinstance(futures_market.get_tradeable_products(tick_type="mark"), list)
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_resolutions(futures_market) -> None:
+    """
+    Checks the ``get_resolutions`` endpoint.
+    """
     assert isinstance(
         futures_market.get_resolutions(tick_type="trade", tradeable="PI_XBTUSD"),
         list,
     )
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_fee_schedules(futures_market) -> None:
+    """
+    Checks the ``get_fee_schedules`` endpoint.
+    """
     assert is_success(futures_market.get_fee_schedules())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_market
 def test_get_fee_schedules_vol(futures_auth_market) -> None:
+    """
+    Checks the ``get_fee_schedules_vol`` endpoint.
+    """
     assert is_success(futures_auth_market.get_fee_schedules_vol())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_orderbook(futures_market) -> None:
+    """
+    Checks the ``get_orderbook`` endpoint.
+    """
     # assert type(market.get_orderbook()) == dict # raises 500-INTERNAL_SERVER_ERROR on Kraken, but symbol is optional as described in the API documentation (Dec, 2022)
     assert is_success(futures_market.get_orderbook(symbol="PI_XBTUSD"))
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_tickers(futures_market) -> None:
+    """
+    Checks the ``get_tickers`` endpoint.
+    """
     assert is_success(futures_market.get_tickers())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_instruments(futures_market) -> None:
+    """
+    Checks the ``get_instruments`` endpoint.
+    """
     assert is_success(futures_market.get_instruments())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_instruments_status(futures_market) -> None:
+    """
+    Checks the ``get_instruments_status`` endpoint.
+    """
     assert is_success(futures_market.get_instruments_status())
     assert is_success(futures_market.get_instruments_status(instrument="PI_XBTUSD"))
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_trade_history(futures_market) -> None:
+    """
+    Checks the ``get_trade_history`` endpoint.
+    """
     assert is_success(futures_market.get_trade_history(symbol="PI_XBTUSD"))
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_historical_funding_rates(futures_market) -> None:
+    """
+    Checks the ``get_historical_funding_rates`` endpoint.
+    """
     assert is_success(futures_market.get_historical_funding_rates(symbol="PI_XBTUSD"))
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_leverage_preference(futures_auth_market) -> None:
+    """
+    Checks the ``get_leverage_preference`` endpoint.
+    """
     assert is_not_error(futures_auth_market.get_leverage_preference())
 
 
-@pytest.mark.skip(
-    reason="Skipping Futures set_leverage_preference endpoint, because this needs full access without sandbox environment"
-)
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_market
+@pytest.mark.skip(reason="CI does not have trade permission")
 def test_set_leverage_preference(futures_auth_market) -> None:
+    """
+    Checks the ``set_leverage_preference`` endpoint.
+    """
     old_leverage_preferences = futures_auth_market.get_leverage_preference()
     assert (
         "result" in old_leverage_preferences.keys()
@@ -114,14 +195,24 @@ def test_set_leverage_preference(futures_auth_market) -> None:
                 break
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_market
 def test_get_pnl_preference(futures_auth_market) -> None:
+    """
+    Checks the ``get_pnl_preference`` endpoint.
+    """
     assert is_not_error(futures_auth_market.get_pnl_preference())
 
 
-@pytest.mark.skip(
-    reason="Skipping Futures set_pnl_preference endpoint, because this needs full access without sandbox environment"
-)
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_market
+@pytest.mark.skip(reason="CI does not have trade permission")
 def test_set_pnl_preference(futures_auth_market) -> None:
+    """
+    Checks the ``set_pnl_preference`` endpoint.
+    """
     old_pnl_preference = futures_auth_market.get_pnl_preference()
     assert (
         "result" in old_pnl_preference.keys()
@@ -153,7 +244,12 @@ def test_set_pnl_preference(futures_auth_market) -> None:
                 break
 
 
+@pytest.mark.futures
+@pytest.mark.futures_market
 def test_get_public_execution_events(futures_market) -> None:
+    """
+    Checks the ``get_public_execution_events`` endpoint.
+    """
     assert is_not_error(
         futures_market.get_public_execution_events(
             tradeable="PF_SOLUSD", since=1668989233, before=1668999999
@@ -161,7 +257,12 @@ def test_get_public_execution_events(futures_market) -> None:
     )
 
 
-def get_public_order_events(futures_market) -> None:
+@pytest.mark.futures
+@pytest.mark.futures_market
+def test_get_public_order_events(futures_market) -> None:
+    """
+    Checks the ``public_order_events`` endpoint.
+    """
     assert is_not_error(
         futures_market.get_public_order_events(
             tradeable="PF_SOLUSD", since=1668989233, sort="asc"
@@ -169,7 +270,12 @@ def get_public_order_events(futures_market) -> None:
     )
 
 
-def get_public_mark_price_events(futures_market) -> None:
+@pytest.mark.futures
+@pytest.mark.futures_market
+def test_get_public_mark_price_events(futures_market) -> None:
+    """
+    Checks the ``get_public_mark_price_events`` endpoint.
+    """
     assert is_not_error(
         futures_market.get_public_mark_price_events(
             tradeable="PF_SOLUSD", since=1668989233

--- a/tests/futures/test_futures_trade.py
+++ b/tests/futures/test_futures_trade.py
@@ -14,30 +14,51 @@ from .helper import is_success
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests(futures_demo_trade):
-    """Fixture to execute asserts before and after a test is run"""
+    """
+    Fixture that ensures all orders are cancelled after test.
+    """
     # Setup: fill with any logic you want
 
     yield  # this is where the testing happens
 
-    # Teardown : fill with any logic you want
+    # Teardown: fill with any logic you want
     futures_demo_trade.cancel_all_orders()
+    sleep(0.25)
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
 def test_get_fills(futures_demo_trade) -> None:
+    """
+    Checks the ``get_fills`` endpoint.
+    """
     assert is_success(futures_demo_trade.get_fills())
     assert is_success(
         futures_demo_trade.get_fills(lastFillTime="2020-07-21T12:41:52.790Z")
     )
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
 def test_dead_mans_switch(futures_demo_trade) -> None:
+    """
+    Checks the ``dead_mans_switch`` endpoint.
+    """
     assert is_success(futures_demo_trade.dead_mans_switch(timeout=60))
     assert is_success(
         futures_demo_trade.dead_mans_switch(timeout=0)
     )  # reset dead mans switch
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
 def test_get_orders_status(futures_demo_trade) -> None:
+    """
+    Checks the ``get_orders_status`` endpoint.
+    """
     assert is_success(
         futures_demo_trade.get_orders_status(
             orderIds=[
@@ -56,7 +77,13 @@ def test_get_orders_status(futures_demo_trade) -> None:
     )
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
 def test_create_order(futures_demo_trade) -> None:
+    """
+    Checks the ``create_order`` endpoint.
+    """
     try:
         futures_demo_trade.create_order(
             orderType="lmt",
@@ -101,7 +128,14 @@ def test_create_order(futures_demo_trade) -> None:
     #     pass
 
 
-def test_failing_create_order(futures_demo_trade) -> None:
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
+def test_create_order_failing(futures_demo_trade) -> None:
+    """
+    Checks ``create_order`` endpoint to fail when using invalid
+    parameters.
+    """
     with pytest.raises(ValueError):
         futures_demo_trade.create_order(
             orderType="mkt",
@@ -122,7 +156,13 @@ def test_failing_create_order(futures_demo_trade) -> None:
         )
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
 def test_create_batch_order(futures_demo_trade) -> None:
+    """
+    Checks the ``create_order_batch`` endpoint.
+    """
     try:
         assert is_success(
             futures_demo_trade.create_batch_order(
@@ -162,7 +202,13 @@ def test_create_batch_order(futures_demo_trade) -> None:
         pass
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
 def test_edit_order(futures_demo_trade) -> None:
+    """
+    Checks the ``edit_order`` endpoint.
+    """
     # success, because kraken received the correct message, even if the id is invalid
     assert is_success(
         futures_demo_trade.edit_order(orderId="my_another_client_id", limitPrice=3)
@@ -175,21 +221,47 @@ def test_edit_order(futures_demo_trade) -> None:
     )
 
 
-def test_failing_edit_order(futures_demo_trade) -> None:
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
+def test_edit_order_failing(futures_demo_trade) -> None:
+    """
+    Checks if the ``edit_order`` endpoint fails when using invalid
+    parameters.
+    """
     with pytest.raises(ValueError):
         futures_demo_trade.edit_order()
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
 def test_cancel_order(futures_demo_trade) -> None:
+    """
+    Checks the ``cancel_order`` endpoint.
+    """
     assert is_success(futures_demo_trade.cancel_order(cliOrdId="my_another_client_id"))
     assert is_success(futures_demo_trade.cancel_order(order_id="1234"))
 
 
-def test_failing_cancel_order(futures_demo_trade) -> None:
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
+def test_cancel_order_failing(futures_demo_trade) -> None:
+    """
+    Checks if the ``cancel_order`` endpoint is failing when
+    passing invalid arguments.
+    """
     with pytest.raises(ValueError):
         futures_demo_trade.cancel_order()
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_trade
 def test_cancel_all_orders(futures_demo_trade) -> None:
+    """
+    Checks the ``cancel_all_orders`` endpoint.
+    """
     assert is_success(futures_demo_trade.cancel_all_orders(symbol="pi_xbtusd"))
     assert is_success(futures_demo_trade.cancel_all_orders())

--- a/tests/futures/test_futures_user.py
+++ b/tests/futures/test_futures_user.py
@@ -4,44 +4,94 @@
 # Github: https://github.com/btschwertfeger
 #
 
+import os
 import random
+import tempfile
+
+import pytest
 
 from .helper import is_success
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_wallets(futures_auth_user) -> None:
+    """
+    Checks the ``get_wallets`` endpoint.
+    """
     assert is_success(futures_auth_user.get_wallets())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_subaccounts(futures_auth_user) -> None:
+    """
+    Checks the ``get_subaccounts`` endpoint.
+    """
     assert is_success(futures_auth_user.get_subaccounts())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_unwindqueue(futures_auth_user) -> None:
+    """
+    Checks the ``get_unwindqueue`` endpoint.
+    """
     assert is_success(futures_auth_user.get_unwindqueue())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_notifications(futures_auth_user) -> None:
+    """
+    Checks the ``get_notifications`` endpoint.
+    """
     assert is_success(futures_auth_user.get_notifications())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_account_log(futures_auth_user) -> None:
+    """
+    Checks the ``get_account_log`` endpoint.
+    """
     assert isinstance(futures_auth_user.get_account_log(), dict)
     assert isinstance(
         futures_auth_user.get_account_log(info="futures liquidation"), dict
     )
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_account_log_csv(futures_auth_user) -> None:
+    """
+    Checks the ``get_account_log_csv`` endpoint.
+    """
     response = futures_auth_user.get_account_log_csv()
     assert response.status_code in (200, "200")
-    with open(f"account_log-{random.randint(0, 10000)}.csv", "wb") as file:
-        for chunk in response.iter_content(chunk_size=512):
-            if chunk:
-                file.write(chunk)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with open(
+            os.path.join(tmp_dir, f"account_log-{random.randint(0, 10000)}.csv"), "wb"
+        ) as file:
+            for chunk in response.iter_content(chunk_size=512):
+                if chunk:
+                    file.write(chunk)
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_execution_events(futures_auth_user) -> None:
+    """
+    Checks the ``get_execution_events`` endpoint.
+    """
     result = futures_auth_user.get_execution_events(
         tradeable="PF_SOLUSD", since=1668989233, before=1668999999, sort="asc"
     )
@@ -50,7 +100,13 @@ def test_get_execution_events(futures_auth_user) -> None:
     assert "elements" in result.keys()
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_order_events(futures_auth_user) -> None:
+    """
+    Checks the ``get_order_events`` endpoint.
+    """
     result = futures_auth_user.get_order_events(
         tradeable="PF_SOLUSD", since=1668989233, before=1668999999, sort="asc"
     )
@@ -58,15 +114,33 @@ def test_get_order_events(futures_auth_user) -> None:
     assert "elements" in result.keys()
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_open_orders(futures_auth_user) -> None:
+    """
+    Checks the ``get_open_orders`` endpoint.
+    """
     assert is_success(futures_auth_user.get_open_orders())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_open_positions(futures_auth_user) -> None:
+    """
+    Checks the ``get_open_positions`` endpoint.
+    """
     assert is_success(futures_auth_user.get_open_positions())
 
 
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
 def test_get_trigger_events(futures_auth_user) -> None:
+    """
+    Checks the ``get_trigger_events`` endpoint.
+    """
     result = futures_auth_user.get_trigger_events(
         tradeable="PF_SOLUSD", since=1668989233, before=1668999999, sort="asc"
     )

--- a/tests/futures/test_futures_websocket.py
+++ b/tests/futures/test_futures_websocket.py
@@ -3,7 +3,9 @@
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # Github: https://github.com/btschwertfeger
 #
+
 """Module that tests the Kraken Futures websocket client"""
+
 import asyncio
 import os
 import time
@@ -18,15 +20,17 @@ class Bot(KrakenFuturesWSClient):
     """Class to create a websocket bot"""
 
     async def on_message(self, event) -> None:
-        log = ""
-        try:
-            with open("futures_ws_log.log", "r", encoding="utf-8") as f:
-                log = f.read()
-        except FileNotFoundError:
-            pass
+        # The following comments are only for debugging.
+        # log = ""
+        # try:
+        #     with open("futures_ws_log.log", "r", encoding="utf-8") as f:
+        #         log = f.read()
+        # except FileNotFoundError:
+        #     pass
 
-        with open("futures_ws_log.log", "w", encoding="utf-8") as f:
-            f.write(f"{log}\n{event}")
+        # with open("futures_ws_log.log", "w", encoding="utf-8") as f:
+        #     f.write(f"{log}\n{event}")
+        pass
 
 
 class WebsocketTests(unittest.TestCase):
@@ -36,32 +40,55 @@ class WebsocketTests(unittest.TestCase):
         self.__full_ws_access = os.getenv("FULLACCESS") is not None
 
     def __create_loop(self, coro) -> None:
+        """Function that creates an event loop."""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         asyncio.run(coro())
         loop.close()
 
-    async def __wait(self, seconds: float = 1) -> None:
+    async def __wait(self, seconds: float = 1.0) -> None:
+        """Function that realizes the wait for ``seconds``."""
         start = time.time()
         while time.time() - seconds < start:
             await asyncio.sleep(0.2)
         return
 
+    @pytest.mark.futures
+    @pytest.mark.futures_websocket
     def test_create_public_bot(self) -> None:
+        """
+        Checks if the unauthenticated websocket client
+        can be instantiated.
+        """
+
         async def create_bot() -> None:
             bot = Bot()
             await self.__wait(1.5)
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_auth
+    @pytest.mark.futures_websocket
     def test_create_private_bot(self) -> None:
+        """
+        Checks if the authenticated websocket client
+        can be instantiated.
+        """
+
         async def create_bot() -> None:
             Bot(key=self.__key, secret=self.__secret)
             await self.__wait(1.5)
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_websocket
     def test_get_subscriptions(self) -> None:
+        """
+        Checks the ``get_subscriptions`` function.
+        """
+
         async def create_bot() -> None:
             bot = Bot()
             bot.get_active_subscriptions
@@ -69,7 +96,13 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_websocket
     def test_get_available_public_subscriptions(self) -> None:
+        """
+        Checks the ``get_available_public_subscriptions`` function.
+        """
+
         async def create_bot() -> None:
             bot = Bot()
             assert bot.get_available_public_subscription_feeds() == [
@@ -83,7 +116,13 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_websocket
     def test_get_available_private_subscriptions(self) -> None:
+        """
+        Checks the ``get_available_private_subscriptions`` function.
+        """
+
         async def create_bot() -> None:
             bot = Bot()
             assert bot.get_available_private_subscription_feeds() == [
@@ -101,7 +140,14 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_auth
+    @pytest.mark.futures_websocket
     def test_get_auth_state(self) -> None:
+        """
+        Checks if the ``is_auth`` attribute is set correctly.
+        """
+
         async def create_bot() -> None:
             bot = Bot()
             assert not bot.is_auth
@@ -113,7 +159,14 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_websocket
     def test_subscribe_public(self) -> None:
+        """
+        Checks if the unauthenticated websocket client is able to subscribe
+        to public feeds.
+        """
+
         async def create_bot() -> None:
             bot = Bot()
             products = ["PI_XBTUSD", "PF_SOLUSD"]
@@ -127,7 +180,15 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_auth
+    @pytest.mark.futures_websocket
     def test_subscribe_private(self) -> None:
+        """
+        Checks if the authenticated websocket client is able to subscribe
+        to private feeds.
+        """
+
         async def create_bot() -> None:
             auth_bot = Bot(key=self.__key, secret=self.__secret)
 
@@ -141,7 +202,14 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_websocket
     def test_unsubsribe_public(self) -> None:
+        """
+        Checks if the unauthenticated websocket client is able to unsubscribe
+        from public feeds.
+        """
+
         async def create_bot() -> None:
             bot = Bot()
             products = ["PI_XBTUSD", "PF_SOLUSD"]
@@ -154,7 +222,15 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_auth
+    @pytest.mark.futures_websocket
     def test_unsubscribe_private(self) -> None:
+        """
+        Checks if the authenticated websocket client is able to unsubscribe
+        from private feeds.
+        """
+
         async def create_bot() -> None:
             auth_bot = Bot(key=self.__key, secret=self.__secret)
 
@@ -168,7 +244,13 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.futures
+    @pytest.mark.futures_websocket
     def test_get_active_subscriptions(self) -> None:
+        """
+        Checks the ``get_active_subscriptions`` function.
+        """
+
         async def create_bot() -> None:
             bot = Bot()
             assert bot.get_active_subscriptions() == []

--- a/tests/spot/conftest.py
+++ b/tests/spot/conftest.py
@@ -12,8 +12,13 @@ from kraken.spot import Funding, Market, Staking, Trade, User
 
 
 @pytest.fixture
-def spot_auth_user() -> Market:
+def spot_auth_user() -> User:
     return User(key=os.getenv("SPOT_API_KEY"), secret=os.getenv("SPOT_SECRET_KEY"))
+
+
+@pytest.fixture
+def spot_market() -> Market:
+    return Market()
 
 
 @pytest.fixture

--- a/tests/spot/test_spot_funding.py
+++ b/tests/spot/test_spot_funding.py
@@ -9,19 +9,42 @@ from kraken.exceptions import KrakenException
 
 from .helper import is_not_error
 
+# todo: Mock skipped tests - or is this to dangerous?
 
+
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_funding
 def test_get_deposit_methods(spot_auth_funding) -> None:
+    """
+    Checks if the response of the ``get_deposit_methods`` is of
+    type list which mean that the request was successful.
+    """
     assert isinstance(spot_auth_funding.get_deposit_methods(asset="XBT"), list)
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_funding
 def test_get_deposit_address(spot_auth_funding) -> None:
+    """
+    Checks the ``get_deposit_address`` function by performing a valid request
+    and validating that the response is of type list.
+    """
     assert isinstance(
         spot_auth_funding.get_deposit_address(asset="XBT", method="Bitcoin", new=False),
         list,
     )
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_funding
 def test_get_recent_deposits_status(spot_auth_funding) -> None:
+    """
+    Checks the ``get_recent_deposit_status`` endpoint by executing multiple
+    request with different parameters and validating its return value.
+    """
     assert isinstance(spot_auth_funding.get_recent_deposits_status(), list)
     assert isinstance(spot_auth_funding.get_recent_deposits_status(asset="XLM"), list)
     assert isinstance(
@@ -33,9 +56,18 @@ def test_get_recent_deposits_status(spot_auth_funding) -> None:
     )
 
 
-@pytest.mark.skip(reason="Skipping Spot test_withdraw_funds endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_funding
+@pytest.mark.skip(reason="CI does not have withdraw permission")
 def test_withdraw_funds(spot_auth_funding) -> None:
-    # CI API Keys are not allowd to withdraw, trade and cancel
+    """
+    Checks the ``withdraw_funds`` endpoint by performing a withdraw.
+
+    This test is disabled, because testing a withdraw cannot be done without
+    a real withdraw which is not what should be done here. Also the
+    API keys for testing are not allowed to withdraw or trade.
+    """
     with pytest.raises(KrakenException.KrakenPermissionDeniedError):
         assert is_not_error(
             spot_auth_funding.withdraw_funds(
@@ -44,9 +76,17 @@ def test_withdraw_funds(spot_auth_funding) -> None:
         )
 
 
-@pytest.mark.skip(reason="Skipping Spot test_get_withdrawal_info endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_funding
+@pytest.mark.skip(reason="CI does not have withdraw permission")
 def test_get_withdrawal_info(spot_auth_funding) -> None:
-    # CI API Keys are not allowd to withdraw, trade and cancel
+    """
+    Checks the ``get_withdrawa_info`` endpoint by requesting the data.
+
+    This test is disabled, because the API keys for testing are not
+    allowed to withdraw or trade or even get withdraw information.
+    """
     with pytest.raises(KrakenException.KrakenPermissionDeniedError):
         assert is_not_error(
             spot_auth_funding.get_withdrawal_info(
@@ -55,8 +95,19 @@ def test_get_withdrawal_info(spot_auth_funding) -> None:
         )
 
 
-@pytest.mark.skip(reason="Skipping Spot test_get_recent_withdraw_status endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_funding
+@pytest.mark.skip(reason="CI does not have withdraw permission")
 def test_get_recent_withdraw_status(spot_auth_funding) -> None:
+    """
+    Checks the ``get_recend_withdraw_status`` endpoint using different arguments.
+
+    This test is disabled, because testing a withdraw and receiving
+    withdrawal information cannot be done without a real withdraw which is not what
+    should be done here. Also the  API keys for testing are not allowed to withdraw
+    or trade.
+    """
     assert isinstance(spot_auth_funding.get_recent_withdraw_status(), list)
     assert isinstance(spot_auth_funding.get_recent_withdraw_status(asset="XLM"), list)
     assert isinstance(
@@ -64,12 +115,23 @@ def test_get_recent_withdraw_status(spot_auth_funding) -> None:
     )
 
 
-@pytest.mark.skip(reason="Skipping Spot test_wallet_transfer endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_funding
+@pytest.mark.skip(reason="CI does not have withdraw permission")
 def test_wallet_transfer(spot_auth_funding) -> None:
-    # CI API Keys are not allowd to withdraw, trade and cancel
-    # this endpoint is broken, even the provided example on the kraken doc does not work
+    """
+    Checks the ``get_recend_withdraw_status`` endpoint using different arguments.
+    (only works if futures wallet exists)
+
+    This test is disabled, because testing a withdraw and receiving
+    withdrawal information cannot be done without a real withdraw which is not what
+    should be done here. Also the  API keys for testing are not allowed to withdraw
+    or trade.
+
+    This endpoint is broken, even the provided example on the kraken doc does not work.
+    """
     with pytest.raises(KrakenException.KrakenInvalidArgumentsError):
-        # only works if futures wallet exists
         assert is_not_error(
             spot_auth_funding.wallet_transfer(
                 asset="XLM", from_="Futures Wallet", to_="Spot Wallet", amount=10000

--- a/tests/spot/test_spot_market.py
+++ b/tests/spot/test_spot_market.py
@@ -5,66 +5,120 @@
 #
 from time import sleep
 
+import pytest
+
 from .helper import is_not_error
 
 
-def test_get_system_status(spot_auth_market) -> None:
-    assert is_not_error(spot_auth_market.get_system_status())
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_get_system_status(spot_market) -> None:
+    """
+    Checks the ``get_system_status`` endpoint by performing a
+    valid request and validating that the response does not
+    contain the error key.
+    """
+    assert is_not_error(spot_market.get_system_status())
 
 
-def test_get_assets(spot_auth_market) -> None:
-    for params in [
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_get_assets(spot_market) -> None:
+    """
+    Checks the ``get_assets`` endpoint by performing multiple
+    requests with different paramaters and
+    validating that the response does not contain the error key.
+    """
+    for params in (
         {},
         {"assets": "USD"},
         {"assets": ["USD"]},
         {"assets": ["XBT", "USD"]},
         {"assets": ["XBT", "USD"], "aclass": "currency"},
-    ]:
-        assert is_not_error(spot_auth_market.get_assets(**params))
+    ):
+        assert is_not_error(spot_market.get_assets(**params))
         sleep(1.5)
 
 
-def test_get_tradable_asset_pair(spot_auth_market) -> None:
-    assert is_not_error(spot_auth_market.get_tradable_asset_pair(pair="BTCUSD"))
-    assert is_not_error(
-        spot_auth_market.get_tradable_asset_pair(pair=["DOTEUR", "BTCUSD"])
-    )
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_get_tradable_asset_pair(spot_market) -> None:
+    """
+    Checks the ``get_tradable_asset_pair`` endpoint by performing multiple
+    requests with different paramaters and validating that the response
+    does not contain the error key.
+    """
+    assert is_not_error(spot_market.get_tradable_asset_pair(pair="BTCUSD"))
+    assert is_not_error(spot_market.get_tradable_asset_pair(pair=["DOTEUR", "BTCUSD"]))
     for i in ("info", "leverage", "fees", "margin"):
-        assert is_not_error(
-            spot_auth_market.get_tradable_asset_pair(pair="DOTEUR", info=i)
-        )
-        break
+        assert is_not_error(spot_market.get_tradable_asset_pair(pair="DOTEUR", info=i))
+        break  # there is no reason for requesting more - but this loop is just for info
 
 
-def test_get_ticker(spot_auth_market) -> None:
-    assert is_not_error(spot_auth_market.get_ticker())
-    assert is_not_error(spot_auth_market.get_ticker(pair="XBTUSD"))
-    assert is_not_error(spot_auth_market.get_ticker(pair=["DOTUSD", "XBTUSD"]))
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_get_ticker(spot_market) -> None:
+    """
+    Checks the ``get_ticker`` endpoint by performing multiple
+    requests with different paramaters and validating that the response
+    does not contain the error key.
+    """
+    assert is_not_error(spot_market.get_ticker())
+    assert is_not_error(spot_market.get_ticker(pair="XBTUSD"))
+    assert is_not_error(spot_market.get_ticker(pair=["DOTUSD", "XBTUSD"]))
 
 
-def test_get_ohlc(spot_auth_market) -> None:
-    assert is_not_error(spot_auth_market.get_ohlc(pair="XBTUSD"))
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_get_ohlc(spot_market) -> None:
+    """
+    Checks the ``get_ohlc`` endpoint by performing multiple
+    requests with different paramaters and validating that the response
+    does not contain the error key.
+    """
+    assert is_not_error(spot_market.get_ohlc(pair="XBTUSD"))
     assert is_not_error(
-        spot_auth_market.get_ohlc(pair="XBTUSD", interval=240, since="1616663618")
+        spot_market.get_ohlc(pair="XBTUSD", interval=240, since="1616663618")
     )  # interval in [1 5 15 30 60 240 1440 10080 21600]
 
 
-def test_get_order_book(spot_auth_market) -> None:
-    assert is_not_error(spot_auth_market.get_order_book(pair="XBTUSD"))
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_get_order_book(spot_market) -> None:
+    """
+    Checks the ``get_order_book`` endpoint by performing multiple
+    requests with different paramaters and validating that the response
+    does not contain the error key.
+    """
+    assert is_not_error(spot_market.get_order_book(pair="XBTUSD"))
     assert is_not_error(
-        spot_auth_market.get_order_book(pair="XBTUSD", count=2)
+        spot_market.get_order_book(pair="XBTUSD", count=2)
     )  # count in [1...500]
 
 
-def test_get_recent_trades(spot_auth_market) -> None:
-    assert is_not_error(spot_auth_market.get_recent_trades(pair="XBTUSD"))
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_get_recent_trades(spot_market) -> None:
+    """
+    Checks the ``get_recent_trades`` endpoint by performing multiple
+    requests with different paramaters and validating that the response
+    does not contain the error key.
+    """
+    assert is_not_error(spot_market.get_recent_trades(pair="XBTUSD"))
     assert is_not_error(
-        spot_auth_market.get_recent_trades(pair="XBTUSD", since="1616663618")
+        spot_market.get_recent_trades(pair="XBTUSD", since="1616663618")
     )
 
 
-def test_get_recent_spreads(spot_auth_market) -> None:
-    assert is_not_error(spot_auth_market.get_recent_spreads(pair="XBTUSD"))
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_get_recent_spreads(spot_market) -> None:
+    """
+    Checks the ``get_recent_spreads`` endpoint by performing multiple
+    requests with different paramaters and validating that the response
+    does not contain the error key.
+    """
+    assert is_not_error(spot_market.get_recent_spreads(pair="XBTUSD"))
     assert is_not_error(
-        spot_auth_market.get_recent_spreads(pair="XBTUSD", since="1616663618")
+        spot_market.get_recent_spreads(pair="XBTUSD", since="1616663618")
     )

--- a/tests/spot/test_spot_staking.py
+++ b/tests/spot/test_spot_staking.py
@@ -9,16 +9,35 @@ from kraken.exceptions import KrakenException
 
 from .helper import is_not_error
 
+# todo: Mock skipped tests - or is this to dangerous?
 
+
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_staking
 def test_list_stakeable_assets(spot_auth_staking) -> None:
+    """
+    Checks if the ``list_stakeable_assets`` endpoint returns the
+    expected data type or raises the KrakenPermissionDeniedError.
+
+    The error will be raised if some permissions of the API keys are not set.
+    """
     try:
         assert isinstance(spot_auth_staking.list_stakeable_assets(), list)
     except KrakenException.KrakenPermissionDeniedError:
         pass
 
 
-@pytest.mark.skip(reason="Skipping Spot test_stake_asset endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_staking
+@pytest.mark.skip(reason="CI does not have withdraw/stake permission")
 def test_stake_asset(spot_auth_staking) -> None:
+    """
+    Checks the ``stake_asset`` endpoint by requesting a stake.
+
+    This test is skipped since staking is not the desired result.
+    """
     try:
         assert is_not_error(
             spot_auth_staking.stake_asset(
@@ -29,8 +48,17 @@ def test_stake_asset(spot_auth_staking) -> None:
         pass
 
 
-@pytest.mark.skip(reason="Skipping Spot test_unstake_asset endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_staking
+@pytest.mark.skip(reason="CI does not have withdraw/stake permission")
 def test_unstake_asset(spot_auth_staking) -> None:
+    """
+    Checks if the ``unstake_asset`` endpoints returns a response that does
+    not contain the error key.
+
+    This test is skipped since unstakign is not wanted in the CI.
+    """
     try:
         assert is_not_error(
             spot_auth_staking.unstake_asset(asset="DOT", amount="4500000")
@@ -39,11 +67,27 @@ def test_unstake_asset(spot_auth_staking) -> None:
         pass
 
 
-@pytest.mark.skip(reason="Skipping Spot test_get_pending_staking_transactions endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_staking
+@pytest.mark.skip(reason="CI does not have withdraw/stake permission")
 def test_get_pending_staking_transactions(spot_auth_staking) -> None:
+    """
+    Checks the ``get_pending_staking_transactions`` endpoint by validating
+    that the response is of type list. This test is also skipped since
+    the withdraw/stake permission is not set on the CI api keys.
+    """
     assert isinstance(spot_auth_staking.get_pending_staking_transactions(), list)
 
 
-@pytest.mark.skip(reason="Skipping Spot test_list_staking_transactions endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_staking
+@pytest.mark.skip(reason="CI does not have withdraw/stake permission")
 def test_list_staking_transactions(spot_auth_staking) -> None:
+    """
+    Checks the ``list_staking_transactions`` endpoint by performing a regular
+    request. This test is skipped since the CI API keys do not have the
+    withdraw/stake permission.
+    """
     assert isinstance(spot_auth_staking.list_staking_transactions(), list)

--- a/tests/spot/test_spot_trade.py
+++ b/tests/spot/test_spot_trade.py
@@ -9,8 +9,19 @@ import pytest
 
 from kraken.exceptions import KrakenException
 
+# todo: Mock skipped tests - or is this to dangerous?
 
+
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_trade
 def test_create_order(spot_auth_trade) -> None:
+    """
+    This test checks the ``create_order`` function by performing
+    calls to create an order - but in validate mode - so that
+    no real order is placed. In some cases the KrakenPermissionDeniedError
+    will be catched.
+    """
     try:
         assert isinstance(
             spot_auth_trade.create_order(
@@ -87,8 +98,15 @@ def test_create_order(spot_auth_trade) -> None:
         pass
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_trade
 def test_failing_create_order(spot_auth_trade) -> None:
-    # stop-loss-limit (and take-profit-limit) require a second price `price2`)
+    """
+    Test that checks if the ``create_order`` function raises a ValueError
+    bevause of missing or invalid parameters.
+    > stop-loss-limit (and take-profit-limit) require a second price ``price2``)
+    """
     with pytest.raises(ValueError):
         spot_auth_trade.create_order(
             ordertype="stop-loss-limit",
@@ -102,7 +120,14 @@ def test_failing_create_order(spot_auth_trade) -> None:
         )
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_trade
 def test_create_order_batch(spot_auth_trade) -> None:
+    """
+    Checks the ``create_order_batch`` function by executing
+    a batch order in validate mode.
+    """
     assert isinstance(
         spot_auth_trade.create_order_batch(
             orders=[
@@ -136,7 +161,15 @@ def test_create_order_batch(spot_auth_trade) -> None:
     )
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_trade
 def test_edit_order(spot_auth_trade) -> None:
+    """
+    Test the ``edit_order`` function by editing an order.
+
+    In some cases KrakenPermissionDeniedError will be raised.
+    """
     try:
         assert isinstance(
             spot_auth_trade.edit_order(
@@ -156,29 +189,63 @@ def test_edit_order(spot_auth_trade) -> None:
         pass
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_trade
 def test_cancel_order(spot_auth_trade) -> None:
-    # because testing keys are not allowd to trade
+    """
+    Checks the ``cancel_order`` function by canceling an order.
+
+    A KrakenPermissionDeniedError is expected since CI keys are
+    not allowd to trade/cancel/withdraw/stake.
+    """
     with pytest.raises(KrakenException.KrakenPermissionDeniedError):
         spot_auth_trade.cancel_order(txid="OB6JJR-7NZ5P-N5SKCB")
 
 
-@pytest.mark.skip(reason="Skipping Spot test_cancel_all_orders endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_trade
+@pytest.mark.skip(reason="CI does not have trade/cancel permission")
 def test_cancel_all_orders(spot_auth_trade) -> None:
+    """
+    Checks the ``cancel_all_orders`` endpoint by executing the function.
+    A KrakenPermissionDeniedError will be raised since the CI API keys
+    do not have cancel permission.
+    """
     try:
         assert isinstance(spot_auth_trade.cancel_all_orders(), dict)
     except KrakenException.KrakenPermissionDeniedError:
         pass
 
 
-@pytest.mark.skip(reason="Skipping Spot test_cancel_all_orders_after_x endpoint")
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_trade
+@pytest.mark.skip(reason="CI does not have trade/cancel permission")
 def test_cancel_all_orders_after_x(spot_auth_trade) -> None:
+    """
+    Checks the ``cancel_all_orders_after_x`` function by validating its response data
+    type.
+
+    THe KrakenPermissionDeniedError will be catched since the CI API keys are not
+    allowed to cancel orders.
+    """
     try:
-        assert isinstance(spot_auth_trade.cancel_all_orders_after_x(timeout=6), dict)
+        assert isinstance(spot_auth_trade.cancel_all_orders_after_x(timeout=0), dict)
     except KrakenException.KrakenPermissionDeniedError:
         pass
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_trade
 def test_cancel_order_batch(spot_auth_trade) -> None:
+    """
+    Tests the ``cancel_order_batch`` function by cancelling dummy orders that
+    do not exist anymore. In this way the endpoint is tested without raising
+    a KrakenPermissionDeniedError because of missing CI API key permissions.
+    """
     assert isinstance(
         spot_auth_trade.cancel_order_batch(
             orders=[

--- a/tests/spot/test_spot_user.py
+++ b/tests/spot/test_spot_user.py
@@ -4,7 +4,9 @@
 # Github: https://github.com/btschwertfeger
 #
 
+import os
 import random
+import tempfile
 from time import sleep, time
 
 import pytest
@@ -14,26 +16,63 @@ from kraken.exceptions import KrakenException
 from .helper import is_not_error
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_account_balance(spot_auth_user) -> None:
+    """
+    Checks the ``get_account_balance`` function by validating that
+    the response do not contain the error key.
+    """
     assert is_not_error(spot_auth_user.get_account_balance())
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_balances(spot_auth_user):
+    """
+    Checks the ``get_balances`` function by validating that
+    the response do not contain the error key.
+    """
     assert is_not_error(spot_auth_user.get_balances(currency="USD"))
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_trade_balance(spot_auth_user) -> None:
+    """
+    Checks the ``get_trade_balances`` function by validating that
+    the response do not contain the error key.
+
+    (sleep since we dont want API rate limit error...)
+    """
     sleep(3)
     assert is_not_error(spot_auth_user.get_trade_balance())
     assert is_not_error(spot_auth_user.get_trade_balance(asset="EUR"))
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_open_orders(spot_auth_user) -> None:
+    """
+    Checks the ``get_open_orders`` function by validating that
+    the response do not contain the error key.
+    """
     assert is_not_error(spot_auth_user.get_open_orders(trades=True))
     assert is_not_error(spot_auth_user.get_open_orders(trades=False, userref="1234567"))
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_closed_orders(spot_auth_user) -> None:
+    """
+    Checks the ``get_closed_orders`` function by validating that
+    the responses do not contain the error key.
+    """
     assert is_not_error(spot_auth_user.get_closed_orders())
     assert is_not_error(spot_auth_user.get_closed_orders(trades=True, userref="1234"))
     assert is_not_error(
@@ -55,20 +94,27 @@ def test_get_closed_orders(spot_auth_user) -> None:
     )
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_trades_info(spot_auth_user) -> None:
+    """
+    Checks the ``get_trades_info`` function by validating that
+    the responses do not contain the error key.
+    """
     for params, method in zip(
-        [
+        (
             {"txid": "OXBBSK-EUGDR-TDNIEQ"},
             {"txid": "OXBBSK-EUGDR-TDNIEQ", "trades": True},
             {"txid": "OQQYNL-FXCFA-FBFVD7"},
             {"txid": ["OE3B4A-NSIEQ-5L6HW3", "O23GOI-WZDVD-XWGC3R"]},
-        ],
-        [
+        ),
+        (
             spot_auth_user.get_trades_info,
             spot_auth_user.get_trades_info,
             spot_auth_user.get_trades_info,
             spot_auth_user.get_trades_info,
-        ],
+        ),
     ):
         try:
             assert is_not_error(method(**params))
@@ -78,20 +124,27 @@ def test_get_trades_info(spot_auth_user) -> None:
             sleep(2)
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_orders_info(spot_auth_user) -> None:
+    """
+    Checks the ``get_orders_info`` function by validating that
+    the responses do not contain the error key.
+    """
     for params, method in zip(
-        [
+        (
             {"txid": "OXBBSK-EUGDR-TDNIEQ"},
             {"txid": "OXBBSK-EUGDR-TDNIEQ", "trades": True},
             {"txid": "OQQYNL-FXCFA-FBFVD7", "consolidate_taker": True},
             {"txid": ["OE3B4A-NSIEQ-5L6HW3", "O23GOI-WZDVD-XWGC3R"]},
-        ],
-        [
+        ),
+        (
             spot_auth_user.get_orders_info,
             spot_auth_user.get_orders_info,
             spot_auth_user.get_orders_info,
             spot_auth_user.get_orders_info,
-        ],
+        ),
     ):
         try:
             assert is_not_error(method(**params))
@@ -101,9 +154,15 @@ def test_get_orders_info(spot_auth_user) -> None:
             sleep(2)
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_trades_history(spot_auth_user) -> None:
+    """
+    Checks the ``get_trades_history`` function by validating that
+    the responses do not contain the error key.
+    """
     sleep(3)
-
     assert is_not_error(spot_auth_user.get_trades_history(type_="all", trades=True))
     assert is_not_error(
         spot_auth_user.get_trades_history(
@@ -115,7 +174,14 @@ def test_get_trades_history(spot_auth_user) -> None:
     )
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_open_positions(spot_auth_user) -> None:
+    """
+    Checks the ``get_open_positions`` function by validating that
+    the responses do not contain the error key.
+    """
     assert isinstance(spot_auth_user.get_open_positions(), list)
     assert isinstance(
         spot_auth_user.get_open_positions(txid="OQQYNL-FXCFA-FBFVD7"), list
@@ -126,7 +192,14 @@ def test_get_open_positions(spot_auth_user) -> None:
     )
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_ledgers_info(spot_auth_user) -> None:
+    """
+    Checks the ``get_ledgers_info`` function by validating that
+    the responses do not contain the error key.
+    """
     assert is_not_error(spot_auth_user.get_ledgers_info())
     assert is_not_error(spot_auth_user.get_ledgers_info(type_="deposit"))
     assert is_not_error(
@@ -146,7 +219,14 @@ def test_get_ledgers_info(spot_auth_user) -> None:
     )
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_ledgers(spot_auth_user) -> None:
+    """
+    Checks the ``get_ledgers`` function by validating that
+    the responses do not contain the error key.
+    """
     assert is_not_error(spot_auth_user.get_ledgers(id_="LNYQGU-SUR5U-UXTOWM"))
     assert is_not_error(
         spot_auth_user.get_ledgers(
@@ -155,12 +235,26 @@ def test_get_ledgers(spot_auth_user) -> None:
     )
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_get_trade_volume(spot_auth_user) -> None:
+    """
+    Checks the ``get_trade_volume`` function by validating that
+    the responses do not contain the error key.
+    """
     assert is_not_error(spot_auth_user.get_trade_volume())
     assert is_not_error(spot_auth_user.get_trade_volume(pair="DOT/EUR", fee_info=False))
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_request_save_export_report(spot_auth_user) -> None:
+    """
+    Checks the ``save_export_report`` function by requesting an
+    report and saving them.
+    """
     try:
         spot_auth_user.request_export_report(
             report="invalid", description="this is an invalid report type"
@@ -212,10 +306,11 @@ def test_request_save_export_report(spot_auth_user) -> None:
         sleep(5)
 
         result = spot_auth_user.retrieve_export(id_=response["id"])
-        with open(f"{export_descr}.zip", "wb") as file:
-            for chunk in result.iter_content(chunk_size=512):
-                if chunk:
-                    file.write(chunk)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with open(os.path.join(tmp_dir, f"{export_descr}.zip"), "wb") as file:
+                for chunk in result.iter_content(chunk_size=512):
+                    if chunk:
+                        file.write(chunk)
 
         status = spot_auth_user.get_export_report_status(report=report)
         assert isinstance(status, list)
@@ -235,15 +330,29 @@ def test_request_save_export_report(spot_auth_user) -> None:
             sleep(2)
 
 
-def test_export_report_status(spot_auth_user) -> None:
-    # just demonstrating invalid report; real test is in `test_request_save_export_report` function
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
+def test_export_report_status_invalid(spot_auth_user) -> None:
+    """
+    Checks the ``export_report_status`` function by passing an invalid
+    report type.
+    """
     try:
         spot_auth_user.get_export_report_status(report="invalid")
     except ValueError:
         pass
 
 
+@pytest.mark.spot
+@pytest.mark.spot_auth
+@pytest.mark.spot_user
 def test_create_subaccount(spot_auth_user) -> None:
-    # creating subaccounts is only availablle for institutional clients
+    """
+    Checks the ``create_subaccount`` function by creating one.
+
+    Creating subaccounts is only available for institutional clients (May 2023),
+    so a KrakenPermissionDeniedError will be raised.
+    """
     with pytest.raises(KrakenException.KrakenPermissionDeniedError):
         spot_auth_user.create_subaccount(email="abc@welt.de", username="tomtucker")

--- a/tests/spot/test_spot_user.py
+++ b/tests/spot/test_spot_user.py
@@ -23,6 +23,7 @@ def test_get_balances(spot_auth_user):
 
 
 def test_get_trade_balance(spot_auth_user) -> None:
+    sleep(3)
     assert is_not_error(spot_auth_user.get_trade_balance())
     assert is_not_error(spot_auth_user.get_trade_balance(asset="EUR"))
 

--- a/tests/spot/test_spot_websocket.py
+++ b/tests/spot/test_spot_websocket.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # Github: https://github.com/btschwertfeger
 #
+
 """Module that tests the Kraken Spot websocket client
 NOTE:
 *   Since there is no sandbox environment for the Spot trading API,
@@ -11,7 +12,10 @@ NOTE:
     the websocket client receives a message about missing auhtntification. Since the
     API keys have no trade permission, this will be excepted to exit the asyncio event loop.
     A asyncio.CancelledError will be raised and excepted during this procedure.
+
+todo: Create fixtures for the custom exception and the Bot class.
 """
+
 import asyncio
 import os
 import time
@@ -49,15 +53,21 @@ class Bot(KrakenSpotWSClient):
     """Class to create a websocket bot"""
 
     async def on_message(self, event) -> None:
-        log = ""
-        try:
-            with open("spot_ws_log.log", "r", encoding="utf-8") as f:
-                log = f.read()
-        except FileNotFoundError:
-            pass
+        """
+        This is the callback function that must be implemented
+        to handle custom websocket messages.
+        """
+        # The following comments are only used for debugging while
+        # implementing tests.
+        # log = ""
+        # try:
+        #     with open("spot_ws_log.log", "r", encoding="utf-8") as f:
+        #         log = f.read()
+        # except FileNotFoundError:
+        #     pass
 
-        with open("spot_ws_log.log", "w", encoding="utf-8") as f:
-            f.write(log + "\n" + str(event))
+        # with open("spot_ws_log.log", "w", encoding="utf-8") as f:
+        #     f.write(log + "\n" + str(event))
 
         if isinstance(event, dict) and "error" in event.keys():
             if "KrakenPermissionDeniedError" in event["error"]:
@@ -71,25 +81,40 @@ class WebsocketTests(unittest.TestCase):
         self.__full_ws_access = os.getenv("FULLACCESS") == "True"
 
     def __create_loop(self, coro) -> None:
+        """Function that creates an event loop."""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         asyncio.run(coro())
         loop.close()
 
-    async def __wait(self, seconds: float = 1) -> None:
+    async def __wait(self, seconds: float = 1.0) -> None:
+        """Function that realizes the wait for ``seconds``."""
         start = time.time()
         while time.time() - seconds < start:
             await asyncio.sleep(0.2)
         return
 
+    @pytest.mark.spot
+    @pytest.mark.spot_websocket
     def test_create_public_bot(self) -> None:
+        """
+        Checks if the websocket client can be instantiated.
+        """
+
         async def create_bot():
             bot = Bot()
             await self.__wait(seconds=2.5)
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
     def test_create_private_bot(self) -> None:
+        """
+        Checks if the authenticated websocket client can be instantiated.
+        """
+
         async def create_bot():
             if self.__full_ws_access:
                 Bot(key=self.__key, secret=self.__secret)
@@ -101,7 +126,14 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=create_bot)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_websocket
     def test_access_public_bot_attributes(self) -> None:
+        """
+        Checks the ``access_public_bot_attributes`` function
+        works as expected.
+        """
+
         async def checkit() -> None:
             bot = Bot()
 
@@ -124,7 +156,15 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
     def test_access_private_bot_attributes(self) -> None:
+        """
+        Checks the ``access_private_bot_attributes`` function
+        works as expected.
+        """
+
         async def checkit() -> None:
             if self.__full_ws_access:
                 auth_bot = Bot(key=self.__key, secret=self.__secret)
@@ -138,7 +178,14 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_websocket
     def test_public_subscribe(self) -> None:
+        """
+        Function that checks if the websocket client
+        is able to subscribe to public feeds.
+        """
+
         async def checkit() -> None:
             bot = Bot()
             subscription = {"name": "ticker"}
@@ -154,7 +201,14 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
     def test_private_subscribe(self) -> None:
+        """
+        Checks if the authenticated websocket client can subscribe to private feeds.
+        """
+
         async def checkit() -> None:
             subscription = {"name": "ownTrades"}
 
@@ -179,15 +233,15 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_websocket
     def test_public_unsubscribe(self) -> None:
+        """
+        Checks if the websocket client can unsubscrube from public feeds.
+        """
+
         async def checkit() -> None:
             bot = Bot()
-
-            with pytest.raises(AttributeError):
-                await bot.unsubscribe(subscription={})
-
-            with pytest.raises(ValueError):
-                await bot.unsubscribe(subscription={"name": "ticker"}, pair="XBT/USD")
 
             # since we have no subscriptions, this will work, but the response will inform us that there are no subscriptions
             await bot.unsubscribe(subscription={"name": "ticker"}, pair=["XBT/USD"])
@@ -199,7 +253,53 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_websocket
+    def test_public_unsubscribe_failure(self) -> None:
+        """
+        Checks if the websocket client responses with failures
+        when the ``unsubscribe`` funciton receives invalid parameters.
+        """
+
+        async def checkit() -> None:
+            bot = Bot()
+
+            with pytest.raises(AttributeError):
+                await bot.unsubscribe(subscription={})
+
+            with pytest.raises(ValueError):
+                await bot.unsubscribe(subscription={"name": "ticker"}, pair="XBT/USD")
+
+            await self.__wait(seconds=2)
+
+        self.__create_loop(coro=checkit)
+
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
     def test_private_unsubscribe(self) -> None:
+        async def checkit() -> None:
+            bot = Bot()
+            auth_bot = Bot(key=self.__key, secret=self.__secret)
+
+            if self.__full_ws_access:
+                await auth_bot.unsubscribe(subscription={"name": "ownTrades"})
+            else:
+                # with pytest.raises(asyncio.CancelledError):
+                await auth_bot.unsubscribe(subscription={"name": "ownTrades"})
+            await self.__wait(seconds=2)
+
+        self.__create_loop(coro=checkit)
+
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
+    def test_private_unsubscribe_failing(self) -> None:
+        """
+        Checks if the ``unsubscribe`` function fails when invalid
+        parameters are passed.
+        """
+
         async def checkit() -> None:
             bot = Bot()
             auth_bot = Bot(key=self.__key, secret=self.__secret)
@@ -212,17 +312,19 @@ class WebsocketTests(unittest.TestCase):
                     subscription={"name": "ownTrades"}, pair=["XBTUSD"]
                 )
 
-            if self.__full_ws_access:
-                await auth_bot.unsubscribe(subscription={"name": "ownTrades"})
-                await self.__wait(seconds=2)
-            else:
-                # with pytest.raises(asyncio.CancelledError):
-                await auth_bot.unsubscribe(subscription={"name": "ownTrades"})
-                await self.__wait(seconds=2)
+            await self.__wait(seconds=2)
 
         self.__create_loop(coro=checkit)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
     def test_create_order(self) -> None:
+        """
+        Checks the ``create_order`` function by submitting a
+        new order - but in validate mode.
+        """
+
         async def checkit() -> None:
             auth_bot = Bot(key=self.__key, secret=self.__secret)
             params = dict(
@@ -253,7 +355,14 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
     def test_edit_order(self) -> None:
+        """
+        Checks the edit order function by editing an order in validate mode.
+        """
+
         async def checkit() -> None:
             auth_bot = Bot(key=self.__key, secret=self.__secret)
 
@@ -278,8 +387,15 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
-    @unittest.skip("Skipping Spot test_cancel_order endpoint")
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
+    @unittest.skip("CI does not have trade/cancel permission")
     def test_cancel_order(self) -> None:
+        """
+        Checks the ``cancel_order`` function by canceling some orders.
+        """
+
         async def checkit() -> None:
             auth_bot = Bot(key=self.__key, secret=self.__secret)
             if self.__full_ws_access:
@@ -292,8 +408,15 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
-    @unittest.skip("Skipping Spot test_cancel_all_orders endpoint")
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
+    @unittest.skip("CI does not have trade/cancel permission")
     def test_cancel_all_orders(self) -> None:
+        """
+        Check the ``cancel_all_orders`` function by executing the function.
+        """
+
         async def checkit() -> None:
             auth_bot = Bot(key=self.__key, secret=self.__secret)
             if self.__full_ws_access:
@@ -306,8 +429,16 @@ class WebsocketTests(unittest.TestCase):
 
         self.__create_loop(coro=checkit)
 
-    @unittest.skip("Skipping Spot test_cancel_all_orders_after_x endpoint")
-    def cancel_all_orders_after(self) -> None:
+    @pytest.mark.spot
+    @pytest.mark.spot_auth
+    @pytest.mark.spot_websocket
+    @unittest.skip("CI does not have trade/cancel permission")
+    def test_cancel_all_orders_after(self) -> None:
+        """
+        Checking the ``cancel_all_orders_after`` function by
+        executing it.
+        """
+
         async def checkit() -> None:
             auth_bot = Bot(key=self.__key, secret=self.__secret)
             if self.__full_ws_access:


### PR DESCRIPTION
# Summary
- The `KrakenApiLimitExceededError` error will be raised when the response contains the error key and `EAPI:Rate limit exceeded` at its value (breaking change). 
- Also the doc strings of the unit tests were extended and markers were added.
- The unit tests were split into public and private jobs to decrease the CI to run through.