### PR TITLE
Change `kraken.spot.User.get_balances` and add `kraken.spot.User.get_balance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,21 @@
 
 **Implemented enhancements:**
 
+- `kraken.spot.Trade.create_order`: Ability to use floats as trade amounts or prices [\#94](https://github.com/btschwertfeger/python-kraken-sdk/issues/94)
 - /public/AssetPairs would be nice. [\#90](https://github.com/btschwertfeger/python-kraken-sdk/issues/90)
+- Add the `truncate` parameter to `kraken.spot.Trade.create_order` [\#95](https://github.com/btschwertfeger/python-kraken-sdk/pull/95) ([btschwertfeger](https://github.com/btschwertfeger))
 
 **Fixed bugs:**
 
-- The `cancel_order_batch` endpoint in Spot trading does not work. {'error': \['EAPI:Bad request'\]} [\#65](https://github.com/btschwertfeger/python-kraken-sdk/issues/65)
+- `kraken.spot.Trade.cancel_order_batch` endpoint in Spot trading does not work. `{'error': ['EAPI:Bad request']}` [\#65](https://github.com/btschwertfeger/python-kraken-sdk/issues/65)
 
 **Closed issues:**
 
-- Create CONTRIBUTING.md [\#91](https://github.com/btschwertfeger/python-kraken-sdk/issues/91)
+- `kraken.spot.Trade.create_order`: documentatoin for txid outdated. [\#96](https://github.com/btschwertfeger/python-kraken-sdk/issues/96)
+- Create `CONTRIBUTING.md` [\#91](https://github.com/btschwertfeger/python-kraken-sdk/issues/91)
 - Extend the typing - using mypy [\#84](https://github.com/btschwertfeger/python-kraken-sdk/issues/84)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Create a contribution guideline [\#92](https://github.com/btschwertfeger/python-kraken-sdk/pull/92) ([btschwertfeger](https://github.com/btschwertfeger))
 
@@ -53,7 +56,7 @@
 - Fix and extend release workflow [\#68](https://github.com/btschwertfeger/python-kraken-sdk/pull/68) ([btschwertfeger](https://github.com/btschwertfeger))
 - Fixed bug where `spot.user.get_balances` floats to periodic X.9999... [\#78](https://github.com/btschwertfeger/python-kraken-sdk/pull/78) ([btschwertfeger](https://github.com/btschwertfeger))
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Split the unit tests into individual files [\#75](https://github.com/btschwertfeger/python-kraken-sdk/pull/75) ([btschwertfeger](https://github.com/btschwertfeger))
 - Removed matrix from CodeQL job [\#74](https://github.com/btschwertfeger/python-kraken-sdk/pull/74) ([btschwertfeger](https://github.com/btschwertfeger))
@@ -92,7 +95,7 @@
 - Add a workflow or jobs that run all tests before a merge is done [\#54](https://github.com/btschwertfeger/python-kraken-sdk/issues/54)
 - Move from setup.py to pyroject.toml [\#45](https://github.com/btschwertfeger/python-kraken-sdk/issues/45)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Prepare Release v1.1.0 [\#61](https://github.com/btschwertfeger/python-kraken-sdk/pull/61) ([btschwertfeger](https://github.com/btschwertfeger))
 - 57 remove the unnecessary `client` when importing clients [\#59](https://github.com/btschwertfeger/python-kraken-sdk/pull/59) ([btschwertfeger](https://github.com/btschwertfeger))
@@ -122,7 +125,7 @@
 
 - Missing package \(dotenv\) in requirements.txt [\#33](https://github.com/btschwertfeger/python-kraken-sdk/issues/33)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - examples now use os.getenv instead of python-dotenv [\#34](https://github.com/btschwertfeger/python-kraken-sdk/pull/34) ([btschwertfeger](https://github.com/btschwertfeger))
 - Release v1.0.1 [\#44](https://github.com/btschwertfeger/python-kraken-sdk/pull/44) ([btschwertfeger](https://github.com/btschwertfeger))
@@ -135,7 +138,7 @@
 
 - Extended CI/CD [\#31](https://github.com/btschwertfeger/python-kraken-sdk/pull/31) ([btschwertfeger](https://github.com/btschwertfeger))
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Extend unittests [\#32](https://github.com/btschwertfeger/python-kraken-sdk/pull/32) ([btschwertfeger](https://github.com/btschwertfeger))
 - Add unit tests \#2 [\#30](https://github.com/btschwertfeger/python-kraken-sdk/pull/30) ([btschwertfeger](https://github.com/btschwertfeger))
@@ -144,7 +147,7 @@
 
 [Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v0.7.7...v0.8.0)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Add unit tests [\#29](https://github.com/btschwertfeger/python-kraken-sdk/pull/29) ([btschwertfeger](https://github.com/btschwertfeger))
 
@@ -168,7 +171,7 @@
 
 [Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v0.7.2...v0.7.3)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Add exceptions [\#28](https://github.com/btschwertfeger/python-kraken-sdk/pull/28) ([btschwertfeger](https://github.com/btschwertfeger))
 - Create CODE_OF_CONDUCT.md [\#27](https://github.com/btschwertfeger/python-kraken-sdk/pull/27) ([btschwertfeger](https://github.com/btschwertfeger))
@@ -185,7 +188,7 @@
 
 - add futures websocket endpoints [\#21](https://github.com/btschwertfeger/python-kraken-sdk/issues/21)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Optimized websocket clients [\#26](https://github.com/btschwertfeger/python-kraken-sdk/pull/26) ([btschwertfeger](https://github.com/btschwertfeger))
 
@@ -197,7 +200,7 @@
 
 - add futures trade endpoints [\#20](https://github.com/btschwertfeger/python-kraken-sdk/issues/20)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Add testing [\#25](https://github.com/btschwertfeger/python-kraken-sdk/pull/25) ([btschwertfeger](https://github.com/btschwertfeger))
 - implemented Futures WS Client; adjust spot ws client [\#24](https://github.com/btschwertfeger/python-kraken-sdk/pull/24) ([btschwertfeger](https://github.com/btschwertfeger))
@@ -206,7 +209,7 @@
 
 [Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v0.5.4.2...v0.6.1)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - Add futures clients [\#23](https://github.com/btschwertfeger/python-kraken-sdk/pull/23) ([btschwertfeger](https://github.com/btschwertfeger))
 
@@ -226,7 +229,7 @@
 
 - Add futures market endpoints [\#19](https://github.com/btschwertfeger/python-kraken-sdk/issues/19)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - 19 add futures market endpoints [\#22](https://github.com/btschwertfeger/python-kraken-sdk/pull/22) ([btschwertfeger](https://github.com/btschwertfeger))
 
@@ -252,7 +255,7 @@
 - Add setup files for publishing package [\#17](https://github.com/btschwertfeger/python-kraken-sdk/issues/17)
 - Create README [\#14](https://github.com/btschwertfeger/python-kraken-sdk/issues/14)
 
-**Merged pull requests:**
+Uncategorized merged pull requests:
 
 - 17 add setup files for publishing package [\#18](https://github.com/btschwertfeger/python-kraken-sdk/pull/18) ([btschwertfeger](https://github.com/btschwertfeger))
 - added README.md now ... [\#16](https://github.com/btschwertfeger/python-kraken-sdk/pull/16) ([btschwertfeger](https://github.com/btschwertfeger))

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,12 @@ changelog:
 	docker run -it --rm \
 		-v $(PWD):/usr/local/src/your-app \
 		githubchangeloggenerator/github-changelog-generator \
-		-u btschwertfeger \
-		-p python-kraken-sdk \
-		-t $(GHTOKEN)  \
+		--user btschwertfeger \
+		--project python-kraken-sdk \
+		--token $(GHTOKEN)  \
 		--breaking-labels Breaking \
-		--enhancement-labels Feature
+		--enhancement-labels 'Feature,Enhancement' \
+		--pr-label "Uncategorized merged pull requests:"
 
 ## clean		Clean the workspace
 ##

--- a/kraken/spot/user/__init__.py
+++ b/kraken/spot/user/__init__.py
@@ -145,11 +145,11 @@ class User(KrakenBaseSpotAPI):
 
             >>> from kraken.spot import User
             >>> user = User(key="api-key", secret="secret-key")
-            >>> user.get_balance(currency="DOT")
+            >>> user.get_balance(currency="EUR")
             {
-                'currency': 'DOT',
-                'balance': 32011.21197000,
-                'available_balance': 14999.06197000
+                'currency': 'ZEUR',
+                'balance': 6011.2119,
+                'available_balance': 4999.0619
             }
         """
         balance: Decimal = Decimal(0)

--- a/kraken/spot/user/__init__.py
+++ b/kraken/spot/user/__init__.py
@@ -70,7 +70,8 @@ class User(KrakenBaseSpotAPI):
             >>> from kraken.spot import User
             >>> user = User(key="api-key", secret="secret-key")
             >>> user.get_account_balances()
-            {                'ZUSD': '241983.1415',
+            {
+                'ZUSD': '241983.1415',
                 'KFEE': '8020.22',
                 'BCH': '0.0000077100',
                 'ETHW': '0.0000040',
@@ -84,17 +85,18 @@ class User(KrakenBaseSpotAPI):
             method="POST", uri="/private/Balance"
         )
 
-    def get_balances(self: "User", currency: str) -> dict:
+    def get_balances(self: "User") -> dict:
         """
-        Returns the balance and available balance of a given currency.
+        Retrieve the user's asset balances and the
+        the corresponding amount held by open orders.
 
-        Requires the ``Query funds`` and ``Query open orders & trades`` permissions in the API key settings.
+        Requires the ``Query funds`` permission in the API key settings.
 
-        :param currency: The currency to get the balances from
-        :type currency: str
-        :return: Dictionary containing the ``currency`` (currency as string),
-         ``balance`` (inclding value in orders), and ``available_balance``
-         (amount that is not in orders)
+        :return: Dictionary containing the ``currency`` as keys, that
+            hold a dictinoary containing the ``balance`` key
+            holding the actual balance including the value in orders
+            and the ``hold_trade`` key that represents the amount
+            held in open orders.
         :rtype: dict
 
         .. code-block:: python
@@ -103,31 +105,63 @@ class User(KrakenBaseSpotAPI):
 
             >>> from kraken.spot import User
             >>> user = User(key="api-key", secret="secret-key")
-            >>> user.get_balances(currency="DOT")
+            >>> user.get_balances()
+            {
+                'XXLM': {
+                    'balance': '0.00000000', 'hold_trade': '0.00000000'
+                },
+                'ZEUR': {
+                    'balance': '500.0000', 'hold_trade': '0.0000'
+                },
+                'XXBT': {
+                    'balance': '2.1031709100', 'hold_trade': '0.1401000000'
+                },
+                'KFEE': {
+                    'balance': '1407.73', 'hold_trade': '0.00'
+                },
+                ...
+            }
+        """
+        return self._request(  # type: ignore[return-value]
+            method="POST", uri="/private/BalanceEx"
+        )
+
+    def get_balance(self: "User", currency: str) -> dict:
+        """
+        Returns the balance and available balance of a given currency.
+
+        Requires the ``Query funds`` permission in the API key settings.
+
+        :param currency: The currency to get the balances from
+        :type currency: str
+        :return: Dictionary containing the ``currency`` (currency as string),
+            ``balance`` (inclding value in orders), and ``available_balance``
+            (amount that is not in orders)
+        :rtype: dict
+
+        .. code-block:: python
+            :linenos:
+            :caption: Spot User: Get balance
+
+            >>> from kraken.spot import User
+            >>> user = User(key="api-key", secret="secret-key")
+            >>> user.get_balance(currency="DOT")
             {
                 'currency': 'DOT',
                 'balance': 32011.21197000,
                 'available_balance': 14999.06197000
             }
         """
-
         balance: Decimal = Decimal(0)
-        curr_opts: tuple = (currency, f"Z{currency}", f"X{currency}")
-        for symbol, value in self.get_account_balance().items():
-            if symbol in curr_opts:
-                balance = Decimal(value)
-                break
+        available_balance: Decimal = Decimal(0)
 
-        available_balance: Decimal = balance
-        for order in self.get_open_orders()["open"].values():
-            if currency in order["descr"]["pair"][0 : len(currency)]:
-                if order["descr"]["type"] == "sell":
-                    available_balance -= Decimal(order["vol"])
-            elif currency in order["descr"]["pair"][-len(currency) :]:
-                if order["descr"]["type"] == "buy":
-                    available_balance -= Decimal(order["vol"]) * Decimal(
-                        order["descr"]["price"]
-                    )
+        curr_opts: tuple = (currency, f"Z{currency}", f"X{currency}")
+        for symbol, data in self.get_balances().items():
+            if symbol in curr_opts:
+                currency = symbol
+                balance = Decimal(data["balance"])
+                available_balance = balance - Decimal(data["hold_trade"])
+                break
 
         return {
             "currency": currency,
@@ -138,7 +172,6 @@ class User(KrakenBaseSpotAPI):
     def get_trade_balance(self: "User", asset: Optional[str] = "ZUSD") -> dict:
         """
         Get the summary of all collateral balances.
-
 
         Requires the ``Query funds``, ``Query open orders & trades``,
         and ``Query closed orders & trades`` permissions in the API key settings.


### PR DESCRIPTION
# Summary

Since the undocumented Spot endpoint `/private/BalanceEx` was found in #88 that returns the current balances and those held in orders, it was decided to use the `kraken.spot.User.get_balances` function to access this endpoint. 

The old functionality of `kraken.spot.User.get_balances` was moved to the new function `kraken.spot.User.get_balance` and was simplified - thanks to the new `/private/BalanceEx` endpoint.

Closes: #88 
