### PR TITLE
Add Futures user endpoints: `check_trading_enabled_on_subaccount` and `set_trading_on_subaccount`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: "master"
   schedule:
     - cron: "0 0 * * 0"
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -74,7 +74,7 @@ ignored-modules=
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use, and will cap the count on Windows to
 # avoid hangs.
-jobs=1
+jobs=2
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or
@@ -90,7 +90,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.11
 
 # Discover python modules and packages in the file system subtree.
 recursive=no
@@ -198,7 +198,8 @@ good-names=i,
            orderType,
            reduceOnly,triggerSignal,
            EXCEPTION_ASSIGNMENT,
-           trailingStopDeviationUnit,trailingStopMaxDeviation
+           trailingStopDeviationUnit,trailingStopMaxDeviation,
+           subaccountUid
 
 
 # Good variable names regexes, separated by a comma. If names match any regex,

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -434,7 +434,7 @@ class KrakenBaseFuturesAPI:
                 self.__session.request(
                     method=method,
                     url=f"{self.url}{uri}",
-                    params=str.encode(query_string),
+                    params=str.encode(post_string),
                     headers=headers,
                     timeout=timeout,
                 ),

--- a/kraken/futures/market/__init__.py
+++ b/kraken/futures/market/__init__.py
@@ -608,10 +608,11 @@ class Market(KrakenBaseFuturesAPI):
         params = {"symbol": symbol}
         if maxLeverage is not None:
             params["maxLeverage"] = maxLeverage
+
         return self._request(
             method="PUT",
             uri="/derivatives/api/v3/leveragepreferences",
-            query_params=params,
+            post_params=params,
             auth=True,
         )
 
@@ -669,7 +670,7 @@ class Market(KrakenBaseFuturesAPI):
         return self._request(
             method="PUT",
             uri="/derivatives/api/v3/pnlpreferences",
-            query_params={"symbol": symbol, "pnlPreference": pnlPreference},
+            post_params={"symbol": symbol, "pnlPreference": pnlPreference},
             auth=True,
         )
 

