### PR TITLE
Disable custom Kraken exceptions (optional)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 - Add API rate limit exception; extend test doc strings [\#79](https://github.com/btschwertfeger/python-kraken-sdk/pull/79) ([btschwertfeger](https://github.com/btschwertfeger))
 - Fix bug/typo: "recend" -\> recent throughout kraken.spot [\#76](https://github.com/btschwertfeger/python-kraken-sdk/pull/76) ([jcr-jeff](https://github.com/jcr-jeff))
 
+**Implemented enhancements:**
+
+- Enable trading on Futures subaccount [\#72](https://github.com/btschwertfeger/python-kraken-sdk/issues/72)
+- Check if trading is enabled for Futures subaccount [\#71](https://github.com/btschwertfeger/python-kraken-sdk/issues/71)
+- Add Futures user endpoints: `check_trading_enabled_on_subaccount` and `set_trading_on_subaccount` [\#80](https://github.com/btschwertfeger/python-kraken-sdk/pull/80) ([btschwertfeger](https://github.com/btschwertfeger))
+
 **Fixed bugs:**
 
 - Release workflow skips the PyPI publish [\#67](https://github.com/btschwertfeger/python-kraken-sdk/issues/67)

--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,12 @@ clean:
 		python_kraken_sdk.egg-info \
 		docs/_build \
 		.vscode
+
 	rm -f .coverage coverage.xml pytest.xml \
 		kraken/_version.py \
 		*.log *.csv *.zip \
-		tests/*.zip tests/.csv
+		tests/*.zip tests/.csv \
+		python_kraken_sdk-*.whl
 
 	find tests -name "__pycache__" | xargs rm -rf
 	find kraken -name "__pycache__" | xargs rm -rf

--- a/kraken/exceptions/__init__.py
+++ b/kraken/exceptions/__init__.py
@@ -62,6 +62,7 @@ class KrakenException:
             ##
             "authenticationError": self.KrakenAuthenticationError,
             "insufficientAvailableFunds": self.KrakenInsufficientAvailableFundsError,
+            "requiredArgumentMissing": self.KrakenRequiredArgumentMissingError,
             "apiLimitExceeded": self.KrakenApiLimitExceededError,
             "invalidUnit": self.KrakenInvalidUnitError,
             "Unavailable": self.KrakenUnavailableError,
@@ -103,6 +104,10 @@ class KrakenException:
     @docstring_message
     class KrakenInvalidArgumentsError(Exception):
         """The request payload is malformed, incorrect or ambiguous."""
+
+    @docstring_message
+    class KrakenRequiredArgumentMissingError(Exception):
+        """The request is missing a required argument."""
 
     @docstring_message
     class KrakenInvalidArgumentsIndexUnavailableError(Exception):

--- a/tests/futures/test_futures_base_api.py
+++ b/tests/futures/test_futures_base_api.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# Github: https://github.com/btschwertfeger
+#
+
+"""Module that checks the general Futures Base API class."""
+
+
+import pytest
+
+from kraken.base_api import KrakenBaseFuturesAPI
+from kraken.exceptions import KrakenException
+
+
+@pytest.mark.futures
+def test_KrakenBaseFuturesAPI_without_exception() -> None:
+    """
+    Checks first if the expected error will be raised and than
+    creates a new KrakenBaseFuturesAPI instance that do not raise
+    the custom Kraken exceptions. This new instance thant executes
+    the same request and the returned response gets evaluated.
+    """
+    with pytest.raises(KrakenException.KrakenRequiredArgumentMissingError):
+        KrakenBaseFuturesAPI(
+            key="fake",
+            secret="fake",
+        )._request(method="POST", uri="/derivatives/api/v3/sendorder", auth=True)
+
+    result: dict = (
+        KrakenBaseFuturesAPI(key="fake", secret="fake", use_custom_exceptions=False)
+        ._request(method="POST", uri="/derivatives/api/v3/sendorder", auth=True)
+        .json()
+    )
+
+    assert (
+        result.get("result") == "error"
+        and result.get("error") == "requiredArgumentMissing"
+    )

--- a/tests/spot/test_spot_base_api.py
+++ b/tests/spot/test_spot_base_api.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# Github: https://github.com/btschwertfeger
+#
+
+"""Module that checks the general Spot Base API class."""
+
+import pytest
+
+from kraken.base_api import KrakenBaseSpotAPI
+from kraken.exceptions import KrakenException
+
+
+@pytest.mark.spot
+def test_KrakenBaseSpotAPI_without_exception() -> None:
+    """
+    Checks first if the expected error will be raised and than
+    creates a new KrakenBaseSpotAPI instance that do not raise
+    the custom Kraken exceptions. This new instance thant executes
+    the same request and the returned response gets evaluated.
+    """
+    with pytest.raises(KrakenException.KrakenInvalidAPIKeyError):
+        KrakenBaseSpotAPI(
+            key="fake",
+            secret="fake",
+        )._request(method="POST", uri="/private/AddOrder", auth=True)
+
+    assert KrakenBaseSpotAPI(
+        key="fake", secret="fake", use_custom_exceptions=False
+    )._request(method="POST", uri="/private/AddOrder", auth=True).json() == {
+        "error": ["EAPI:Invalid key"]
+    }


### PR DESCRIPTION
# Summary
The custom Kraken exceptions can be disabled when passing `use_custom_exceptions=False` during Spot and Futures REST client instantiation.