### PR TITLE
Rename `get_tradeable_asset_pair` to `get_asset_pairs` and make the `pair` parameter optional

### DIFF
--- a/examples/spot_examples.py
+++ b/examples/spot_examples.py
@@ -5,6 +5,7 @@
 #
 
 """Module that implements some example usage for the Kraken Futures REST clients."""
+
 import logging
 import logging.config
 import os
@@ -78,7 +79,7 @@ def market_examples() -> None:
     market = Market()
 
     print(market.get_assets(assets=["XBT"]))
-    print(market.get_tradable_asset_pair(pair=["DOTEUR"]))
+    print(market.get_asset_pairs(pair=["DOTEUR"]))
     print(market.get_ticker(pair="XBTUSD"))
     print(market.get_ohlc(pair="XBTUSD", interval=5))
     print(market.get_order_book(pair="XBTUSD", count=10))

--- a/kraken/spot/market/__init__.py
+++ b/kraken/spot/market/__init__.py
@@ -118,16 +118,18 @@ class Market(KrakenBaseSpotAPI):
             method="GET", uri="/public/Assets", params=params, auth=False
         )
 
-    def get_tradable_asset_pair(
-        self: "Market", pair: Union[str, List[str]], info: Optional[str] = None
+    def get_asset_pairs(
+        self: "Market",
+        pair: Optional[Union[str, List[str]]] = None,
+        info: Optional[str] = None,
     ) -> dict:
         """
-        Get information about the tradable asset pairs.
+        Get information about the tradable asset pairs. Can be filtered by name.
 
         - https://docs.kraken.com/rest/#operation/getTradableAssetPairs
 
         :param asset: Filter by asset pair(s)
-        :type asset: str | List[str]
+        :type asset: str | List[str], optional
         :param info: Filter by info, can be one of: ``info`` (all info), ``leverage``
             (leverage info), ``fees`` (fee info), and ``margin`` (margin info)
         :type info: str, optional
@@ -178,7 +180,8 @@ class Market(KrakenBaseSpotAPI):
             }
         """
         params: dict = {}
-        params["pair"] = self._to_str_list(pair)
+        if pair is not None:
+            params["pair"] = self._to_str_list(pair)
         if info is not None:
             params["info"] = info
 

--- a/tests/spot/test_spot_market.py
+++ b/tests/spot/test_spot_market.py
@@ -47,17 +47,19 @@ def test_get_assets(spot_market: Market) -> None:
 
 @pytest.mark.spot
 @pytest.mark.spot_market
-def test_get_tradable_asset_pair(spot_market: Market) -> None:
+def test_get_asset_pairs(spot_market: Market) -> None:
     """
     Checks the ``get_tradable_asset_pair`` endpoint by performing multiple
     requests with different paramaters and validating that the response
     does not contain the error key.
     """
-    assert is_not_error(spot_market.get_tradable_asset_pair(pair="BTCUSD"))
-    assert is_not_error(spot_market.get_tradable_asset_pair(pair=["DOTEUR", "BTCUSD"]))
+    assert is_not_error(spot_market.get_asset_pairs())
+    assert is_not_error(spot_market.get_asset_pairs(pair="BTCUSD"))
+    assert is_not_error(spot_market.get_asset_pairs(pair=["DOTEUR", "BTCUSD"]))
     for i in ("info", "leverage", "fees", "margin"):
-        assert is_not_error(spot_market.get_tradable_asset_pair(pair="DOTEUR", info=i))
+        assert is_not_error(spot_market.get_asset_pairs(pair="DOTEUR", info=i))
         break  # there is no reason for requesting more - but this loop is just for info
+    sleep(3)
 
 
 @pytest.mark.spot


### PR DESCRIPTION
# Summary

As mentioned in #90 - the /AssetPairs endpoint do not require a `pair` query parameter. Since this parameter is now optional, the function name did not match, so it was renamed from `get_tradeable_asset_pair` to `get_asset_pairs`.  