### PR TITLE
`kraken.spot.Market.get_recent_trades`: add `count` parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,15 @@ install:
 	$(PYTHON) -m pip install .
 
 ## ======= T E S T I N G =======
-## test		Run the unittests
+## test		Run the unit tests
 ##
 test:
 	$(PYTEST) $(PYTEST_OPTS) $(TEST_DIR)
 
 tests: test
+
+test-wip:
+	$(PYTEST) -m "wip" $(PYTEST_OPTS) $(TEST_DIR)
 
 coverage:
 	$(PYTEST) $(PYTEST_COV_OPTS) $(TEST_DIR)

--- a/kraken/spot/market.py
+++ b/kraken/spot/market.py
@@ -329,7 +329,10 @@ class Market(KrakenBaseSpotAPI):
         )
 
     def get_recent_trades(
-        self: "Market", pair: str, since: Optional[Union[str, int]] = None
+        self: "Market",
+        pair: str,
+        since: Optional[Union[str, int]] = None,
+        count: Optional[int] = None,
     ) -> dict:
         """
         Get the latest trades for a specific trading pair (up to 1000).
@@ -340,6 +343,8 @@ class Market(KrakenBaseSpotAPI):
         :type pair: str
         :param since: Filter trades since given timestamp (default: ``None``)
         :type since: str | int, optional
+        :param count: Limit the results
+        :type count: int
         :return: The last public trades (up to 1000 results)
         :rtype: dict
 
@@ -361,7 +366,9 @@ class Market(KrakenBaseSpotAPI):
         """
         params: dict = {"pair": pair}
         if defined(since):
-            params["since"] = None
+            params["since"] = since
+        if defined(count):
+            params["count"] = count
         return self._request(  # type: ignore[return-value]
             method="GET", uri="/public/Trades", params=params, auth=False
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ testpaths = ["tests"]
 
 [tool.pytest.ini_options]
 markers = [
-    "select: Used to run a specific test by hand.",
+    "wip: Used to run a specific test by hand.",
     "spot: mark a test that tests a Spot endpoint.",
     "spot_auth: mark a test that tests a authenticaed Spot endpoint.",
     "spot_trade: mark a test that tests a Spot Trade endpoint.",

--- a/tests/spot/test_spot_market.py
+++ b/tests/spot/test_spot_market.py
@@ -116,6 +116,10 @@ def test_get_recent_trades(spot_market: Market) -> None:
         spot_market.get_recent_trades(pair="XBTUSD", since="1616663618")
     )
 
+    count10 = spot_market.get_recent_trades(pair="XBTUSD", count=10)
+    assert is_not_error(count10)
+    assert len(count10["XXBTZUSD"]) == 10
+
 
 @pytest.mark.spot
 @pytest.mark.spot_market


### PR DESCRIPTION
# Summary

This MR adds the `count` parameter to `kraken.spot.Market.get_recent_trades` to limit the results.