### PR TITLE
Add the `truncate` parameter to `kraken.spot.Trade.create_order`

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -159,7 +159,7 @@ jobs:
   ##    a regular commit/push.
   ##
   UploadTestPyPI:
-    if: success() && github.actor == "btschwertfeger" && github.ref == 'refs/heads/master'
+    if: success() && github.actor == 'btschwertfeger' && github.ref == 'refs/heads/master'
     needs:
       [
         Test-Spot-Public,

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -159,7 +159,7 @@ jobs:
   ##    a regular commit/push.
   ##
   UploadTestPyPI:
-    if: success() && ${{ github.actor }} == "btschwertfeger" && github.ref == 'refs/heads/master'
+    if: success() && github.actor == "btschwertfeger" && github.ref == 'refs/heads/master'
     needs:
       [
         Test-Spot-Public,

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -178,7 +178,7 @@ jobs:
   ##    Generates and uploads the coverage statistics to codecov
   ##
   CodeCov:
-    if: ${{ github.actor }} == "btschwertfeger"
+    if: success() && github.actor == 'btschwertfeger'
     needs:
       [
         Test-Spot-Public,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,25 +16,10 @@ repos:
       - id: fix-byte-order-marker
       - id: fix-encoding-pragma
       - id: mixed-line-ending
-      # - id: name-tests-test
-      #   args: ["--pytest-test-first"]
       - id: requirements-txt-fixer
       - id: end-of-file-fixer
       - id: pretty-format-json
       - id: detect-private-key
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
-    hooks:
-      - id: mypy
-        name: mypy
-        args:
-          [
-            --config-file=pyproject.toml,
-            --install-types,
-            --non-interactive,
-            kraken,
-          ]
-        pass_filenames: false
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
@@ -65,6 +50,19 @@ repos:
         types: [python]
         exclude: ^examples/|^tests/|^setup.py$
         args: ["--rcfile=.pylintrc", "-d", "R0801"] # ignore duplicate code
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.2.0
+    hooks:
+      - id: mypy
+        name: mypy
+        args:
+          [
+            --config-file=pyproject.toml,
+            --install-types,
+            --non-interactive,
+            kraken,
+          ]
+        pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -20,11 +20,11 @@
 .. |Downloads badge| image:: https://static.pepy.tech/personalized-badge/python-kraken-sdk?period=total&units=abbreviation&left_color=grey&right_color=orange&left_text=downloads
    :target: https://pepy.tech/project/python-kraken-sdk
 
-.. |CodeQL badge| image:: https://github.com/btschwertfeger/Python-Kraken-SDK/actions/workflows/codeql.yml/badge.svg?branch=master
-   :target: https://github.com/btschwertfeger/Python-Kraken-SDK/actions/workflows/codeql.yml
+.. |CodeQL badge| image:: https://github.com/btschwertfeger/Python-Kraken-SDK/actions/workflows/codeql.yaml/badge.svg?branch=master
+   :target: https://github.com/btschwertfeger/Python-Kraken-SDK/actions/workflows/codeql.yaml
 
-.. |CI/CD badge| image:: https://github.com/btschwertfeger/Python-Kraken-SDK/actions/workflows/cicd.yml/badge.svg?branch=master
-   :target: https://github.com/btschwertfeger/Python-Kraken-SDK/actions/workflows/cicd.yml
+.. |CI/CD badge| image:: https://github.com/btschwertfeger/Python-Kraken-SDK/actions/workflows/cicd.yaml/badge.svg?branch=master
+   :target: https://github.com/btschwertfeger/Python-Kraken-SDK/actions/workflows/cicd.yaml
 
 .. |codecov badge| image:: https://codecov.io/gh/btschwertfeger/Python-Kraken-SDK/branch/master/badge.svg
    :target: https://app.codecov.io/gh/btschwertfeger/Python-Kraken-SDK

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -11,7 +11,6 @@ import hmac
 import json
 import time
 import urllib.parse
-from copy import deepcopy
 from typing import Any, Dict, List, Optional, Type, Union
 from urllib.parse import urljoin
 from uuid import uuid1

--- a/kraken/futures/market/__init__.py
+++ b/kraken/futures/market/__init__.py
@@ -5,6 +5,7 @@
 
 """Module that implements the Kraken Futures market client"""
 
+from functools import lru_cache
 from typing import List, Optional, Union
 
 from ...base_api import KrakenBaseFuturesAPI
@@ -125,6 +126,7 @@ class Market(KrakenBaseFuturesAPI):
             auth=False,
         )
 
+    @lru_cache()
     def get_tick_types(self: "Market") -> List[str]:
         """
         Retrieve the available tick types that can be used for example to access
@@ -145,6 +147,7 @@ class Market(KrakenBaseFuturesAPI):
         """
         return self._request(method="GET", uri="/api/charts/v1/", auth=False)  # type: ignore[return-value]
 
+    @lru_cache()
     def get_tradeable_products(self: "Market", tick_type: str) -> List[str]:
         """
         Retrieve a list containing the tradeable assets on the futures market.
@@ -168,6 +171,7 @@ class Market(KrakenBaseFuturesAPI):
             method="GET", uri=f"/api/charts/v1/{tick_type}", auth=False
         )
 
+    @lru_cache()
     def get_resolutions(self: "Market", tick_type: str, tradeable: str) -> List[str]:
         """
         Retrieve the list of available resolutions for a specific asset.
@@ -193,6 +197,7 @@ class Market(KrakenBaseFuturesAPI):
             method="GET", uri=f"/api/charts/v1/{tick_type}/{tradeable}", auth=False
         )
 
+    @lru_cache()
     def get_fee_schedules(self: "Market") -> dict:
         """
         Retrieve information about the current fees
@@ -301,6 +306,7 @@ class Market(KrakenBaseFuturesAPI):
         params: dict = {}
         if symbol is not None:
             params["symbol"] = symbol
+
         return self._request(  # type: ignore[return-value]
             method="GET",
             uri="/derivatives/api/v3/orderbook",

--- a/kraken/spot/__init__.py
+++ b/kraken/spot/__init__.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 
+"""Module that provides the Spot REST clients and utility functions."""
 
-"""Module that provides the Spot REST clients"""
 # pylint: disable=unused-import
 from kraken.spot.funding import Funding
 from kraken.spot.market import Market
 from kraken.spot.staking import Staking
 from kraken.spot.trade import Trade
 from kraken.spot.user import User
+from kraken.spot.utils import Utils
 from kraken.spot.websocket import KrakenSpotWSClient

--- a/kraken/spot/market/__init__.py
+++ b/kraken/spot/market/__init__.py
@@ -6,7 +6,6 @@
 
 """Module that implements the Kraken Spot market client"""
 
-from functools import lru_cache
 from typing import List, Optional, Union
 
 from ...base_api import KrakenBaseSpotAPI
@@ -55,7 +54,6 @@ class Market(KrakenBaseSpotAPI):
         super().__enter__()
         return self
 
-    @lru_cache()
     def get_assets(
         self: "Market",
         assets: Optional[Union[str, List[str]]] = None,
@@ -120,7 +118,6 @@ class Market(KrakenBaseSpotAPI):
             method="GET", uri="/public/Assets", params=params, auth=False
         )
 
-    @lru_cache()
     def get_asset_pairs(
         self: "Market",
         pair: Optional[Union[str, List[str]]] = None,

--- a/kraken/spot/market/__init__.py
+++ b/kraken/spot/market/__init__.py
@@ -6,6 +6,7 @@
 
 """Module that implements the Kraken Spot market client"""
 
+from functools import lru_cache
 from typing import List, Optional, Union
 
 from ...base_api import KrakenBaseSpotAPI
@@ -54,6 +55,7 @@ class Market(KrakenBaseSpotAPI):
         super().__enter__()
         return self
 
+    @lru_cache()
     def get_assets(
         self: "Market",
         assets: Optional[Union[str, List[str]]] = None,
@@ -118,6 +120,7 @@ class Market(KrakenBaseSpotAPI):
             method="GET", uri="/public/Assets", params=params, auth=False
         )
 
+    @lru_cache()
     def get_asset_pairs(
         self: "Market",
         pair: Optional[Union[str, List[str]]] = None,

--- a/kraken/spot/market/__init__.py
+++ b/kraken/spot/market/__init__.py
@@ -141,7 +141,7 @@ class Market(KrakenBaseSpotAPI):
             :caption: Spot Market: Get information about tradeable asset pairs
 
             >>> from kraken.spot import Market
-            >>> Market().get_tradeable_asset_pair(pair="XBTUSD")
+            >>> Market().get_asset_pairs(pair="XBTUSD")
             {
                 'XXBTZUSD': {
                     'altname': 'XBTUSD',

--- a/kraken/spot/trade/__init__.py
+++ b/kraken/spot/trade/__init__.py
@@ -167,7 +167,7 @@ class Trade(KrakenBaseSpotAPI):
             ...     volume="0.0001"
             ... )
             {
-                'txid': 'TNGMNU-XQSRA-LKCWOK',
+                'txid': ['TNGMNU-XQSRA-LKCWOK'],
                 'descr': {
                     'order': 'buy 4.00000000 XBTUSD @ limit 23000.0'
                 }
@@ -190,7 +190,7 @@ class Trade(KrakenBaseSpotAPI):
             ...     oflags=["post", "fcib"]
             ... )
             {
-                'txid': 'TPPI2H-CUZZ2-EQR2IE',
+                'txid': ['TPPI2H-CUZZ2-EQR2IE'],
                 'descr': {
                     'order': 'buy 4.0000 XBTUSD @ limit 23000.0'
                 }
@@ -210,7 +210,7 @@ class Trade(KrakenBaseSpotAPI):
             ...     side="buy",
             ... )
             {
-                'txid': 'THNUL1-8ZAS5-EEF3A8',
+                'txid': ['THNUL1-8ZAS5-EEF3A8'],
                 'descr': {
                     'order': 'buy 20.00000000 XBTUSD @ stop loss 22000.0'
                 }

--- a/kraken/spot/trade/__init__.py
+++ b/kraken/spot/trade/__init__.py
@@ -107,7 +107,7 @@ class Trade(KrakenBaseSpotAPI):
                 * Prefixed by # is the same as ``+`` and ``-`` but the sign is set automatically
                 * The percentate sign ``%`` can be used to define relative changes.
         :type price2: str | int | float, optional
-        :param truncate: If enabled: round the price and volume to Kraken's
+        :param truncate: If enabled: round the ``price`` and ``volume`` to Kraken's
             maximum allowed decimal places. See https://support.kraken.com/hc/en-us/articles/4521313131540
             fore more information about decimals.
         :type truncate: bool, optional
@@ -318,7 +318,7 @@ class Trade(KrakenBaseSpotAPI):
 
         if price is not None:
             params["price"] = (
-                str(price)
+                price
                 if not truncate
                 else Utils.truncate(amount=price, amount_type="price", pair=pair)
             )

--- a/kraken/spot/trade/__init__.py
+++ b/kraken/spot/trade/__init__.py
@@ -9,6 +9,7 @@
 from typing import List, Optional, Union
 
 from ...base_api import KrakenBaseSpotAPI
+from ..utils import Utils
 
 
 class Trade(KrakenBaseSpotAPI):
@@ -58,10 +59,11 @@ class Trade(KrakenBaseSpotAPI):
         self: "Trade",
         ordertype: str,
         side: str,
-        volume: Union[str, int, float],
         pair: str,
+        volume: Union[str, int, float],
         price: Optional[Union[str, int, float]] = None,
         price2: Optional[Union[str, int, float]] = None,
+        truncate: bool = False,
         trigger: Optional[str] = None,
         leverage: Optional[str] = None,
         reduce_only: Optional[bool] = False,
@@ -75,7 +77,7 @@ class Trade(KrakenBaseSpotAPI):
         close_price: Optional[Union[str, int, float]] = None,
         close_price2: Optional[Union[str, int, float]] = None,
         deadline: Optional[str] = None,
-        validate: Optional[bool] = False,
+        validate: bool = False,
         userref: Optional[int] = None,
     ) -> dict:
         """
@@ -92,6 +94,8 @@ class Trade(KrakenBaseSpotAPI):
         :type ordertype: str
         :param side: ``buy`` or ``sell``
         :type side: str
+        :param pair: The asset to trade
+        :type pair: str
         :param volume: The volume of the position to create
         :type volume: str | int | float
         :param price: The limit price for ``limit`` orders and the trigger price for orders with
@@ -103,6 +107,10 @@ class Trade(KrakenBaseSpotAPI):
                 * Prefixed by # is the same as ``+`` and ``-`` but the sign is set automatically
                 * The percentate sign ``%`` can be used to define relative changes.
         :type price2: str | int | float, optional
+        :param truncate: If enabled: round the price and volume to Kraken's
+            maximum allowed decimal places. See https://support.kraken.com/hc/en-us/articles/4521313131540
+            fore more information about decimals.
+        :type truncate: bool, optional
         :param trigger: What triggers the position of ``stop-loss``, ``stop-loss-limit``, ``take-profit``, and
             ``take-profit-limit`` orders. Will also be used for associated conditional close orders.
             Kraken will use ``last`` if nothing is specified.
@@ -279,21 +287,25 @@ class Trade(KrakenBaseSpotAPI):
             }
         """
         params: dict = {
-            "ordertype": str(ordertype),
-            "type": str(side),
-            "volume": str(volume),
-            "pair": str(pair),
+            "ordertype": ordertype,
+            "type": side,
+            "pair": pair,
+            "volume": volume
+            if not truncate
+            else Utils.truncate(amount=volume, amount_type="volume", pair=pair),
             "stp_type": stptype,
             "starttm": starttm,
             "validate": validate,
             "reduce_only": reduce_only,
         }
+
         trigger_ordertypes: tuple = (
             "stop-loss",
             "stop-loss-limit",
             "take-profit-limit",
             "take-profit-limit",
         )
+
         if trigger is not None:
             if ordertype not in trigger_ordertypes:
                 raise ValueError(f"Cannot use trigger on ordertype {ordertype}!")
@@ -303,8 +315,13 @@ class Trade(KrakenBaseSpotAPI):
             params["timeinforce"] = timeinforce
         if expiretm is not None:
             params["expiretm"] = str(expiretm)
+
         if price is not None:
-            params["price"] = str(price)
+            params["price"] = (
+                str(price)
+                if not truncate
+                else Utils.truncate(amount=price, amount_type="price", pair=pair)
+            )
 
         if ordertype in ("stop-loss-limit", "take-profit-limit"):
             if price2 is None:

--- a/kraken/spot/utils/__init__.py
+++ b/kraken/spot/utils/__init__.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# GitHub: https://github.com/btschwertfeger
+
+"""Module that provides the Utils class that stores Spot related functions."""
+
+from decimal import Decimal
+from math import floor
+from typing import Union
+
+from ..market import Market
+
+
+class Utils:
+    """
+    The Utils class provides utility functions for the Spot related clients.
+    """
+
+    @staticmethod
+    def truncate(
+        amount: Union[Decimal, float, int, str], amount_type: str, pair: str
+    ) -> str:
+        """
+        Kraken only allows volume and price amounts to be specified with a specific number of
+        decimal places, and these varry depending on the currency pair used.
+
+        This function converts an amount of a specific type and pair to a string that uses
+        the correct number of decimal places.
+
+        - https://support.kraken.com/hc/en-us/articles/4521313131540
+
+        :param amount: The floating point number to represent
+        :type amount: Decimal | float | int | str
+        :param amount_type: What the amount represents. Either 'price' or 'volume'
+        :type amount_type: str
+        :param pair: The currency pair the amount is in reference to.
+        :type pair: str
+        :raises ValueError: If the ``amount_type`` is ``price`` and the price is less
+            than the costmin.
+        :raises ValueError: If the ``amount_type`` is ``volume`` and the volume is
+            less than the ordermin.
+        :raises ValueError: If no valid ``amount_type`` was passed.
+        :return: A string representation of the amount.
+        :rtype: str
+        """
+        if amount_type not in ("price", "volume"):
+            raise ValueError("Amount type must be 'volume' or 'price'!")
+
+        pair_data: dict = Market().get_asset_pairs(pair=pair)
+        data: dict = pair_data[list(pair_data)[0]]
+
+        pair_decimals: int = int(data["pair_decimals"])
+        lot_decimals: int = int(data["lot_decimals"])
+
+        ordermin: Decimal = Decimal(data["ordermin"])
+        costmin: Decimal = Decimal(data["costmin"])
+
+        amount = Decimal(amount)
+        decimals: int
+
+        if amount_type == "price":
+            if costmin > amount:
+                raise ValueError(f"Price is less than the costmin: {costmin}!")
+            decimals = pair_decimals
+        else:  # amount_type == "volume":
+            if ordermin > amount:
+                raise ValueError(f"Volume is less than the ordermin: {ordermin}!")
+            decimals = lot_decimals
+
+        amount_rounded: float = floor(float(amount) * 10**decimals) / 10**decimals
+        return f"{amount_rounded:.{decimals}f}"

--- a/kraken/spot/websocket/__init__.py
+++ b/kraken/spot/websocket/__init__.py
@@ -15,7 +15,7 @@ import traceback
 from copy import deepcopy
 from random import random
 from time import time
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import websockets
 
@@ -35,14 +35,14 @@ class ConnectSpotWebsocket:
     :param callback: Callback function that receives the websocket messages
     :type callback: function
     :param private: If the websocket connects to endpoints that
-     require authentication (default: ``False``)
+        require authentication (default: ``False``)
     :type private: bool, optional
     """
 
     MAX_RECONNECT_NUM: int = 10
 
     def __init__(
-        self,
+        self: "ConnectSpotWebsocket",
         client: KrakenSpotWSClient,
         endpoint: str,
         callback: Any,
@@ -163,7 +163,7 @@ class ConnectSpotWebsocket:
             finished, pending = await asyncio.wait(
                 tasks.keys(), return_when=asyncio.FIRST_EXCEPTION
             )
-            exception_occur = False
+            exception_occur: bool = False
             for task in finished:
                 if task.exception():
                     exception_occur = True
@@ -208,12 +208,15 @@ class ConnectSpotWebsocket:
         )
 
     async def send_ping(self: "ConnectSpotWebsocket") -> None:
