### PR TITLE
Add the `truncate` parameter to create_order of the Spot websocket clients' `create_order` and `cancel_order`+ `kraken.spot.Trade.edit_order`

### DIFF
--- a/examples/spot_ws_examples.py
+++ b/examples/spot_ws_examples.py
@@ -30,8 +30,8 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 async def main() -> None:
     """Create bot and subscribe to topics/feeds"""
 
-    key: str = os.getenv("API_KEY")
-    secret: str = os.getenv("SECRET_KEY")
+    key: str = os.getenv("SPOT_API_KEY")
+    secret: str = os.getenv("SPOT_SECRET_KEY")
 
     # ___Custom_Trading_Bot______________
     class Bot(KrakenSpotWSClient):
@@ -47,9 +47,9 @@ async def main() -> None:
             print(msg)
             # if condition:
             #     await self.create_order(
-            #         ordertype='limit',
-            #         side='buy',
-            #         pair='BTC/EUR',
+            #         ordertype="limit",
+            #         side="buy",
+            #         pair="BTC/EUR",
             #         price=20000,
             #         volume=200
             #     )

--- a/kraken/spot/trade/__init__.py
+++ b/kraken/spot/trade/__init__.py
@@ -315,19 +315,16 @@ class Trade(KrakenBaseSpotAPI):
             if ordertype not in trigger_ordertypes:
                 raise ValueError(f"Cannot use trigger on ordertype {ordertype}!")
             params["trigger"] = trigger
-
         if defined(timeinforce):
             params["timeinforce"] = timeinforce
         if defined(expiretm):
             params["expiretm"] = str(expiretm)
-
         if defined(price):
             params["price"] = (
                 price
                 if not truncate
                 else self.truncate(amount=price, amount_type="price", pair=pair)
             )
-
         if ordertype in ("stop-loss-limit", "take-profit-limit"):
             if not defined(price2):
                 raise ValueError(
@@ -338,7 +335,6 @@ class Trade(KrakenBaseSpotAPI):
             raise ValueError(
                 f"Ordertype {ordertype} dos not allow a second price (price2)!"
             )
-
         if defined(leverage):
             params["leverage"] = str(leverage)
         if defined(oflags):
@@ -443,6 +439,7 @@ class Trade(KrakenBaseSpotAPI):
         volume: Optional[Union[str, int, float]] = None,
         price: Optional[Union[str, int, float]] = None,
         price2: Optional[Union[str, int, float]] = None,
+        truncate: bool = False,
         oflags: Optional[str] = None,
         deadline: Optional[str] = None,
         cancel_response: Optional[bool] = None,
@@ -467,6 +464,10 @@ class Trade(KrakenBaseSpotAPI):
         :type price: str | int | float, optional
         :param price2: Set a new second price
         :type price2: str | int | float, optional
+        :param truncate: If enabled: round the ``price`` and ``volume`` to Kraken's
+            maximum allowed decimal places. See https://support.kraken.com/hc/en-us/articles/4521313131540
+            fore more information about decimals.
+        :type truncate: bool, optional
         :param oflags: Order flags like ``post``, ``fcib``, ``fciq``, ``nomp``, ``viqc`` (see the referenced Kraken documentation for more information)
         :type oflags: str | List[str], optional
         :param deadline: (see the referenced Kraken documentation for more information)
@@ -507,9 +508,17 @@ class Trade(KrakenBaseSpotAPI):
         if defined(userref):
             params["userref"] = userref
         if defined(volume):
-            params["volume"] = volume
+            params["volume"] = (
+                str(volume)
+                if not truncate
+                else Trade().truncate(amount=volume, amount_type="volume", pair=pair),
+            )
         if defined(price):
-            params["price"] = price
+            params["price"] = (
+                str(price)
+                if not truncate
+                else Trade().truncate(amount=price, amount_type="price", pair=pair)
+            )
         if defined(price2):
             params["price2"] = price2
         if defined(oflags):

--- a/kraken/spot/trade/__init__.py
+++ b/kraken/spot/trade/__init__.py
@@ -511,13 +511,13 @@ class Trade(KrakenBaseSpotAPI):
             params["volume"] = (
                 str(volume)
                 if not truncate
-                else Trade().truncate(amount=volume, amount_type="volume", pair=pair),
+                else self.truncate(amount=volume, amount_type="volume", pair=pair)
             )
         if defined(price):
             params["price"] = (
                 str(price)
                 if not truncate
-                else Trade().truncate(amount=price, amount_type="price", pair=pair)
+                else self.truncate(amount=price, amount_type="price", pair=pair)
             )
         if defined(price2):
             params["price2"] = price2

--- a/kraken/spot/ws_client/__init__.py
+++ b/kraken/spot/ws_client/__init__.py
@@ -12,6 +12,7 @@ import logging
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from ...base_api import KrakenBaseSpotAPI, defined, ensure_string
+from ..trade import Trade
 
 if TYPE_CHECKING:
     # to avaoid circular import for type checking
@@ -70,6 +71,7 @@ class SpotWsClientCl(KrakenBaseSpotAPI):
         volume: Union[str, int, float],
         price: Optional[Union[str, int, float]] = None,
         price2: Optional[Union[str, int, float]] = None,
+        truncate: bool = False,
         leverage: Optional[Union[str, int, float]] = None,
         oflags: Optional[Union[str, List[str]]] = None,
         starttm: Optional[Union[str, int]] = None,
@@ -105,6 +107,10 @@ class SpotWsClientCl(KrakenBaseSpotAPI):
         :param price2: The second price for ``stop-loss-limit`` and ``take-profit-limit``
             orders (see the referenced Kraken documentation for more information)
         :type price2: str | int | float, optional
+        :param truncate: If enabled: round the ``price`` and ``volume`` to Kraken's
+            maximum allowed decimal places. See https://support.kraken.com/hc/en-us/articles/4521313131540
+            fore more information about decimals.
+        :type truncate: bool, optional
         :param leverage: The leverage
         :type leverage: str | int | float, optional
         :param oflags: Order flags like ``post``, ``fcib``, ``fciq``, ``nomp``, ``viqc``
@@ -170,19 +176,25 @@ class SpotWsClientCl(KrakenBaseSpotAPI):
             "ordertype": str(ordertype),
             "type": str(side),
             "pair": str(pair),
-            "price": str(price),
-            "volume": str(volume),
+            "volume": str(volume)
+            if not truncate
+            else Trade().truncate(amount=volume, amount_type="volume", pair=pair),
             "validate": str(validate),
         }
