### PR TITLE
Enable Windows builds within the CI

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -38,5 +38,17 @@ jobs:
       - name: Build the package
         run: python -m build --outdir .
 
-      - name: Install the package
+      - name: Install the package on Linux or MacOS
+        if: runner.os != 'Windows'
         run: python -m pip install python_kraken_sdk*.whl
+
+      - name: Install the package on Windows
+        if: runner.os == 'Windows'
+        run: |
+          try {
+              $WHEEL = Get-ChildItem -Path . -Filter "python_kraken_sdk*.whl" -ErrorAction Stop
+              python -m pip install $WHEEL
+          } catch {
+              Write-Error "Error: .whl file not found in the current directory."
+              exit 1
+          }

--- a/.github/workflows/_test_spot_private.yaml
+++ b/.github/workflows/_test_spot_private.yaml
@@ -7,7 +7,7 @@
 #
 # Runs tests for:
 #   * Spot REST clients
-#   * Spot websocket client
+#   * Spot websocket clients
 #
 
 name: Test Spot
@@ -48,7 +48,7 @@ jobs:
       - name: Install package
         run: python -m pip install .
 
-      ##    Unit tests of the private Spot REST clients and endpoints
+      ##    Unit tests of private Spot REST clients and endpoints
       ##
       - name: Testing Spot REST endpoints
         env:
@@ -57,7 +57,7 @@ jobs:
         run: |
           pytest -vv -m "spot_auth and not spot_websocket" tests
 
-      ##    Unit tests of the Spot websocket client
+      ##    Unit tests of Spot websocket clients
       ##
       - name: Testing Spot websocket client
         env:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -73,9 +73,9 @@ jobs:
     needs: [Pre-Commit]
     uses: ./.github/workflows/_build.yaml
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest] #, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}
@@ -116,7 +116,7 @@ jobs:
       max-parallel: 1 # to avoid failing tests because of API Rate limits
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest] # only ubuntu since this takes to much time ATM
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}
@@ -147,7 +147,7 @@ jobs:
       max-parallel: 1 # to avoid failing tests because of API Rate limits
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}
@@ -161,12 +161,10 @@ jobs:
   UploadTestPyPI:
     if: success() && github.actor == 'btschwertfeger' && github.ref == 'refs/heads/master'
     needs:
-      [
-        Test-Spot-Public,
-        Test-Spot-Private,
-        Test-Futures-Public,
-        Test-Futures-Private,
-      ]
+      - Test-Spot-Public
+      - Test-Spot-Private
+      - Test-Futures-Public
+      - Test-Futures-Private
     name: Upload current development version to Test PyPI
     uses: ./.github/workflows/_pypi_publish.yaml
     with:
@@ -180,12 +178,10 @@ jobs:
   CodeCov:
     if: success() && github.actor == 'btschwertfeger'
     needs:
-      [
-        Test-Spot-Public,
-        Test-Spot-Private,
-        Test-Futures-Public,
-        Test-Futures-Private,
-      ]
+      - Test-Spot-Public
+      - Test-Spot-Private
+      - Test-Futures-Public
+      - Test-Futures-Private
     uses: ./.github/workflows/_codecov.yaml
     with:
       os: "ubuntu-latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,9 +34,9 @@ jobs:
     uses: ./.github/workflows/_build.yaml
     needs: [Pre-Commit]
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-latest] #, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}
@@ -108,7 +108,7 @@ jobs:
       max-parallel: 1 # to avoid failing tests because of API Rate limits
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     with:
       os: ${{ matrix.os }}
@@ -120,12 +120,10 @@ jobs:
   ##
   UploadTestPyPI:
     needs:
-      [
-        Test-Spot-Public,
-        Test-Spot-Private,
-        Test-Futures-Public,
-        Test-Futures-Private,
-      ]
+      - Test-Spot-Public
+      - Test-Spot-Private
+      - Test-Futures-Public
+      - Test-Futures-Private
     name: Upload the current release to Test PyPI
     uses: ./.github/workflows/_pypi_publish.yaml
     with:


### PR DESCRIPTION
# Summary

As the corresponding issue suggests - the Windows build job was enabled using a conditional evaluation to separate the Unix and Windows build job syntax.