--- a/kraken/futures/user/__init__.py
+++ b/kraken/futures/user/__init__.py
@@ -809,7 +809,7 @@ class User(KrakenBaseFuturesAPI):
             ...    subaccountUid="778387bh61b-f990-4128-16a7-gasdsdghasd",
             ... )
             {
-               "tradingEnabled": false
+               "tradingEnabled": False
             }
         """
         return self._request(

--- a/kraken/futures/user/__init__.py
+++ b/kraken/futures/user/__init__.py
@@ -784,3 +784,73 @@ class User(KrakenBaseFuturesAPI):
         return self._request(
             method="GET", uri="/derivatives/api/v3/openorders", auth=True
         )
+
+    def check_trading_enabled_on_subaccount(self, subaccountUid: str) -> dict:
+        """
+        Checks if trading is enabled or disabled on the specified subaccount.
+
+        Requires the ``General API - Full Access`` permission in the API key settings.
+
+        This endpoint is only available for institutional clients and is not tested so far and
+        results in ``KrakenAuthenticationError``.
+
+        - https://docs.futures.kraken.com/#http-api-trading-v3-api-other-check-if-a-subaccount-has-trading-enabled-or-disabled
+
+        :return: The open futures positions/orders
+        :rtype: dict
+
+        .. code-block:: python
+            :linenos:
+            :caption: Futures Trade: Check if trading is enabled on a subaccount
+
+            >>> from kraken.futures import Trade
+            >>> trade = Trade(key="api-key", secret="secret-key")
+            >>> trade.set_trading_on_subaccount(
+            ...    subaccountUid="778387bh61b-f990-4128-16a7-gasdsdghasd",
+            ... )
+            {
+               "tradingEnabled": false
+            }
+        """
+        return self._request(
+            method="GET",
+            uri=f"/derivatives/api/v3/subaccount/{subaccountUid}/trading-enabled",
+            auth=True,
+        )
+
+    def set_trading_on_subaccount(
+        self, subaccountUid: str, trading_enabled: bool
+    ) -> dict:
+        """
+        Enable or disable trading on a subaccount.
+
+        Requires the ``General API - Full Access`` permission in the API key settings.
+
+        This endpoint is only available for institutional clients and is not tested so far and
+        always results in ``INTERNAL_SERVER_ERROR``.
+
+        - https://docs.futures.kraken.com/#http-api-trading-v3-api-other-enable-or-disable-trading-on-a-subaccount
+
+        :return: The open futures positions/orders
+        :rtype: dict
+
+        .. code-block:: python
+            :linenos:
+            :caption: Futures Trade: Dis-/Enable trading on a subaccount
+
+            >>> from kraken.futures import Trade
+            >>> trade = Trade(key="api-key", secret="secret-key")
+            >>> trade.set_trading_on_subaccount(
+            ...    subaccountUid="778387bh61b-f990-4128-16a7-gasdsdghasd",
+            ...    trading_enabled=True
+            ... )
+            {
+                "tradingEnabled": True
+            }
+        """
+        return self._request(
+            method="PUT",
+            uri=f"/derivatives/api/v3/subaccount/{subaccountUid}/trading-enabled",
+            post_params={"tradingEnabled": trading_enabled},
+            auth=True,
+        )

--- a/tests/futures/test_futures_user.py
+++ b/tests/futures/test_futures_user.py
@@ -146,3 +146,39 @@ def test_get_trigger_events(futures_auth_user) -> None:
     )
     assert isinstance(result, dict)
     assert "elements" in result.keys()
+
+
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
+@pytest.mark.skip("Subaccount actions are only available for insitutional clients")
+def test_check_trading_enabled_on_subaccount(futures_auth_user) -> None:
+    """
+    Checks the ``check_trading_enabled_on_subaccount`` function.
+
+    Until now, subaccounts are only available for institutional clients, so this
+    execution raises an error. This test will work correctly (hopefully) when
+    Kraken eneables subaccounts for pro trader.
+    """
+    assert {
+        "tradingEnabled": False
+    } == futures_auth_user.check_trading_enabled_on_subaccount(
+        subaccountUid="778387bh61b-f990-4128-16a7-gasdsdghasd"
+    )
+
+
+@pytest.mark.futures
+@pytest.mark.futures_auth
+@pytest.mark.futures_user
+@pytest.mark.skip("Subaccount actions are only available for insitutional clients")
+def test_set_trading_on_subaccount(futures_auth_user) -> None:
+    """
+    Checks the ``set_trading_on_subaccount`` function.
+
+    Until now, subaccounts are only available for institutional clients, so this
+    execution raises an error. This test will work correctly (hopefully) when
+    Kraken eneables subaccounts for pro trader.
+    """
+    assert {"tradingEnabled": True} == futures_auth_user.set_trading_on_subaccount(
+        subaccountUid="778387bh61b-f990-4128-16a7-gasdsdghasd", trading_enabled=True
+    )


### PR DESCRIPTION
# Summary

Two new endpoints for the Futures User were added. **These endpoints are not tested and cannot be tested, since until now sub accounts are only available for institutional clients.**

- `check_trading_enabled_on_subaccount` Closes #71  
- `set_trading_on_subaccount` Closes #72 

Fore more information about these endpoints, please have a look at: 
- https://docs.futures.kraken.com/#http-api-trading-v3-api-other-check-if-a-subaccount-has-trading-enabled-or-disabled
- https://docs.futures.kraken.com/#http-api-trading-v3-api-other-enable-or-disable-trading-on-a-subaccount

... as you can see (May 2023) the docs say that no authentication is required - this does not make any sense. These endpoints will be adjusted within this Python module as soon as Kraken enables subaccounts for pro trader.