+        if defined(price):
+            payload["price"] = (
+                str(price)
+                if not truncate
+                else Trade().truncate(amount=price, amount_type="price", pair=pair)
+            )
         if defined(price2):
             payload["price2"] = str(price2)
         if defined(oflags):
-            if isinstance(oflags, str):
-                payload["oflags"] = oflags
-            else:
+            if not isinstance(oflags, str):
                 raise ValueError(
-                    "oflags must be a comma delimited list of order flags as str. Available flags: viqc, fcib, fciq, nompp, post"
+                    "oflags must be a comma delimited list of order flags as str. Available flags: {viqc, fcib, fciq, nompp, post}"
                 )
+            payload["oflags"] = oflags
         if defined(starttm):
             payload["starttm"] = str(starttm)
         if defined(expiretm):
@@ -212,6 +224,7 @@ class SpotWsClientCl(KrakenBaseSpotAPI):
         pair: Optional[str] = None,
         price: Optional[Union[str, int, float]] = None,
         price2: Optional[Union[str, int, float]] = None,
+        truncate: bool = False,
         volume: Optional[Union[str, int, float]] = None,
         oflags: Optional[Union[str, List[str]]] = None,
         newuserref: Optional[Union[str, int]] = None,
@@ -234,6 +247,10 @@ class SpotWsClientCl(KrakenBaseSpotAPI):
         :type price: str | int | float, optional
         :param price2: Set a new second price
         :type price2: str | int | float, optional
+        :param truncate: If enabled: round the ``price`` and ``volume`` to Kraken's
+            maximum allowed decimal places. See https://support.kraken.com/hc/en-us/articles/4521313131540
+            fore more information about decimals.
+        :type truncate: bool, optional
         :param volume: Set a new volume
         :type volume: str | int | float, optional
         :param oflags: Set new oflags (overwrite old ones)
@@ -275,11 +292,19 @@ class SpotWsClientCl(KrakenBaseSpotAPI):
         if defined(pair):
             payload["pair"] = pair
         if defined(price):
-            payload["price"] = str(price)
+            payload["price"] = (
+                str(price)
+                if not truncate
+                else Trade().truncate(amount=price, amount_type="price", pair=pair)
+            )
         if defined(price2):
             payload["price2"] = str(price2)
         if defined(volume):
-            payload["volume"] = str(volume)
+            payload["volume"] = (
+                str(volume)
+                if not truncate
+                else Trade().truncate(amount=volume, amount_type="volume", pair=pair)
+            )
         if defined(oflags):
             payload["oflags"] = oflags
         if defined(newuserref):

--- a/tests/spot/test_spot_trade.py
+++ b/tests/spot/test_spot_trade.py
@@ -166,7 +166,8 @@ def test_edit_order(spot_auth_trade: Trade) -> None:
     Test the ``edit_order`` function by editing an order.
 
     KrakenException.KrakenPermissionDeniedError: since CI does not have
-    trade permissions.
+    trade permissions. If the request would be malformed, another
+    exception could be observed.
     """
     with pytest.raises(KrakenException.KrakenPermissionDeniedError):
         spot_auth_trade.edit_order(
@@ -177,6 +178,7 @@ def test_edit_order(spot_auth_trade: Trade) -> None:
             price=27500,
             price2=26500,
             cancel_response=False,
+            truncate=True,
             oflags=["post"],
             validate=True,
         )


### PR DESCRIPTION
# Summary

The `truncate` parameter described here https://github.com/btschwertfeger/python-kraken-sdk/pull/95 was added to the `kraken.spot.Trade.edit_order`, `kraken.spot.KrakenSpotWSClient.edit_order`, and `kraken.spot.KrakenSpotWSClient.create_order`.

Closes #111 