### PR TITLE
Adjust logging and examples; add pylint check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,16 @@ repos:
           - --select=E9,F63,F7,F82
           - --show-source
           - --statistics
+  - repo: https://github.com/pycqa/pylint
+    rev: v2.17.0
+    hooks:
+      - id: pylint
+        name: pylint
+        types: [python]
+        exclude: ^examples/|^tests/|^setup.py$
+        args:
+          - --rcfile=pyproject.toml
+          - -d=R0801 # ignore duplicate code
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.282
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import sys
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "python-kraken-sdk"
-copyright = "2023, Benjamin Thomas Schwertfeger"  # noqa: A001
+copyright = "2023, Benjamin Thomas Schwertfeger"  # noqa: A001 # pylint: disable=redefined-builtin
 author = "Benjamin Thomas Schwertfeger"
 
 # to import the package

--- a/examples/futures_ws_examples.py
+++ b/examples/futures_ws_examples.py
@@ -67,30 +67,31 @@ async def main() -> None:
     # ...
 
     # _____Private_Websocket_Feeds_________________
-    client_auth = Client(key=key, secret=secret)
-    # print(client_auth.get_available_private_subscription_feeds())
+    if key and secret:
+        client_auth = Client(key=key, secret=secret)
+        # print(client_auth.get_available_private_subscription_feeds())
 
-    # subscribe to a private/authenticated websocket feed
-    await client_auth.subscribe(feed="fills")
-    await client_auth.subscribe(feed="open_positions")
-    # await client_auth.subscribe(feed='open_orders')
-    # await client_auth.subscribe(feed='open_orders_verbose')
-    # await client_auth.subscribe(feed='deposits_withdrawals')
-    # await client_auth.subscribe(feed='account_balances_and_margins')
-    # await client_auth.subscribe(feed='balances')
-    # await client_auth.subscribe(feed='account_log')
-    # await client_auth.subscribe(feed='notifications_auth')
+        # subscribe to a private/authenticated websocket feed
+        await client_auth.subscribe(feed="fills")
+        await client_auth.subscribe(feed="open_positions")
+        # await client_auth.subscribe(feed='open_orders')
+        # await client_auth.subscribe(feed='open_orders_verbose')
+        # await client_auth.subscribe(feed='deposits_withdrawals')
+        # await client_auth.subscribe(feed='account_balances_and_margins')
+        # await client_auth.subscribe(feed='balances')
+        # await client_auth.subscribe(feed='account_log')
+        # await client_auth.subscribe(feed='notifications_auth')
 
-    # authenticated clients can also subscribe to public feeds
-    # await client_auth.subscribe(feed='ticker', products=['PI_XBTUSD', 'PF_ETHUSD'])
+        # authenticated clients can also subscribe to public feeds
+        # await client_auth.subscribe(feed='ticker', products=['PI_XBTUSD', 'PF_ETHUSD'])
 
-    # time.sleep(1)
-    # unsubscribe from a private/authenticated websocket feed
-    await client_auth.unsubscribe(feed="fills")
-    await client_auth.unsubscribe(feed="open_positions")
-    # ...
+        # time.sleep(1)
+        # unsubscribe from a private/authenticated websocket feed
+        await client_auth.unsubscribe(feed="fills")
+        await client_auth.unsubscribe(feed="open_positions")
+        # ...
 
-    while not client.exception_occur and not client_auth.exception_occur:
+    while not client.exception_occur:  # and not client_auth.exception_occur:
         await asyncio.sleep(6)
 
 

--- a/examples/spot_trading_bot_template_v2.py
+++ b/examples/spot_trading_bot_template_v2.py
@@ -5,7 +5,7 @@
 
 """
 Module that provides a template to build a Spot trading algorithm using the
-python-kraken-sdk and Kraken Spot websocket API v1.
+python-kraken-sdk and Kraken Spot websocket API v2.
 """
 
 from __future__ import annotations

