### PR TITLE
Let REST and websocket clients be used as context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ General:
 - access both public and private endpoints
 - responsive error handling, custom exceptions and logging
 - extensive example scripts (see `/examples`)
+- clients can be used as context manager
+- coding standards like snake case are not always followed to maintain the parameter naming convention of the Kraken API
+- ...
 
 Documentation:
 
 - Stable: [https://python-kraken-sdk.readthedocs.io/en/stable](https://python-kraken-sdk.readthedocs.io/en/stable)
-- Latest: [https://python-kraken-sdk.readthedocs.io/en/katest](https://python-kraken-sdk.readthedocs.io/en/latest)
+- Latest: [https://python-kraken-sdk.readthedocs.io/en/latest](https://python-kraken-sdk.readthedocs.io/en/latest)
 
 ---
 

--- a/docs/src/introduction.rst
+++ b/docs/src/introduction.rst
@@ -46,6 +46,7 @@ General:
 - access both public and private endpoints
 - responsive error handling, custom exceptions and logging
 - extensive examples
+- all clients can be used as context manager
 - coding standards like snake case are not always followed to maintain the parameter naming convention of the Kraken API
 
 Important Notice

--- a/examples/futures_examples.py
+++ b/examples/futures_examples.py
@@ -190,11 +190,10 @@ def funding_examples() -> None:
 
 
 def main() -> None:
-    """Main"""
-    # user_examples()
+    user_examples()
     market_examples()
-    # trade_examples()
-    # funding_examples()
+    trade_examples()
+    funding_examples()
 
 
 if __name__ == "__main__":

--- a/examples/futures_ws_examples.py
+++ b/examples/futures_ws_examples.py
@@ -56,7 +56,7 @@ async def main() -> Coroutine:
     # unsubscribe from a websocket feed
     time.sleep(2)  # in case subscribe is not done yet
     # await bot.unsubscribe(feed='ticker', products=['PI_XBTUSD'])
-    await bot.unsubscribe(feed="ticker", products=["PF_SOLUSD"])
+    await bot.unsubscribe(feed="ticker", products=["PF_XBTUSD"])
     await bot.unsubscribe(feed="book", products=products)
     # ....
 
@@ -100,3 +100,28 @@ if __name__ == "__main__":
         pass
     finally:
         loop.close()
+
+# ============================================================
+# Alternative - as ContextManager:
+
+# from kraken.futures import KrakenFuturesWSClient
+# import asyncio
+
+# async def on_message(msg):
+#     print(msg)
+
+# async def main() -> None:
+#     async with KrakenFuturesWSClient(callback=on_message) as session:
+#         await session.subscribe(feed="ticker", products=["PF_XBTUSD"])
+#     while True:
+#         await asyncio.sleep(6)
+
+# if __name__ == "__main__":
+#     loop = asyncio.new_event_loop()
+#     asyncio.set_event_loop(loop)
+#     try:
+#         asyncio.run(main())
+#     except KeyboardInterrupt:
+#         pass
+#     finally:
+#         loop.close()

--- a/examples/spot_examples.py
+++ b/examples/spot_examples.py
@@ -128,7 +128,7 @@ def trade_examples() -> None:
                     },
                 ],
                 pair="BTC/USD",
-                validate=False,
+                validate=True,
             )
         )
 
@@ -195,7 +195,6 @@ def staking_examples() -> None:
 
 
 def main() -> None:
-    """Main"""
     user_examples()
     market_examples()
     trade_examples()

--- a/examples/spot_ws_examples.py
+++ b/examples/spot_ws_examples.py
@@ -103,3 +103,29 @@ if __name__ == "__main__":
         # so you can handle the behaviour/next actions individually within you bot
     finally:
         loop.close()
