### PR TITLE
`kraken.spot.OrderbookClient`: add timestamps to book's ask and bid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,45 @@
 
 ## [Unreleased](https://github.com/btschwertfeger/python-kraken-sdk/tree/HEAD)
 
-[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v1.3.0...HEAD)
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v1.4.1...HEAD)
+
+Uncategorized merged pull requests:
+
+- Add "Question" issue template [\#122](https://github.com/btschwertfeger/python-kraken-sdk/pull/122) ([btschwertfeger](https://github.com/btschwertfeger))
+
+## [v1.4.1](https://github.com/btschwertfeger/python-kraken-sdk/tree/v1.4.1) (2023-06-28)
+
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v1.4.0...v1.4.1)
+
+**Fixed bugs:**
+
+- `kraken.spot.Market.get_recent_trades`: 'since' parameter does not work [\#119](https://github.com/btschwertfeger/python-kraken-sdk/issues/119)
+- Fix `kraken.spot.Market.get_recent_trades` parameter 'since' [\#120](https://github.com/btschwertfeger/python-kraken-sdk/pull/120) ([btschwertfeger](https://github.com/btschwertfeger))
+
+**Closed issues:**
+
+- Create `.github/release.yaml` [\#108](https://github.com/btschwertfeger/python-kraken-sdk/issues/108)
+
+## [v1.4.0](https://github.com/btschwertfeger/python-kraken-sdk/tree/v1.4.0) (2023-06-16)
+
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v1.3.0...v1.4.0)
 
 **Implemented enhancements:**
 
 - Add the `truncate` parameter to `create_order` of the Spot websocket client [\#111](https://github.com/btschwertfeger/python-kraken-sdk/issues/111)
-- Add the `truncate` parameter to create_order of the Spot websocket clients' `create_order` and `cancel_order`+ `kraken.spot.Trade.edit_order` [\#113](https://github.com/btschwertfeger/python-kraken-sdk/pull/113) ([btschwertfeger](https://github.com/btschwertfeger))
+- Add a Spot Orderbook client that handles a realtime order book [\#104](https://github.com/btschwertfeger/python-kraken-sdk/issues/104)
+- A the Spot order book client \(`kraken.spot.OrderbookClient`\) [\#106](https://github.com/btschwertfeger/python-kraken-sdk/pull/106) ([btschwertfeger](https://github.com/btschwertfeger))
+- Add the `truncate` parameter to the Spot websocket clients' `create_order` and `cancel_order`+ `kraken.spot.Trade.edit_order` [\#113](https://github.com/btschwertfeger/python-kraken-sdk/pull/113) ([btschwertfeger](https://github.com/btschwertfeger))
+
+**Fixed bugs:**
+
+- user.get_trade_volume\(\) says it supports multiple currencies as a list, but it does not seem to. [\#115](https://github.com/btschwertfeger/python-kraken-sdk/issues/115)
+- kraken.exceptions.KrakenException.KrakenInvalidNonceError: An invalid nonce was supplied. [\#114](https://github.com/btschwertfeger/python-kraken-sdk/issues/114)
 
 Uncategorized merged pull requests:
 
 - Update `/examples/spot_orderbook.py` [\#110](https://github.com/btschwertfeger/python-kraken-sdk/pull/110) ([btschwertfeger](https://github.com/btschwertfeger))
+- Create `release.yaml` [\#116](https://github.com/btschwertfeger/python-kraken-sdk/pull/116) ([btschwertfeger](https://github.com/btschwertfeger))
 
 ## [v1.3.0](https://github.com/btschwertfeger/python-kraken-sdk/tree/v1.3.0) (2023-05-24)
 

--- a/examples/spot_orderbook.py
+++ b/examples/spot_orderbook.py
@@ -5,11 +5,6 @@
 #
 
 """
-NOTE: * The Spot Orderbook client is not released yet. It will be released
-        in python-kraken-sdk=v1.4.0.
-      * Have a look at https://gist.github.com/btschwertfeger/6eea0eeff193f7cd1b262cfce4f0eb51
-        for an example that works now.
-
 This module provides an example on how to use the Spot Orderbook
 client of the python-kraken-sdk (https://github.com/btschwertfeger/python-kraken-sdk)
 to retrieve and maintain a valid Spot order book for (a) specific
@@ -74,7 +69,7 @@ class Orderbook(OrderbookClient):
         print("Bid         Volume\t\t Ask         Volume")
         for level in range(self.depth):
             print(
-                f"{bid[level][0]} ({bid[level][1]}) \t {ask[level][0]} ({ask[level][1]})"
+                f"{bid[level][0]} ({bid[level][1][0]}) \t {ask[level][0]} ({ask[level][1][0]})"
             )
 
         assert book["valid"]  # ensure that the checksum is valid

--- a/kraken/spot/orderbook.py
+++ b/kraken/spot/orderbook.py
@@ -10,6 +10,7 @@ import logging
 from asyncio import sleep as asyncio_sleep
 from binascii import crc32
 from collections import OrderedDict
+from datetime import datetime, timezone
 from inspect import iscoroutinefunction
 from typing import Callable, Dict, List, Optional, Union
 
@@ -257,7 +258,7 @@ class OrderbookClient:
         :return: ``True`` if any critical error occurred else ``False``
         :rtype: bool
         """
-        return self.ws_client.exception_occur
+        return bool(self.ws_client.exception_occur)
 
     def get(self: "OrderbookClient", pair: str) -> Optional[dict]:
         """
@@ -267,6 +268,24 @@ class OrderbookClient:
         :type pair: str
         :return: The orderbook of that ``pair``.
         :rtype: dict
+
+        .. code-block::python
+            :linenos:
+            :caption: Orderbook: Get ask and bid
+
+            …
+            class Orderbook(OrderbookClient):
+
+                async def on_book_update(
+                    self: "Orderbook",
+                    pair: str,
+                    message: list
+                ) -> None:
+                    book: Dict[str, Any] = self.get(pair="XBT/USD")
+                    ask: List[Tuple[str, str]] = list(book["ask"].items())
+                    bid: List[Tuple[str, str]] = list(book["bid"].items())
+                    # ask and bid are now in format [price, (volume, timestamp)]
+                    # … and include the whole orderbook
         """
         return self.__book.get(pair)
 
@@ -286,8 +305,8 @@ class OrderbookClient:
             ['25030.40000', '2.77134976', '1684658131.751539'],
             ['25032.20000', '0.13978808', '1684658131.751577']
         ]
-        ... where the first value is the ask or bid price, the second
-            represents the volume and the last one is the time stamp.
+        … where the first value is the ask or bid price, the second
+          represents the volume and the last one is the timestamp.
 
         :param side: The side to assign the data to,
             either ``ask`` or ``bid``
@@ -298,10 +317,13 @@ class OrderbookClient:
         for entry in snapshot:
             price: str = entry[0]
             volume: str = entry[1]
+            timestamp: datetime = datetime.fromtimestamp(
+                float(entry[2]), timezone.utc
+            ).replace(tzinfo=None)
 
             if float(volume) > 0.0:
                 # Price level exist or is new
-                self.__book[pair][side][price] = volume
+                self.__book[pair][side][price] = (volume, timestamp)
             else:
                 # Price level moved out of range
                 self.__book[pair][side].pop(price)
@@ -333,28 +355,21 @@ class OrderbookClient:
         :type checksum: str
         """
         book: dict = self.__book[pair]
-
-        # sort ask (desc) and bid (asc)
-        ask: List[tuple] = sorted(book["ask"].items(), key=self.get_first)
-        bid: List[tuple] = sorted(
-            book["bid"].items(),
-            key=self.get_first,
-            reverse=True,
-        )
+        ask = list(book["ask"].items())
+        bid = list(book["bid"].items())
 
         local_checksum: str = ""
-        for price_level, volume in ask[:10]:
+        for price_level, (volume, _) in ask[:10]:
             local_checksum += price_level.replace(".", "").lstrip("0") + volume.replace(
                 ".", ""
             ).lstrip("0")
 
-        for price_level, volume in bid[:10]:
+        for price_level, (volume, _) in bid[:10]:
             local_checksum += price_level.replace(".", "").lstrip("0") + volume.replace(
                 ".", ""
             ).lstrip("0")
 
         self.__book[pair]["valid"] = checksum == str(crc32(local_checksum.encode()))
-        # assert self.__book[pair]["valid"]
 
     @staticmethod
     def get_first(values: tuple) -> float:

--- a/kraken/spot/orderbook.py
+++ b/kraken/spot/orderbook.py
@@ -10,7 +10,6 @@ import logging
 from asyncio import sleep as asyncio_sleep
 from binascii import crc32
 from collections import OrderedDict
-from datetime import datetime, timezone
 from inspect import iscoroutinefunction
 from typing import Callable, Dict, List, Optional, Union
 
@@ -317,9 +316,7 @@ class OrderbookClient:
         for entry in snapshot:
             price: str = entry[0]
             volume: str = entry[1]
-            timestamp: datetime = datetime.fromtimestamp(
-                float(entry[2]), timezone.utc
-            ).replace(tzinfo=None)
+            timestamp: str = entry[2]
 
             if float(volume) > 0.0:
                 # Price level exist or is new


### PR DESCRIPTION
# Summary

The OrderbookClient was extended so that every ask and bit now also provide the timestamp of that change.

This change can be breaking - see [this line](https://github.com/btschwertfeger/python-kraken-sdk/pull/124/files#diff-8770989ca1791400b46cc04e6b605a19164ade2bc33886f2cfe24f5ecfd1e90dR72).