--- a/examples/spot_ws_examples_v1.py
+++ b/examples/spot_ws_examples_v1.py
@@ -94,7 +94,7 @@ async def main() -> None:
         await client_auth.unsubscribe(subscription={"name": "ownTrades"})
         await client_auth.unsubscribe(subscription={"name": "openOrders"})
 
-    while not client.exception_occur and not client_auth.exception_occur:
+    while not client.exception_occur:  # and not client_auth.exception_occur:
         await asyncio.sleep(6)
 
 

--- a/examples/spot_ws_examples_v1.py
+++ b/examples/spot_ws_examples_v1.py
@@ -82,16 +82,17 @@ async def main() -> None:
     await client.unsubscribe(subscription={"name": "spread"}, pair=["DOT/USD"])
     # ...
 
-    client_auth = Client(key=key, secret=secret)
-    # print(client_auth.active_private_subscriptions)
-    # print(client_auth.private_channel_names) # list private channel names
-    # when using the authenticated client, you can also subscribe to public feeds
-    await client_auth.subscribe(subscription={"name": "ownTrades"})
-    await client_auth.subscribe(subscription={"name": "openOrders"})
+    if key and secret:
+        client_auth = Client(key=key, secret=secret)
+        # print(client_auth.active_private_subscriptions)
+        # print(client_auth.private_channel_names) # list private channel names
+        # when using the authenticated client, you can also subscribe to public feeds
+        await client_auth.subscribe(subscription={"name": "ownTrades"})
+        await client_auth.subscribe(subscription={"name": "openOrders"})
 
-    await asyncio.sleep(2)
-    await client_auth.unsubscribe(subscription={"name": "ownTrades"})
-    await client_auth.unsubscribe(subscription={"name": "openOrders"})
+        await asyncio.sleep(2)
+        await client_auth.unsubscribe(subscription={"name": "ownTrades"})
+        await client_auth.unsubscribe(subscription={"name": "openOrders"})
 
     while not client.exception_occur and not client_auth.exception_occur:
         await asyncio.sleep(6)

--- a/examples/spot_ws_examples_v2.py
+++ b/examples/spot_ws_examples_v2.py
@@ -90,17 +90,18 @@ async def main() -> None:
     )
     # ...
 
-    # Per default, the authenticated client starts two websocket connections,
-    # one for authenticated and one for public messages. If there is no need
-    # for a public connection, it can be disabled using the ``no_public``
-    # parameter.
-    client_auth = Client(key=key, secret=secret, no_public=True)
-    # print(client_auth.private_channel_names)  # … list private channel names
-    # when using the authenticated client, you can also subscribe to public feeds
-    await client_auth.subscribe(params={"channel": "executions"})
+    if key and secret:
+        # Per default, the authenticated client starts two websocket connections,
+        # one for authenticated and one for public messages. If there is no need
+        # for a public connection, it can be disabled using the ``no_public``
+        # parameter.
+        client_auth = Client(key=key, secret=secret, no_public=True)
+        # print(client_auth.private_channel_names)  # … list private channel names
+        # when using the authenticated client, you can also subscribe to public feeds
+        await client_auth.subscribe(params={"channel": "executions"})
 
-    await asyncio.sleep(5)
-    await client_auth.unsubscribe(params={"channel": "executions"})
+        await asyncio.sleep(5)
+        await client_auth.unsubscribe(params={"channel": "executions"})
 
     while not client.exception_occur and not client_auth.exception_occur:
         await asyncio.sleep(6)

--- a/examples/spot_ws_examples_v2.py
+++ b/examples/spot_ws_examples_v2.py
@@ -103,7 +103,7 @@ async def main() -> None:
         await asyncio.sleep(5)
         await client_auth.unsubscribe(params={"channel": "executions"})
 
-    while not client.exception_occur and not client_auth.exception_occur:
+    while not client.exception_occur:  # and not client_auth.exception_occur:
         await asyncio.sleep(6)
 
 

--- a/kraken/futures/user.py
+++ b/kraken/futures/user.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
+from kraken.base_api import KrakenBaseFuturesAPI, defined
+
 if TYPE_CHECKING:
     import requests