+
+# ============================================================
+# Alternative - as ContextManager:
+
+# from kraken.spot import KrakenSpotWSClient
+# import asyncio
+
+# async def on_message(msg):
+#     print(msg)
+
+# async def main() -> None:
+#     async with KrakenSpotWSClient(callback=on_message) as session:
+#         await session.subscribe(subscription={"name": "ticker"}, pair=["XBT/USD"])
+
+#     while True:
+#         await asyncio.sleep(6)
+
+# if __name__ == "__main__":
+#     loop = asyncio.new_event_loop()
+#     asyncio.set_event_loop(loop)
+#     try:
+#         asyncio.run(main())
+#     except KeyboardInterrupt:
+#         pass
+#     finally:
+#         loop.close()

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -308,6 +308,12 @@ class KrakenBaseSpotAPI:
             return ",".join(value)
         raise ValueError("a must be type of str or list of strings")
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> None:
+        pass
+
 
 class KrakenBaseFuturesAPI:
     """
@@ -532,3 +538,9 @@ class KrakenBaseFuturesAPI:
         raise Exception(
             f"{response.status_code} - {response.text}"
         )  # pylint: disable=W0719
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> None:
+        pass

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -74,12 +74,12 @@ class KrakenErrorHandler:
             return data
         return data
 
-    def check_batch_status(self, data: List[dict]) -> dict:
+    def check_batch_status(self, data: dict) -> dict:
         """
         Used to check the Futures batch order responses for errors
 
         :param data: The response as dict to check for an error
-        :type data: List[dict]
+        :type data: dict
         :raise kraken.exceptions.KrakenException.*: raises a KrakenError if the response contains an error
         :return: The response as List[dict]
         :rtype: List[dict]