-        """Sends ping to Keaken"""
-        msg = {
-            "event": "ping",
-            "reqid": int(time() * 1000),
-        }
-        await self.__socket.send(json.dumps(msg))
+        """Sends ping to Kraken"""
+        await self.__socket.send(
+            json.dumps(
+                {
+                    "event": "ping",
+                    "reqid": int(time() * 1000),
+                }
+            )
+        )
         self.__last_ping = time()
 
     async def send_message(
@@ -253,7 +256,7 @@ class ConnectSpotWebsocket:
         - ``msg.get("event") == "subscriptionStatus"```
         - ``msg.get("status") == "subscribed"``
         """
-        self.__remove_subscription(msg)  # remove from list, to avoid duplicates
+        self.__remove_subscription(msg)  # remove from list, to avoid duplicate entries
         self.__subscriptions.append(self.__build_subscription(msg))
 
     def __remove_subscription(self: "ConnectSpotWebsocket", msg: dict) -> None:
@@ -268,7 +271,7 @@ class ConnectSpotWebsocket:
         - ``msg.get("event") == "subscriptionStatus"```
         - ``msg.get("status") == "unsubscribed"``
         """
-        sub = self.__build_subscription(msg)
+        sub: dict = self.__build_subscription(msg)
         self.__subscriptions = [x for x in self.__subscriptions if x != sub]
 
     def __build_subscription(self: "ConnectSpotWebsocket", msg: dict) -> dict:
@@ -442,7 +445,7 @@ class KrakenSpotWSClient(SpotWsClientCl):
         if self.__callback is not None:
             await self.__callback(msg)
         else:
-            logging.warning("Received event but no callback is defined")
+            logging.warning("Received event but no callback is defined.")
             print(msg)
 
     async def subscribe(

--- a/tests/spot/helper.py
+++ b/tests/spot/helper.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
-# Github: https://github.com/btschwertfeger
+# GitHub: https://github.com/btschwertfeger
 #
 
-from typing import Any, Union
+from typing import Any
 
 
-def is_not_error(value: Union[dict, Any]) -> bool:
+def is_not_error(value: Any) -> bool:
     """Returns True if 'error' in dict."""
     return isinstance(value, dict) and "error" not in value

--- a/tests/spot/test_spot_trade.py
+++ b/tests/spot/test_spot_trade.py
@@ -34,7 +34,7 @@ def test_create_order(spot_auth_trade: Trade) -> None:
                 volume=1.001,
                 oflags=["post"],
                 pair="BTC/EUR",
-                price=0.01,
+                price=1.001,  # this also checks the truncate option
                 timeinforce="GTC",
                 truncate=True,
                 validate=True,  # important to just test this endpoint without risking money
@@ -50,7 +50,7 @@ def test_create_order(spot_auth_trade: Trade) -> None:
                 volume=10000000,
                 oflags=["post"],
                 pair="BTC/EUR",
-                price=0.01,
+                price=100,
                 expiretm="0",
                 displayvol=1000,
                 validate=True,  # important to just test this endpoint without risking money

--- a/tests/spot/test_spot_trade.py
+++ b/tests/spot/test_spot_trade.py
@@ -31,11 +31,12 @@ def test_create_order(spot_auth_trade: Trade) -> None:
             spot_auth_trade.create_order(
                 ordertype="limit",
                 side="buy",
-                volume=1,
+                volume=1.001,
                 oflags=["post"],
                 pair="BTC/EUR",
                 price=0.01,
                 timeinforce="GTC",
+                truncate=True,
                 validate=True,  # important to just test this endpoint without risking money
             ),
             dict,

--- a/tests/spot/test_spot_utils.py
+++ b/tests/spot/test_spot_utils.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# GitHub: https://github.com/btschwertfeger
+#
+
+"""Module that implements the unit tests for the Spot user client."""
+
+from time import sleep
+
+import pytest
+
+from kraken.spot import Utils
+
+
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_utils_truncate_price() -> None:
+    """
+    Checks if the truncate function returns the expected results by
+    checking different inputs for price.
+
+    NOTE: This test may break in the future since the lot_decimals, pair_decimals,
+    ordermin and costmin attributes could change.
+    """
+    for price, expected in (
+        (10000, "10000.0"),
+        (1000.1, "1000.1"),
+        (1000.01, "1000.0"),
+        (1000.001, "1000.0"),
+    ):
+        assert (
+            Utils.truncate(amount=price, amount_type="price", pair="XBTUSD") == expected
+        )
+    sleep(3)
+
+    for price, expected in (
+        (2, "2.0000"),
+        (12.1, "12.1000"),
+        (13.105, "13.1050"),
+        (4.32595, "4.3259"),
+    ):
+        assert (
+            Utils.truncate(amount=price, amount_type="price", pair="DOTUSD") == expected
+        )
+    sleep(3)
+
+
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_utils_truncate_volume() -> None:
+    """
+    Checks if the truncate function returns the expected results by
+    checking different inputs for volume.
+
+    NOTE: This test may break in the future since the lot_decimals, pair_decimals,
+    ordermin and costmin attributes could change.
+    """
+    for volume, expected in (
+        (1, "1.00000000"),
+        (1.1, "1.10000000"),
+        (1.67, "1.67000000"),
+        (1.9328649837, "1.93286498"),
+    ):
+        assert (
+            Utils.truncate(amount=volume, amount_type="volume", pair="XBTUSD")
+            == expected
+        )
+    sleep(3)
+
+    for volume, expected in (
+        (2, "2.00000000"),
+        (12.158, "12.15800000"),
+        (13.1052093, "13.10520930"),
+        (4.32595342455, "4.32595342"),
+    ):
+        assert (
+            Utils.truncate(amount=volume, amount_type="volume", pair="DOTUSD")
+            == expected
+        )
+    sleep(3)
+
+
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_utils_truncate_fail_price_costmin() -> None:
+    """
+    Checks if the truncate function fails if the price is less than the costmin.
+
+    NOTE: This test may break in the future since the lot_decimals, pair_decimals,
+    ordermin and costmin attributes could change.
+    """
+    with pytest.raises(ValueError):
+        Utils.truncate(amount=0.001, amount_type="price", pair="XBTUSD")
+
+
+@pytest.mark.spot
+@pytest.mark.spot_market
+def test_utils_truncate_fail_volume_ordermin() -> None:
+    """
+    Checks if the truncate function fails if the volume is less than the ordermin.
+
+    NOTE: This test may break in the future since the lot_decimals, pair_decimals,
+    ordermin and costmin attributes could change.
+    """
+    with pytest.raises(ValueError):
+        Utils.truncate(amount=0.00001, amount_type="volume", pair="XBTUSD")
+
+
+@pytest.mark.spot
+@pytest.mark.spot_market
+@pytest.mark.selection
+def test_utils_truncate_fail_invalid_amount_type() -> None:
+    """
+    Checks if the truncate function fails when no valid ``amount_type`` was specified.
+
+    NOTE: This test may break in the future since the lot_decimals, pair_decimals,
+    ordermin and costmin attributes could change.
+    """
+    with pytest.raises(ValueError):
+        Utils.truncate(amount=1, amount_type="invalid", pair="XBTUSD")

--- a/tests/spot/test_spot_utils.py
+++ b/tests/spot/test_spot_utils.py
@@ -109,7 +109,6 @@ def test_utils_truncate_fail_volume_ordermin() -> None:
 
 @pytest.mark.spot
 @pytest.mark.spot_market
-@pytest.mark.selection
 def test_utils_truncate_fail_invalid_amount_type() -> None:
     """
     Checks if the truncate function fails when no valid ``amount_type`` was specified.


### PR DESCRIPTION
# Summary

As described in #94, in some cases the Kraken API returns invalid volume or invalid price errors, since Python creates strings like "1e-05" from float values like 0.00001 which cannot be interpreted by the Kraken API. To also ensure that users of the python-kraken-sdk don't need to worry about the right rounding, the new `truncate` function was implemented that can round ``volume`` and ``price``. If the new `truncate` parameter of `kraken.spot.Trade.create_order` is set to `True`, the price and volume will be rounded to the lowest - last decimal. 

The ``price2`` parameter is not affected since that would break the custom commands described in [Kraken Docs addOrder](https://docs.kraken.com/rest/#tag/User-Trading/operation/addOrder) Closes: #94 

Also the `kraken.spot.Trade.create_order` examples were adjusted. Closes #96 