-
-from kraken.base_api import KrakenBaseFuturesAPI, defined
 
 
 class User(KrakenBaseFuturesAPI):

--- a/kraken/futures/websocket/__init__.py
+++ b/kraken/futures/websocket/__init__.py
@@ -21,7 +21,6 @@ import websockets
 from kraken.exceptions import KrakenException
 
 if TYPE_CHECKING:
-    # to avoid circular import for type checking
     from kraken.futures import KrakenFuturesWSClient
 
 
@@ -89,10 +88,10 @@ class ConnectFuturesWebsocket:
                 try:
                     _msg = await asyncio.wait_for(self.__socket.recv(), timeout=15)
                 except asyncio.TimeoutError:
-                    logging.debug(
-                        "Timeout error in {endpoint}",
-                        extra={"endpoint": self.__ws_endpoint},
-                    )  # important
+                    logging.debug(  # important
+                        "Timeout error in %s",
+                        self.__ws_endpoint,
+                    )
                 except asyncio.CancelledError:
                     logging.exception("asyncio.CancelledError")
                     keep_alive = False
@@ -138,8 +137,9 @@ class ConnectFuturesWebsocket:
 
         reconnect_wait: float = self.__get_reconnect_wait(self.__reconnect_num)
         logging.debug(
-            "asyncio sleep reconnect_wait={wait} s reconnect_num={num}",
-            extra={"wait": reconnect_wait, "num": self.__reconnect_num},
+            "asyncio sleep reconnect_wait=%f s reconnect_num=%d",
+            reconnect_wait,
+            self.__reconnect_num,
         )
         await asyncio.sleep(reconnect_wait)
         logging.debug("asyncio sleep done")
@@ -165,7 +165,7 @@ class ConnectFuturesWebsocket:
                     message = f"{task} got an exception {task.exception()}\n {task.get_stack()}"
                     logging.warning(message)
                     for process in pending:
-                        logging.warning("pending {proc}", extra={"proc": process})
+                        logging.warning("pending %s", process)
                         try:
                             process.cancel()
                         except asyncio.CancelledError:
@@ -181,8 +181,8 @@ class ConnectFuturesWebsocket:
         event: asyncio.Event,
     ) -> None:
         logging.info(
-            "Recover subscriptions {subscriptions} waiting.",
-            extra={"subscriptions": self.__subscriptions},
+            "Recover subscriptions %s waiting.",
+            self.__subscriptions,
         )
         await event.wait()
 
@@ -191,11 +191,11 @@ class ConnectFuturesWebsocket:
                 await self.send_message(deepcopy(sub), private=True)
             elif sub["feed"] in self.__client.get_available_public_subscription_feeds():
                 await self.send_message(deepcopy(sub), private=False)
-            logging.info("{sub}: OK", extra={"sub": sub})
+            logging.info("%s: OK", sub)
 
         logging.info(
-            "Recover subscriptions {subscriptions} done.",
-            extra={"subscriptions": self.__subscriptions},
+            "Recover subscriptions %s done.",
+            self.__subscriptions,
         )
 
     async def send_message(

--- a/kraken/spot/orderbook.py
+++ b/kraken/spot/orderbook.py
@@ -306,8 +306,8 @@ class OrderbookClient:
                     message: list
                 ) -> None:
                     book: Dict[str, Any] = self.get(pair="XBT/USD")