--- a/kraken/futures/funding/__init__.py
+++ b/kraken/futures/funding/__init__.py
@@ -33,6 +33,14 @@ class Funding(KrakenBaseFuturesAPI):
         >>> from kraken.futures import Funding
         >>> funding = Funding() # unauthenticated
         >>> funding = Funding(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Futures Funding: Create the funding client as context manager
+
+        >>> from kraken.futures import Funding
+        >>> with Funding(key="api-key", secret="secret-key") as funding:
+        ...     print(funding.get_historical_funding_rates(symbol="PI_XBTUSD"))
     """
 
     def __init__(

--- a/kraken/futures/market/__init__.py
+++ b/kraken/futures/market/__init__.py
@@ -31,8 +31,16 @@ class Market(KrakenBaseFuturesAPI):
         :caption: Futures Market: Create the market client
 
         >>> from kraken.futures import Market
-        >>> marker = Market() # unauthenticated
-        >>> marker = Market(key="api-key", secret="secret-key") # authenticated
+        >>> market = Market() # unauthenticated
+        >>> market = Market(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Futures Market: Create the market client as context manager
+
+        >>> from kraken.futures import Market
+        >>> with Market() as market:
+        ...     print(market.get_tick_types())
     """
 
     def __init__(

--- a/kraken/futures/trade/__init__.py
+++ b/kraken/futures/trade/__init__.py
@@ -33,6 +33,14 @@ class Trade(KrakenBaseFuturesAPI):
         >>> from kraken.futures import Trade
         >>> trade = Trade() # unauthenticated
         >>> trade = Trade(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Futures Trade: Create the trade client as context manager
+
+        >>> from kraken.futures import Trade
+        >>> with Trade(ke="api-key", secret="secret-key") as trade:
+        ...     print(trade.get_fills())
     """
 
     def __init__(

--- a/kraken/futures/trade/__init__.py
+++ b/kraken/futures/trade/__init__.py
@@ -39,7 +39,7 @@ class Trade(KrakenBaseFuturesAPI):
         :caption: Futures Trade: Create the trade client as context manager
 
         >>> from kraken.futures import Trade
-        >>> with Trade(ke="api-key", secret="secret-key") as trade:
+        >>> with Trade(key="api-key", secret="secret-key") as trade:
         ...     print(trade.get_fills())
     """
 

--- a/kraken/futures/user/__init__.py
+++ b/kraken/futures/user/__init__.py
@@ -33,6 +33,14 @@ class User(KrakenBaseFuturesAPI):
         >>> from kraken.futures import User
         >>> user = User() # unauthenticated
         >>> user = User(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Futures User: Create the user client as context manager
+
+        >>> from kraken.futures import User
+        >>> with User(key="api-key", secret="secret-key") as user:
+        ...     print(user.get_wallets())
     """
 
     def __init__(
@@ -366,7 +374,7 @@ class User(KrakenBaseFuturesAPI):
         :type sort: str | None, optional
         :param tradeable: The asset to filter for
         :type tradeable: str | None, optional
-        :param auth: If the request is accessing a private endpoint (default_ ``True``)
+        :param auth: If the request is accessing a private endpoint (default: ``True``)
         :type auth: bool
         """
         params = {}

--- a/kraken/futures/ws_client/__init__.py
+++ b/kraken/futures/ws_client/__init__.py
@@ -75,6 +75,36 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
                 asyncio.run(main())
             except KeyboardInterrupt:
                 loop.close()
+
+
+                from kraken.futures import KrakenFuturesWSClient
+
+    .. code-block:: python
+        :linenos:
+        :caption: Futures Websocket: Create the websocket client as context manager
+
+        import asyncio
+        from kraken.futures import KrakenFuturesWSClient
+
+        async def on_message(msg):
+            print(msg)
+
+        async def main() -> None:
+            async with KrakenFuturesWSClient(callback=on_message) as session:
+                await session.subscribe(feed="ticker", products=["PF_XBTUSD"])
+
+            while True:
+                await asyncio.sleep(6)
+
+        if __name__ == "__main__":
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                asyncio.run(main())
+            except KeyboardInterrupt:
+                pass
+            finally:
+                loop.close()
     """
 
     PROD_ENV_URL = "futures.kraken.com/ws/v1"
@@ -356,3 +386,9 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
             ]
         """
         return self._conn._get_active_subscriptions()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        pass

--- a/kraken/spot/funding/__init__.py
+++ b/kraken/spot/funding/__init__.py
@@ -31,6 +31,14 @@ class Funding(KrakenBaseSpotAPI):
         >>> from kraken.spot import Funding
         >>> funding = Funding() # unauthenticated
         >>> auth_funding = Funding(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Spot Funding: Create the funding client as context manager
+
+        >>> from kraken.spot import Funding
+        >>> with Funding(key="api-key", secret="secret-key") as funding:
+        ...     print(funding.get_deposit_methods(asset="XLM"))
     """
 
     def get_deposit_methods(self, asset: str) -> dict:

--- a/kraken/spot/market/__init__.py
+++ b/kraken/spot/market/__init__.py
@@ -31,6 +31,14 @@ class Market(KrakenBaseSpotAPI):
         >>> from kraken.spot import Market
         >>> market = Market() # unauthenticated
         >>> auth_market = Market(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Spot Market: Create the market client as context manager
+
+        >>> from kraken.spot import Market
+        >>> with Market() as market:
+        ...     print(market.get_assets())
     """
 
     def get_assets(

--- a/kraken/spot/staking/__init__.py
+++ b/kraken/spot/staking/__init__.py
@@ -31,6 +31,14 @@ class Staking(KrakenBaseSpotAPI):
         >>> from kraken.spot import Staking
         >>> staking = Staking() # unauthenticated
         >>> auth_staking = Staking(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Spot Staking: Create the staking client as context manager
+
+        >>> from kraken.spot import Staking
+        >>> with Staking(key="api-key", secret="secret-key") as staking:
+        ...     print(staking.stake_asset(asset="XLM", amount=200, method="Lumen Staked"))
     """
 
     def stake_asset(

--- a/kraken/spot/trade/__init__.py
+++ b/kraken/spot/trade/__init__.py
@@ -30,6 +30,15 @@ class Trade(KrakenBaseSpotAPI):
         >>> from kraken.spot import Trade
         >>> trade = Trade() # unauthenticated
         >>> auth_trade = Trade(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Spot Trade: Create the trade client as context manager
+
+        >>> from kraken.spot import Trade
+        >>> with Trade(key="api-key", secret="secret-key") as trade:
+        ...     print(trade.create_order(...))
+
     """
 
     def create_order(

--- a/kraken/spot/user/__init__.py
+++ b/kraken/spot/user/__init__.py
@@ -33,6 +33,14 @@ class User(KrakenBaseSpotAPI):
         >>> from kraken.spot import User
         >>> user = User() # unauthenticated
         >>> auth_user = User(key="api-key", secret="secret-key") # authenticated
+
+    .. code-block:: python
+        :linenos:
+        :caption: Spot User: Create the user client as context manager
+
+        >>> from kraken.spot import User
+        >>> with User(key="api-key", secret="secret-key") as user:
+        ...     print(user.get_account_balances())
     """
 
     def get_account_balance(self) -> dict:

--- a/kraken/spot/websocket/__init__.py
+++ b/kraken/spot/websocket/__init__.py
@@ -344,6 +344,41 @@ class KrakenSpotWSClient(SpotWsClientCl):
                 asyncio.run(main())
             except KeyboardInterrupt:
                 loop.close()
+
+    .. code-block:: python
+        :linenos:
+        :caption: HowTo: Use the websocket client as context manager
+
+        import asyncio
+        from kraken.spot import KrakenSpotWSClient
+
+        async def on_message(msg):
+            print(msg)
+
+        async def main() -> None:
+            async with KrakenSpotWSClient(
+                key="api-key",
+                secret="secret-key",
+                callback=on_message
+            ) as session:
+                await session.subscribe(
+                    subscription={"name": "ticker"},
+                    pair=["XBT/USD"]
+                )
+
+            while True:
+                await asyncio.sleep(6)
+
+
+        if __name__ == "__main__":
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                asyncio.run(main())
+            except KeyboardInterrupt:
+                pass
+            finally:
+                loop.close()
     """
 
     PROD_ENV_URL = "ws.kraken.com"
@@ -570,3 +605,9 @@ class KrakenSpotWSClient(SpotWsClientCl):
         if self._priv_conn is not None:
             return self._priv_conn.subscriptions
         raise ConnectionError("Private connection does not exist!")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        pass

--- a/tests/futures/test_futures_base_api.py
+++ b/tests/futures/test_futures_base_api.py
@@ -11,6 +11,9 @@ import pytest
 
 from kraken.base_api import KrakenBaseFuturesAPI
 from kraken.exceptions import KrakenException
+from kraken.futures import Market
+
+from .helper import is_success
 
 
 @pytest.mark.futures
@@ -37,3 +40,38 @@ def test_KrakenBaseFuturesAPI_without_exception() -> None:
         result.get("result") == "error"
         and result.get("error") == "requiredArgumentMissing"
     )
+
+
+@pytest.mark.futures
+def test_futures_rest_contextmanager() -> None:
+    """
+    Checks if the clients can be used as context manager.
+    - Only the Market client is tested since the base class
+      is defined to be a context manager.
+    """
+    with Market() as market:
+        assert isinstance(market.get_instruments(), dict)
+
+
+@pytest.mark.futures
+@pytest.mark.futures_auth
+def test_futures_rest_contextmanager(
+    futures_market,
+    futures_auth_funding,
+    futures_demo_trade,
+    futures_auth_user,
+) -> None:
+    """
+    Checks if the clients can be used as context manager.
+    """
+    with futures_market as market:
+        assert isinstance(market.get_tick_types(), list)
+
+    with futures_auth_funding as funding:
+        assert is_success(funding.get_historical_funding_rates(symbol="PF_SOLUSD"))
+
+    with futures_auth_user as user:
+        assert is_success(user.get_wallets())
+
+    with futures_demo_trade as trade:
+        assert is_success(trade.get_fills())

--- a/tests/futures/test_futures_base_api.py
+++ b/tests/futures/test_futures_base_api.py
@@ -43,17 +43,6 @@ def test_KrakenBaseFuturesAPI_without_exception() -> None:
 
 
 @pytest.mark.futures
-def test_futures_rest_contextmanager() -> None:
-    """
-    Checks if the clients can be used as context manager.
-    - Only the Market client is tested since the base class
-      is defined to be a context manager.
-    """
-    with Market() as market:
-        assert isinstance(market.get_instruments(), dict)
-
-
-@pytest.mark.futures
 @pytest.mark.futures_auth
 def test_futures_rest_contextmanager(
     futures_market,

--- a/tests/futures/test_futures_funding.py
+++ b/tests/futures/test_futures_funding.py
@@ -5,7 +5,7 @@
 #
 import pytest
 
-from .helper import is_not_error, is_success
+from .helper import is_success
 
 # todo: Mocking? Or is this to dangerous?
 


### PR DESCRIPTION
# Summary
All clients can now be used as context manager. The documentation and examples were extended.