-                    ask: List[Tuple[str, str]] = list(book["ask"].items())
-                    bid: List[Tuple[str, str]] = list(book["bid"].items())
+                    ask: list[Tuple[str, str]] = list(book["ask"].items())
+                    bid: list[Tuple[str, str]] = list(book["bid"].items())
                     # ask and bid are now in format [price, (volume, timestamp)]
                     # … and include the whole orderbook
         """

--- a/kraken/spot/websocket/connectors.py
+++ b/kraken/spot/websocket/connectors.py
@@ -108,8 +108,8 @@ class ConnectSpotWebsocketBase:
             None if not self.__is_auth else self.__client.get_ws_token()
         )
         self.LOG.debug(
-            "Websocket token: {details}",
-            extra={"details": self.ws_conn_details},
+            "Websocket token: %s",
+            self.ws_conn_details,
         )
 
         async with websockets.connect(  # pylint: disable=no-member
@@ -162,8 +162,9 @@ class ConnectSpotWebsocketBase:
         except Exception as exc:
             traceback_: str = traceback.format_exc()
             logging.exception(
-                "{exc}: {traceback}",
-                extra={"exc": exc, "traceback": traceback_},
+                "%s: %s",
+                exc,
+                traceback_,
             )
             await self.__callback({"error": traceback_})
         finally:
@@ -215,7 +216,7 @@ class ConnectSpotWebsocketBase:
                     message: str = f"{task} got an exception {task.exception()}\n {task.get_stack()}"
                     self.LOG.warning(message)
                     for process in pending:
-                        self.LOG.warning("pending {proc}", extra={"proc": process})
+                        self.LOG.warning("pending %s", process)
                         try:
                             process.cancel()
                         except asyncio.CancelledError:
@@ -355,7 +356,7 @@ class ConnectSpotWebsocketV1(ConnectSpotWebsocketBase):
                 private = True
 
             await self.client.send_message(cpy, private=private)
-            self.LOG.info("{sub} OK", extra={"sub": sub})
+            self.LOG.info("%s: OK", sub)
 
         self.LOG.info("%s done.", log_msg)
 
@@ -500,7 +501,7 @@ class ConnectSpotWebsocketV2(ConnectSpotWebsocketBase):
 
         for subscription in self._subscriptions:
             await self.client.subscribe(params=subscription)
-            self.LOG.info("{subscription} OK", extra={"subscription": subscription})
+            self.LOG.info("%s: OK", subscription)
 
         self.LOG.info("%s done.", log_msg)
 

--- a/kraken/spot/websocket_v2.py
+++ b/kraken/spot/websocket_v2.py
@@ -170,7 +170,7 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
             api_version="v2",
         )
 
-    async def send_message(  # noqa: PLR0912
+    async def send_message(  # noqa: PLR0912 # pylint: disable=arguments-differ
         self: KrakenSpotWSClientV2,
         message: dict,
         raw: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,9 +259,6 @@ ban-relative-imports = "all"
 [tool.ruff.flake8-bandit]
 check-typed-exception = true
 
-[tool.ruff.isort]
-case-sensitive = true
-
 [tool.ruff.pep8-naming]
 ignore-names = [
   "i",
@@ -297,3 +294,625 @@ ignore-names = [
 [tool.ruff.pylint]
 max-args = 8
 max-branches = 10
+
+[tool.pylint.main]
+# Analyse import fallback blocks. This can be used to support both Python 2 and 3
+# compatible code, which means that the block might have code that exists only in
+# one or another interpreter, leading to false positives when analyzed.
+# analyse-fallback-blocks =
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint in
+# a server-like mode.
+# clear-cache-post-run =
+
+# Always return a 0 (non-error) status code, even if lint errors are found. This
+# is primarily useful in continuous integration scripts.
+# exit-zero =
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+# extension-pkg-allow-list =
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+# extension-pkg-whitelist =
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+# fail-on =
+
+# Specify a score threshold under which the program will exit with error.
+fail-under = 10.0
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+# from-stdin =
+
+# Files or directories to be skipped. They should be base names, not paths.
+# ignore =
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems, it
+# can't be used as an escape character.
+ignore-paths = [
+  ".git\\\\\n.github\\\\\n.pytest_cache\\\\\nbuild\\\\\ndist\\\\\npython_kaken_sdk.egg-info|.git/\n.github/\n.pytest_cache/\nbuild/\ndist/\npython_kaken_sdk.egg-info",
+]
+
+# Files or directories matching the regular expression patterns are skipped. The
+# regex matches against base names, not paths. The default value ignores Emacs
+# file locks
+ignore-patterns = ["^\\.#"]
+
+# List of module names for which member attributes should not be checked (useful
+# for modules/projects where namespaces are manipulated during runtime and thus
+# existing member attributes cannot be deduced by static analysis). It supports
+# qualified module names, as well as Unix pattern matching.
+# ignored-modules =
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+# init-hook =
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs = 2
+
+# Control the amount of potential inferred values when inferring a single object.
+# This can help the performance when dealing with large functions or complex,
+# nested conditions.
+limit-inference-results = 100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+# load-plugins =
+
+# Pickle collected data for later comparisons.
+persistent = true
+
+# Minimum Python version to use for version dependent checks. Will default to the
+# version used to run pylint.
+py-version = "3.11"
+
+# Discover python modules and packages in the file system subtree.
+# recursive =
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+# source-roots =
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode = true
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+# unsafe-load-any-extension =
+
+[tool.pylint.basic]
+# Naming style matching correct argument names.
+argument-naming-style = "snake_case"
+
+# Regular expression matching correct argument names. Overrides argument-naming-
+# style. If left empty, argument names will be checked with the set naming style.
+# argument-rgx =
+
+# Naming style matching correct attribute names.
+attr-naming-style = "snake_case"
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+# attr-rgx =
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names = ["foo", "bar", "baz", "toto", "tutu", "tata"]
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+# bad-names-rgxs =
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style = "any"
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+# class-attribute-rgx =
+
+# Naming style matching correct class constant names.
+class-const-naming-style = "UPPER_CASE"
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+# class-const-rgx =
+
+# Naming style matching correct class names.
+class-naming-style = "PascalCase"
+
+# Regular expression matching correct class names. Overrides class-naming-style.
+# If left empty, class names will be checked with the set naming style.
+# class-rgx =
+
+# Naming style matching correct constant names.
+const-naming-style = "UPPER_CASE"
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming style.
+# const-rgx =
+
+# Minimum line length for functions/classes that require docstrings, shorter ones
+# are exempt.
+docstring-min-length = -1
+
+# Naming style matching correct function names.
+function-naming-style = "snake_case"
+
+# Regular expression matching correct function names. Overrides function-naming-
+# style. If left empty, function names will be checked with the set naming style.
+# function-rgx =
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names = [
+  "i",
+  "j",
+  "k",
+  "_",
+  "fromAccount",
+  "toAccount",
+  "fromUser",
+  "toUser",
+  "sourceWallet",
+  "lastTime",
+  "lastFillTime",
+  "to",
+  "maxLeverage",
+  "pnlPreference",
+  "cliOrdId",
+  "cliOrdIds",
+  "orderId",
+  "orderIds",
+  "stopPrice",
+  "limitPrice",
+  "orderType",
+  "reduceOnly",
+  "triggerSignal",
+  "EXCEPTION_ASSIGNMENT",
+  "trailingStopDeviationUnit",
+  "trailingStopMaxDeviation",
+  "subaccountUid",
+  "ConnectSpotWebsocket",
+]
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+# good-names-rgxs =
+
+# Include a hint for the correct naming format with invalid-name.
+# include-naming-hint =
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style = "any"
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+# inlinevar-rgx =
+
+# Naming style matching correct method names.
+method-naming-style = "snake_case"
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+# method-rgx =
+
+# Naming style matching correct module names.
+module-naming-style = "snake_case"
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+# module-rgx =
+
+# Colon-delimited sets of names that determine each other's naming style when the
+# name regexes allow several styles.
+# name-group =
+
+# Regular expression which should only match function or class names that do not
+# require a docstring.
+no-docstring-rgx = "^_"
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties. These
+# decorators are taken in consideration only for invalid-name.
+property-classes = ["abc.abstractproperty"]
+
+# Regular expression matching correct type alias names. If left empty, type alias
+# names will be checked with the set naming style.
+# typealias-rgx =
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+# typevar-rgx =
+
+# Naming style matching correct variable names.
+variable-naming-style = "snake_case"
+
+# Regular expression matching correct variable names. Overrides variable-naming-
+# style. If left empty, variable names will be checked with the set naming style.
+# variable-rgx =
+
+[tool.pylint.classes]
+# Warn about protected attribute access inside special methods
+# check-protected-access-in-special-methods =
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods = ["__init__", "__new__", "setUp", "__post_init__"]
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected = ["_asdict", "_fields", "_replace", "_source", "_make"]
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg = ["cls"]
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg = ["cls"]
+
+[tool.pylint.design]
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+# exclude-too-few-public-methods =
+
+# List of qualified class names to ignore when counting class parents (see R0901)
+# ignored-parents =
+
+# Maximum number of arguments for function / method.
+max-args = 23
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes = 10
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr = 5
+
+# Maximum number of branch for function / method body.
+max-branches = 18
+
+# Maximum number of locals for function / method body.
+max-locals = 15
+
+# Maximum number of parents for a class (see R0901).
+max-parents = 7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods = 20
+
+# Maximum number of return / yield for function / method body.
+max-returns = 6
+
+# Maximum number of statements in function / method body.
+max-statements = 50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods = 2
+
+[tool.pylint.exceptions]
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions = ["builtins.BaseException", "builtins.Exception"]
+
+[tool.pylint.format]
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+# expected-line-ending-format =
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines = "^\\s*(# )?<?https?://\\S+>?$"
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren = 4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string = "    "
+
+# Maximum number of characters on a single line.
+max-line-length = 130
+
+# Maximum number of lines in a module.
+max-module-lines = 1250
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt = true
+
+# Allow the body of an if to be on the same line as the test if there is no else.
+single-line-if-stmt = true
+
+[tool.pylint.imports]
+# List of modules that can be imported at any level, not just the top level one.
+# allow-any-import-level =
+
+# Allow explicit reexports by alias from a package __init__.
+# allow-reexport-from-package =
+
+# Allow wildcard imports from modules that define __all__.
+# allow-wildcard-with-all =
+
+# Deprecated modules which should not be used, separated by a comma.
+# deprecated-modules =
+
+# Output a graph (.gv or any supported image format) of external dependencies to
+# the given file (report RP0402 must not be disabled).
+# ext-import-graph =
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be disabled).
+# import-graph =
+
+# Output a graph (.gv or any supported image format) of internal dependencies to
+# the given file (report RP0402 must not be disabled).
+# int-import-graph =
+
+# Force import order to recognize a module as part of the standard compatibility
+# libraries.
+# known-standard-library =
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party = ["enchant"]
+
+# Couples of modules and preferred modules, separated by a comma.
+# preferred-modules =
+
+[tool.pylint.logging]
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style = "new"
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules = ["logging"]
+
+[tool.pylint."messages control"]
+# Only show warnings with the listed confidence levels. Leave empty to show all.
+# Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence = [
+  "HIGH",
+  "CONTROL_FLOW",
+  "INFERENCE",
+  "INFERENCE_FAILURE",
+  "UNDEFINED",
+]
+
+# Disable the message, report, category or checker with the given id(s). You can
+# either give multiple identifiers separated by comma (,) or put this option
+# multiple times (only on the command line, not in the configuration file where
+# it should appear only once). You can also use "--disable=all" to disable
+# everything first and then re-enable specific checks. For example, if you want
+# to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable = [
+  "anomalous-backslash-in-string",
+  "bad-inline-option",
+  "broad-exception-caught",
+  "broad-exception-raised",
+  "deprecated-pragma",
+  "fixme",
+  "import-error",
+  "keyword-arg-before-vararg",
+  "line-too-long",
+  "locally-disabled",
+  "logging-fstring-interpolation",
+  "logging-too-many-args",
+  "multiple-statements",
+  "no-self-argument",
+  "raw-checker-failed",
+  "suppressed-message",
+  "too-few-public-methods",
+  "too-many-locals",
+  "too-many-public-methods",
+  "unsubscriptable-object",
+  "unused-argument",
+  "useless-suppression",
+]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where it
+# should appear only once). See also the "--disable" option for examples.
+enable = ["c-extension-no-member"]
+
+[tool.pylint.method_args]
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods = [
+  "requests.api.delete",
+  "requests.api.get",
+  "requests.api.head",
+  "requests.api.options",
+  "requests.api.patch",
+  "requests.api.post",
+  "requests.api.put",
+  "requests.api.request",
+]
+
+[tool.pylint.miscellaneous]
+# List of note tags to take in consideration, separated by a comma.
+notes = ["FIXME", "fixme", "TODO", "todo"]
+
+# Regular expression of note tags to take in consideration.
+# notes-rgx =
+
+[tool.pylint.refactoring]
+# Maximum number of nested blocks for function / method body
+max-nested-blocks = 10
+
+# Complete name of functions that never returns. When checking for inconsistent-
+# return-statements if a never returning function is called then it will be
+# considered as an explicit return statement and no message will be printed.
+never-returning-functions = ["sys.exit", "argparse.parse_error"]
+
+[tool.pylint.reports]
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each category,
+# as well as 'statement' which is the total number of statements analyzed. This
+# score is used by the global evaluation report (RP0004).
+evaluation = "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))"
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+# msg-template =
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+# output-format =
+
+# Tells whether to display a full report or only the messages.
+# reports =
+
+# Activate the evaluation score.
+score = true
+
+[tool.pylint.similarities]
+# Comments are removed from the similarity computation
+ignore-comments = true
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings = true
+
+# Imports are removed from the similarity computation
+ignore-imports = true
+
+# Signatures are removed from the similarity computation
+ignore-signatures = true
+
+# Minimum lines number of a similarity.
+min-similarity-lines = 4
+
+[tool.pylint.spelling]
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions = 4
+
+# Spelling dictionary name. No available dictionaries : You need to install both
+# the python package and the system dependency for enchant to work..
+# spelling-dict =
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives = "fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:"
+
+# List of comma separated words that should not be checked.
+# spelling-ignore-words =
+
+# A path to a file that contains the private dictionary; one word per line.
+# spelling-private-dict-file =
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+# spelling-store-unknown-words =
+
+[tool.pylint.typecheck]
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators = ["contextlib.contextmanager"]
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+# generated-members =
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# class is considered mixin if its name matches the mixin-class-rgx option.
+# Tells whether to warn about missing members when the owner of the attribute is
+# inferred to be None.
+ignore-none = true
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference can
+# return multiple potential results while evaluating a Python object, but some
+# branches might not be evaluated, which results in partial inference. In that
+# case, it might be useful to still emit no-member and other checks for the rest
+# of the inferred objects.
+ignore-on-opaque-inference = true
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins = [
+  "no-member",
+  "not-async-context-manager",
+  "not-context-manager",
+  "attribute-defined-outside-init",
+]
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes = [
+  "optparse.Values",
+  "thread._local",
+  "_thread._local",
+  "argparse.Namespace",
+]
+
+# Show a hint with possible names when a member name was not found. The aspect of
+# finding the hint is based on edit distance.
+missing-member-hint = true
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance = 1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices = 1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx = ".*[Mm]ixin"
+
+# List of decorators that change the signature of a decorated function.
+# signature-mutators =
+
+[tool.pylint.variables]
+# List of additional names supposed to be defined in builtins. Remember that you
+# should avoid defining new builtins when possible.
+# additional-builtins =
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables = true
+
+# List of names allowed to shadow builtins
+# allowed-redefined-builtins =
+
+# List of strings which can identify a callback function by name. A callback name
+# must start or end with one of those strings.
+callbacks = ["cb_", "_cb"]
+
+# A regular expression matching the name of dummy variables (i.e. expected to not
+# be used).
+dummy-variables-rgx = "_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_"
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names = "_.*|^ignored_|^unused_"
+
+# Tells whether we should check for unused import in __init__ files.
+# init-import =
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules = [
+  "six.moves",
+  "past.builtins",
+  "future.builtins",
+  "builtins",
+  "io",
+]


### PR DESCRIPTION
# Summary

* There were some strange logging outputs that have been fixed. 
* The websocket examples were modified to work directly without authentication.
* Pylint was re-added because ruff seems not to be sufficient - so both are used.
