### PR TITLE
Resolve "Add optional `extra_params` to any requesting function"

### DIFF
--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -211,6 +211,7 @@ class KrakenBaseSpotAPI:
         timeout: int = 10,
         auth: bool = True,
         params: Optional[dict] = None,
+        extra_params: Optional[dict] = None,
         do_json: bool = False,
         return_raw: bool = False,
     ) -> Union[Dict[str, Any], List[str], List[Dict[str, Any]], requests.Response]:
@@ -230,6 +231,9 @@ class KrakenBaseSpotAPI:
         :param params: The query or post parameter of the request (default:
             ``None``)
         :type params: dict, optional
+        :param params: Additional query or post parameter of the request
+            (default: ``None``)
+        :type params: dict, optional
         :param do_json: If the ``params`` must be "jsonified" - in case of
             nested dict style
         :type do_json: bool
@@ -240,10 +244,15 @@ class KrakenBaseSpotAPI:
         :raise kraken.exceptions.KrakenException.*: If the response contains
             errors
         :return: The response
-        :rtype: dict[str, Any] | list[str] | list[dict[str, Any]] | requests.Response
+        :rtype: dict[str, Any] | list[str] | list[dict[str, Any]] |
+            requests.Response
         """
-        if params is None:
+        if not defined(params):
             params = {}
+        if not defined(extra_params):
+            extra_params = {}
+
+        params |= extra_params
 
         method = method.upper()
         data_json: str = ""

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -255,7 +255,7 @@ class KrakenBaseSpotAPI:
             params = {}
         if defined(extra_params):
             params |= (
-                json.loads(extra_params)  # type: ignore[arg-type]
+                json.loads(extra_params)
                 if isinstance(extra_params, str)
                 else extra_params
             )
@@ -513,8 +513,8 @@ class KrakenBaseFuturesAPI:
         if defined(post_params):
             if defined(extra_params):
                 post_params |= (
-                    json.loads(extra_params)  # type: ignore[arg-type]
-                    if isinstance(post_params, str)
+                    json.loads(extra_params)
+                    if isinstance(extra_params, str)
                     else extra_params
                 )
             strl = [f"{key}={post_params[key]}" for key in sorted(post_params)]
@@ -522,7 +522,7 @@ class KrakenBaseFuturesAPI:
         else:
             post_params = {}
             if isinstance(extra_params, dict):
-                post_params |= extra_params
+                post_params |= extra_params  # type: ignore[operator]
 
         query_string: str = ""
         if query_params is not None:

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -214,12 +214,12 @@ class KrakenBaseSpotAPI:
         method: str,
         uri: str,
         params: Optional[dict] = None,
-        extra_params: Optional[str | dict] = None,
         timeout: int = 10,
         *,
         auth: bool = True,
         do_json: bool = False,
         return_raw: bool = False,
+        extra_params: Optional[str | dict] = None,
     ) -> dict[str, Any] | list[str] | list[dict[str, Any]] | requests.Response:
         """
         Handles the requested requests, by sending the request, handling the
@@ -470,12 +470,12 @@ class KrakenBaseFuturesAPI:
         method: str,
         uri: str,
         post_params: Optional[dict] = None,
-        extra_params: Optional[dict] = None,
         query_params: Optional[dict] = None,
         timeout: int = 10,
         *,
         auth: bool = True,
         return_raw: bool = False,
+        extra_params: Optional[dict] = None,
     ) -> dict[str, Any] | list[dict[str, Any]] | list[str] | requests.Response:
         """
         Handles the requested requests, by sending the request, handling the
@@ -495,13 +495,10 @@ class KrakenBaseFuturesAPI:
         :param query_params: The query parameter of the request (default:
             ``None``)
         :type query_params: dict, optional
-        :param do_json: If the ``post_params`` must be "jsonified" - in case of
-            nested dict style
         :param timeout: Timeout for the request (default: ``10``)
         :type timeout: int
         :param auth: If the request needs authentication (default: ``True``)
         :type auth: bool
-        :type do_json: bool, optional
         :param return_raw: If the response should be returned without parsing.
             This is used for example when requesting an export of the trade
             history as .zip archive.
@@ -515,19 +512,22 @@ class KrakenBaseFuturesAPI:
 
         post_string: str = ""
         listed_params: list[str]
+        if defined(extra_params):
+            extra_params = (
+                json.loads(extra_params)
+                if isinstance(extra_params, str)
+                else extra_params
+            )
+        else:
+            extra_params = {}
+
         if defined(post_params):
-            if defined(extra_params):
-                post_params |= (
-                    json.loads(extra_params)
-                    if isinstance(extra_params, str)
-                    else extra_params
-                )
+            post_params |= extra_params
             listed_params = [f"{key}={post_params[key]}" for key in sorted(post_params)]
             post_string = "&".join(listed_params)
         else:
             post_params = {}
-            if isinstance(extra_params, dict):
-                post_params |= extra_params
+            post_params |= extra_params
 
         query_string: str = ""
         if query_params is not None:

--- a/kraken/futures/__init__.py
+++ b/kraken/futures/__init__.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # GitHub: https://github.com/btschwertfeger
+# pylint: disable=unused-import
 
 """This module provides the Kraken Futures clients"""
 
-# pylint: disable=unused-import
 from kraken.futures.funding import Funding
 from kraken.futures.market import Market
 from kraken.futures.trade import Trade

--- a/kraken/futures/funding.py
+++ b/kraken/futures/funding.py
@@ -60,7 +60,12 @@ class Funding(KrakenBaseFuturesAPI):
         super().__enter__()
         return self
 
-    def get_historical_funding_rates(self: Funding, symbol: str) -> dict:
+    def get_historical_funding_rates(
+        self: Funding,
+        symbol: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve information about the historical funding rates of a specific ``symbol``
 
@@ -96,6 +101,7 @@ class Funding(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v4/historicalfundingrates",
             query_params={"symbol": symbol},
             auth=False,
+            extra_params=extra_params,
         )
 
     def initiate_wallet_transfer(
@@ -104,6 +110,8 @@ class Funding(KrakenBaseFuturesAPI):
         fromAccount: str,
         toAccount: str,
         unit: str,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Submit a wallet transfer request to transfer funds between margin accounts.
@@ -149,6 +157,7 @@ class Funding(KrakenBaseFuturesAPI):
                 "unit": unit,
             },
             auth=True,
+            extra_params=extra_params,
         )
 
     def initiate_subaccount_transfer(
@@ -159,6 +168,8 @@ class Funding(KrakenBaseFuturesAPI):
         toAccount: str,
         toUser: str,
         unit: str,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Submit a request to transfer funds between the regular and subaccount.
@@ -206,6 +217,7 @@ class Funding(KrakenBaseFuturesAPI):
                 "unit": unit,
             },
             auth=True,
+            extra_params=extra_params,
         )
 
     def initiate_withdrawal_to_spot_wallet(
@@ -213,7 +225,8 @@ class Funding(KrakenBaseFuturesAPI):
         amount: Union[str, float],
         currency: str,
         sourceWallet: Optional[str] = None,
-        **kwargs: dict,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Enables the transfer of funds between the futures and spot wallet.
@@ -251,12 +264,13 @@ class Funding(KrakenBaseFuturesAPI):
         }
         if sourceWallet is not None:
             params["sourceWallet"] = sourceWallet
-        params.update(kwargs)
+
         return self._request(  # type: ignore[return-value]
             method="POST",
             uri="/derivatives/api/v3/withdrawal",
             post_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
 

--- a/kraken/futures/market.py
+++ b/kraken/futures/market.py
@@ -161,7 +161,10 @@ class Market(KrakenBaseFuturesAPI):
             ['mark', 'spot', 'trade']
         """
         return self._request(  # type: ignore[return-value]
-            method="GET", uri="/api/charts/v1/", auth=False, extra_params=extra_params,
+            method="GET",
+            uri="/api/charts/v1/",
+            auth=False,
+            extra_params=extra_params,
         )
 
     @ensure_string("extra_params")

--- a/kraken/futures/market.py
+++ b/kraken/futures/market.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import List, Optional, TypeVar, Union
 
-from kraken.base_api import KrakenBaseFuturesAPI, defined
+from kraken.base_api import KrakenBaseFuturesAPI, defined, ensure_string
 
 Self = TypeVar("Self")
 
@@ -69,6 +69,8 @@ class Market(KrakenBaseFuturesAPI):
         resolution: int,
         from_: Optional[int] = None,
         to: Optional[int] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Retrieve the open, high, low, and close data for a specific symbol and resolution.
@@ -129,10 +131,16 @@ class Market(KrakenBaseFuturesAPI):
             uri=f"/api/charts/v1/{tick_type}/{symbol}/{resolution}",
             query_params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
+    @ensure_string("extra_params")
     @lru_cache()
-    def get_tick_types(self: Market) -> List[str]:
+    def get_tick_types(
+        self: Market,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> List[str]:
         """
         Retrieve the available tick types that can be used for example to access
         the :func:`kraken.futures.Market.get_ohlc` endpoint.
@@ -152,10 +160,18 @@ class Market(KrakenBaseFuturesAPI):
             >>> Market().get_tick_types()
             ['mark', 'spot', 'trade']
         """
-        return self._request(method="GET", uri="/api/charts/v1/", auth=False)  # type: ignore[return-value]
+        return self._request(  # type: ignore[return-value]
+            method="GET", uri="/api/charts/v1/", auth=False, extra_params=extra_params,
+        )
 
+    @ensure_string("extra_params")
     @lru_cache()
-    def get_tradeable_products(self: Market, tick_type: str) -> List[str]:
+    def get_tradeable_products(
+        self: Market,
+        tick_type: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> List[str]:
         """
         Retrieve a list containing the tradeable assets on the futures market.
 
@@ -180,10 +196,18 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri=f"/api/charts/v1/{tick_type}",
             auth=False,
+            extra_params=extra_params,
         )
 
+    @ensure_string("extra_params")
     @lru_cache()
-    def get_resolutions(self: Market, tick_type: str, tradeable: str) -> List[str]:
+    def get_resolutions(
+        self: Market,
+        tick_type: str,
+        tradeable: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> List[str]:
         """
         Retrieve the list of available resolutions for a specific asset.
 
@@ -210,10 +234,16 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri=f"/api/charts/v1/{tick_type}/{tradeable}",
             auth=False,
+            extra_params=extra_params,
         )
 
+    @ensure_string("extra_params")
     @lru_cache()
-    def get_fee_schedules(self: Market) -> dict:
+    def get_fee_schedules(
+        self: Market,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve information about the current fees
 
@@ -253,9 +283,14 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/feeschedules",
             auth=False,
+            extra_params=extra_params,
         )
 
-    def get_fee_schedules_vol(self: Market) -> dict:
+    def get_fee_schedules_vol(
+        self: Market,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Get the personal volumes per fee schedule
 
@@ -283,9 +318,15 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/feeschedules/volumes",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_orderbook(self: Market, symbol: Optional[str] = None) -> dict:
+    def get_orderbook(
+        self: Market,
+        symbol: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Get the orderbook of a specific asset/symbol. Even if the official kraken documentation
         states that the parameter ``symbol`` is not required, they will always respond with an error
@@ -334,9 +375,14 @@ class Market(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/orderbook",
             query_params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
-    def get_tickers(self: Market) -> dict:
+    def get_tickers(
+        self: Market,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve information about the current tickers of all futures contracts.
 
@@ -382,9 +428,14 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/tickers",
             auth=False,
+            extra_params=extra_params,
         )
 
-    def get_instruments(self: Market) -> dict:
+    def get_instruments(
+        self: Market,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve more specific information about the tradeable assets on the Futures market
 
@@ -466,9 +517,15 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/instruments",
             auth=False,
+            extra_params=extra_params,
         )
 
-    def get_instruments_status(self: Market, instrument: Optional[str] = None) -> dict:
+    def get_instruments_status(
+        self: Market,
+        instrument: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve status information of a specific or all futures contracts.
 
@@ -506,13 +563,15 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/instruments/status",
             auth=False,
+            extra_params=extra_params,
         )
 
     def get_trade_history(
         self: Market,
         symbol: Optional[str] = None,
         lastTime: Optional[str] = None,
-        **kwargs: dict,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Retrieve the trade history (max 100 entries), can be filtered using the parameters.
@@ -557,15 +616,21 @@ class Market(KrakenBaseFuturesAPI):
             params["symbol"] = symbol
         if defined(lastTime):
             params["lastTime"] = lastTime
-        params.update(kwargs)
+
         return self._request(  # type: ignore[return-value]
             method="GET",
             uri="/derivatives/api/v3/history",
             query_params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
-    def get_historical_funding_rates(self: Market, symbol: str) -> dict:
+    def get_historical_funding_rates(
+        self: Market,
+        symbol: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve information about the historical funding rates for a specific asset.
 
@@ -604,9 +669,14 @@ class Market(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v4/historicalfundingrates",
             query_params={"symbol": symbol},
             auth=False,
+            extra_params=extra_params,
         )
 
-    def get_leverage_preference(self: Market) -> dict:
+    def get_leverage_preference(
+        self: Market,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Get the current leverage preferences of the user.
 
@@ -635,12 +705,15 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/leveragepreferences",
             auth=True,
+            extra_params=extra_params,
         )
 
     def set_leverage_preference(
         self: Market,
         symbol: str,
         maxLeverage: Optional[Union[str, int, float]] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Set a new leverage preference for a specific futures contract.
@@ -674,9 +747,14 @@ class Market(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/leveragepreferences",
             post_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_pnl_preference(self: Market) -> dict:
+    def get_pnl_preference(
+        self: Market,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Get the current PNL (profit & loss) preferences. This can be used to define the currency
         in which the profits and losses are realized.
@@ -701,9 +779,16 @@ class Market(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/pnlpreferences",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def set_pnl_preference(self: Market, symbol: str, pnlPreference: str) -> dict:
+    def set_pnl_preference(
+        self: Market,
+        symbol: str,
+        pnlPreference: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Modify or set the current PNL preference of the user. This can be used to define a
         specific currency that should be used to realize profits and losses. The default is
@@ -734,6 +819,7 @@ class Market(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/pnlpreferences",
             post_params={"symbol": symbol, "pnlPreference": pnlPreference},
             auth=True,
+            extra_params=extra_params,
         )
 
     def _get_historical_events(
@@ -744,7 +830,8 @@ class Market(KrakenBaseFuturesAPI):
         since: Optional[int] = None,
         sort: Optional[str] = None,
         tradeable: Optional[str] = None,
-        **kwargs: dict,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Method that uses as a gateway for the methods :func:`kraken.futures.Market.get_public_execution_events`,
@@ -777,12 +864,13 @@ class Market(KrakenBaseFuturesAPI):
             params["sort"] = sort
         if defined(tradeable):
             params["tradeable"] = tradeable
-        params.update(kwargs)
+
         return self._request(  # type: ignore[return-value]
             method="GET",
             uri=endpoint,
             post_params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
     def get_public_execution_events(
@@ -792,6 +880,8 @@ class Market(KrakenBaseFuturesAPI):
         continuation_token: Optional[str] = None,
         since: Optional[int] = None,
         sort: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Retrieve information about the public execution events. The returned ``continuation_token``
@@ -873,6 +963,7 @@ class Market(KrakenBaseFuturesAPI):
             continuation_token=continuation_token,
             since=since,
             sort=sort,
+            extra_params=extra_params,
         )
 
     def get_public_order_events(
@@ -882,6 +973,8 @@ class Market(KrakenBaseFuturesAPI):
         continuation_token: Optional[str] = None,
         since: Optional[int] = None,
         sort: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Retrieve information about the public order events - filled, closed, opened, etc, for
@@ -944,6 +1037,7 @@ class Market(KrakenBaseFuturesAPI):
             continuation_token=continuation_token,
             since=since,
             sort=sort,
+            extra_params=extra_params,
         )
 
     def get_public_mark_price_events(
@@ -953,6 +1047,8 @@ class Market(KrakenBaseFuturesAPI):
         continuation_token: Optional[str] = None,
         since: Optional[int] = None,
         sort: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Retrieve information about public mark price events. The returned ``continuation_token``
@@ -1011,6 +1107,7 @@ class Market(KrakenBaseFuturesAPI):
             continuation_token=continuation_token,
             since=since,
             sort=sort,
+            extra_params=extra_params,
         )
 
 

--- a/kraken/futures/trade.py
+++ b/kraken/futures/trade.py
@@ -61,7 +61,12 @@ class Trade(KrakenBaseFuturesAPI):
         super().__enter__()
         return self
 
-    def get_fills(self: Trade, lastFillTime: Optional[str] = None) -> dict:
+    def get_fills(
+        self: Trade,
+        lastFillTime: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Return the current fills of the user.
 
@@ -104,9 +109,15 @@ class Trade(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/fills",
             query_params=query_params,
             auth=True,
+            extra_params=extra_params,
         )
 
-    def create_batch_order(self: Trade, batchorder_list: List[dict]) -> dict:
+    def create_batch_order(
+        self: Trade,
+        batchorder_list: List[dict],
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Create multiple orders at once using the batch order endpoint.
 
@@ -211,9 +222,15 @@ class Trade(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/batchorder",
             post_params={"json": f"{batchorder}"},
             auth=True,
+            extra_params=extra_params,
         )
 
-    def cancel_all_orders(self: Trade, symbol: Optional[str] = None) -> dict:
+    def cancel_all_orders(
+        self: Trade,
+        symbol: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Cancels all open orders, can be filtered by symbol.
 
@@ -259,9 +276,15 @@ class Trade(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/cancelallorders",
             post_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
-    def dead_mans_switch(self: Trade, timeout: Optional[int] = 0) -> dict:
+    def dead_mans_switch(
+        self: Trade,
+        timeout: Optional[int] = 0,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         The Death Man's Switch can be used to cancel all orders after a specific timeout.
         If the timeout is set to 60, all orders will be cancelled after 60 seconds. The timeout
@@ -297,12 +320,15 @@ class Trade(KrakenBaseFuturesAPI):
             method="POST",
             uri="/derivatives/api/v3/cancelallordersafter",
             post_params={"timeout": timeout},
+            extra_params=extra_params,
         )
 
     def cancel_order(
         self: Trade,
         order_id: Optional[str] = None,
         cliOrdId: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         This endpoint can be used to cancel a specific order by ``order_id`` or ``cliOrdId``.
@@ -349,6 +375,7 @@ class Trade(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/cancelorder",
             post_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
     def edit_order(
@@ -358,6 +385,8 @@ class Trade(KrakenBaseFuturesAPI):
         limitPrice: Optional[Union[str, int, float]] = None,
         size: Optional[Union[str, int, float]] = None,
         stopPrice: Optional[Union[str, int, float]] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Edit an open order.
@@ -419,12 +448,15 @@ class Trade(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/editorder",
             post_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
     def get_orders_status(
         self: Trade,
         orderIds: Optional[Union[str, List[str]]] = None,
         cliOrdIds: Optional[Union[str, List[str]]] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get the status of multiple orders.
@@ -464,6 +496,7 @@ class Trade(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/orders/status",
             post_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
     def create_order(  # noqa: PLR0913
@@ -479,6 +512,8 @@ class Trade(KrakenBaseFuturesAPI):
         triggerSignal: Optional[str] = None,
         trailingStopDeviationUnit: Optional[str] = None,
         trailingStopMaxDeviation: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Create and place an order on the futures market.
@@ -676,6 +711,7 @@ class Trade(KrakenBaseFuturesAPI):
             uri="/derivatives/api/v3/sendorder",
             post_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
 

--- a/kraken/futures/user.py
+++ b/kraken/futures/user.py
@@ -64,7 +64,11 @@ class User(KrakenBaseFuturesAPI):
         super().__enter__()
         return self
 
-    def get_wallets(self: User) -> dict:
+    def get_wallets(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Lists the current wallet balances of the user.
 
@@ -150,9 +154,14 @@ class User(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/accounts",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_subaccounts(self: User) -> dict:
+    def get_subaccounts(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         List the subaccounts of the user.
 
@@ -181,9 +190,14 @@ class User(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/subaccounts",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_unwind_queue(self: User) -> dict:
+    def get_unwind_queue(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve information about the percentile of the open position in case of unwinding.
 
@@ -213,9 +227,14 @@ class User(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/unwindqueue",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_notifications(self: User) -> dict:
+    def get_notifications(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve the latest notifications from the Kraken Futures API
 
@@ -247,9 +266,10 @@ class User(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/notifications",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_account_log(
+    def get_account_log(  # noqa: PLR0913
         self: User,
         before: Optional[Union[str, int]] = None,
         count: Optional[Union[str, int]] = None,
@@ -258,6 +278,8 @@ class User(KrakenBaseFuturesAPI):
         since: Optional[Union[str, int]] = None,
         sort: Optional[str] = None,
         to: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get the historical events of the user's account. This is not available in the
@@ -335,14 +357,20 @@ class User(KrakenBaseFuturesAPI):
             params["sort"] = sort
         if defined(to):
             params["to"] = to
+
         return self._request(  # type: ignore[return-value]
             method="GET",
             uri="/api/history/v2/account-log",
             query_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_account_log_csv(self: User) -> requests.Response:
+    def get_account_log_csv(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> requests.Response:
         """
         Return the account log as csv, for example to export it. This is not available in the
         Kraken demo/sandbox environment.
@@ -369,6 +397,7 @@ class User(KrakenBaseFuturesAPI):
             uri="/api/history/v2/accountlogcsv",
             auth=True,
             return_raw=True,
+            extra_params=extra_params,
         )
 
     def _get_historical_events(
@@ -379,7 +408,8 @@ class User(KrakenBaseFuturesAPI):
         since: Optional[int] = None,
         sort: Optional[str] = None,
         tradeable: Optional[str] = None,
-        **kwargs: dict,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Method that uses as a gateway for the methods :func:`kraken.futures.User.get_execution_events`,
@@ -412,12 +442,13 @@ class User(KrakenBaseFuturesAPI):
             params["sort"] = sort
         if defined(tradeable):
             params["tradeable"] = tradeable
-        params.update(kwargs)
+
         return self._request(  # type: ignore[return-value]
             method="GET",
             uri=endpoint,
             query_params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
     def get_execution_events(
@@ -427,6 +458,8 @@ class User(KrakenBaseFuturesAPI):
         since: Optional[int] = None,
         sort: Optional[str] = None,
         tradeable: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Retrieve the order/position execution events of this user. The returned ``continuation_token``
@@ -540,6 +573,7 @@ class User(KrakenBaseFuturesAPI):
             since=since,
             sort=sort,
             tradeable=tradeable,
+            extra_params=extra_params,
         )
 
     def get_order_events(
@@ -549,6 +583,8 @@ class User(KrakenBaseFuturesAPI):
         since: Optional[int] = None,
         sort: Optional[str] = None,
         tradeable: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Retriev information about the user-specific order events including opened, closed, filled, etc.
@@ -616,6 +652,7 @@ class User(KrakenBaseFuturesAPI):
             since=since,
             sort=sort,
             tradeable=tradeable,
+            extra_params=extra_params,
         )
 
     def get_trigger_events(
@@ -625,6 +662,8 @@ class User(KrakenBaseFuturesAPI):
         since: Optional[int] = None,
         sort: Optional[str] = None,
         tradeable: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Retrieve information about trigger events.
@@ -701,9 +740,14 @@ class User(KrakenBaseFuturesAPI):
             since=since,
             sort=sort,
             tradeable=tradeable,
+            extra_params=extra_params,
         )
 
-    def get_open_positions(self: User) -> dict:
+    def get_open_positions(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         List the open positions of the user.
 
@@ -740,9 +784,14 @@ class User(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/openpositions",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_open_orders(self: User) -> dict:
+    def get_open_orders(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve the open orders.
 
@@ -824,9 +873,15 @@ class User(KrakenBaseFuturesAPI):
             method="GET",
             uri="/derivatives/api/v3/openorders",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def check_trading_enabled_on_subaccount(self: User, subaccountUid: str) -> dict:
+    def check_trading_enabled_on_subaccount(
+        self: User,
+        subaccountUid: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Checks if trading is enabled or disabled on the specified subaccount.
 
@@ -857,12 +912,15 @@ class User(KrakenBaseFuturesAPI):
             method="GET",
             uri=f"/derivatives/api/v3/subaccount/{subaccountUid}/trading-enabled",
             auth=True,
+            extra_params=extra_params,
         )
 
     def set_trading_on_subaccount(
         self: User,
         subaccountUid: str,
         trading_enabled: bool,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Enable or disable trading on a subaccount.
@@ -896,6 +954,7 @@ class User(KrakenBaseFuturesAPI):
             uri=f"/derivatives/api/v3/subaccount/{subaccountUid}/trading-enabled",
             post_params={"tradingEnabled": trading_enabled},
             auth=True,
+            extra_params=extra_params,
         )
 
 

--- a/kraken/spot/funding.py
+++ b/kraken/spot/funding.py
@@ -58,7 +58,9 @@ class Funding(KrakenBaseSpotAPI):
         super().__enter__()
         return self
 
-    def get_deposit_methods(self: Funding, asset: str) -> List[dict]:
+    def get_deposit_methods(
+        self: Funding, asset: str, *, extra_params: Optional[dict] = None,
+    ) -> List[dict]:
         """
         Get the available deposit methods for a specific asset.
 
@@ -92,6 +94,7 @@ class Funding(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/DepositMethods",
             params={"asset": asset},  # type: ignore[return-value]
+            extra_params=extra_params,
         )
 
     def get_deposit_address(
@@ -99,6 +102,8 @@ class Funding(KrakenBaseSpotAPI):
         asset: str,
         method: str,
         new: Optional[bool] = False,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> List[dict]:
         """
         Get the deposit addresses for a specific asset. New deposit addresses can be generated.
@@ -114,7 +119,7 @@ class Funding(KrakenBaseSpotAPI):
         :param new: Generate a new deposit address (default: ``False``)
         :type new: bool, optional
         :return: The user and asset specific deposit addresses
-        :rtype: List[dict]
+        :rtype: list[dict]
 
         .. code-block:: python
             :linenos:
@@ -141,12 +146,15 @@ class Funding(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/DepositAddresses",
             params={"asset": asset, "method": method, "new": new},
+            extra_params=extra_params,
         )
 
     def get_recent_deposits_status(
         self: Funding,
         asset: Optional[str] = None,
         method: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> List[dict]:
         """
         Get information about the recent deposit status. The look back period is 90 days and
@@ -216,6 +224,7 @@ class Funding(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/DepositStatus",
             params=params,
+            extra_params=extra_params,
         )
 
     def get_withdrawal_info(
@@ -223,6 +232,8 @@ class Funding(KrakenBaseSpotAPI):
         asset: str,
         key: str,
         amount: Union[str, float],
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about a possible withdraw, including fee and limit information.
@@ -264,6 +275,7 @@ class Funding(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/WithdrawInfo",
             params={"asset": asset, "key": str(key), "amount": str(amount)},
+            extra_params=extra_params,
         )
 
     def withdraw_funds(
@@ -271,6 +283,8 @@ class Funding(KrakenBaseSpotAPI):
         asset: str,
         key: str,
         amount: Union[str, float],
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Create a new withdraw. The key must be the name of the withdraw key
@@ -306,12 +320,15 @@ class Funding(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/Withdraw",
             params={"asset": asset, "key": str(key), "amount": str(amount)},
+            extra_params=extra_params,
         )
 
     def get_recent_withdraw_status(
         self: Funding,
         asset: Optional[str] = None,
         method: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> List[dict]:
         """
         Get information about the recent withdraw status, including withdraws of the
@@ -357,9 +374,12 @@ class Funding(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/WithdrawStatus",
             params=params,
+            extra_params=extra_params,
         )
 
-    def cancel_withdraw(self: Funding, asset: str, refid: str) -> dict:
+    def cancel_withdraw(
+        self: Funding, asset: str, refid: str, *, extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Cancel a requested withdraw. This will only be successful if the withdraw
         is not being processed so far.
@@ -388,6 +408,7 @@ class Funding(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/WithdrawCancel",
             params={"asset": asset, "refid": str(refid)},
+            extra_params=extra_params,
         )
 
     def wallet_transfer(
@@ -396,6 +417,8 @@ class Funding(KrakenBaseSpotAPI):
         from_: str,
         to_: str,
         amount: Union[str, float],
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Transfer assets between the Spot and Futures wallet.
@@ -433,6 +456,7 @@ class Funding(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/WalletTransfer",
             params={"asset": asset, "from": from_, "to": to_, "amount": str(amount)},
+            extra_params=extra_params,
         )
 
 

--- a/kraken/spot/funding.py
+++ b/kraken/spot/funding.py
@@ -59,7 +59,10 @@ class Funding(KrakenBaseSpotAPI):
         return self
 
     def get_deposit_methods(
-        self: Funding, asset: str, *, extra_params: Optional[dict] = None,
+        self: Funding,
+        asset: str,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> List[dict]:
         """
         Get the available deposit methods for a specific asset.
@@ -378,7 +381,11 @@ class Funding(KrakenBaseSpotAPI):
         )
 
     def cancel_withdraw(
-        self: Funding, asset: str, refid: str, *, extra_params: Optional[dict] = None,
+        self: Funding,
+        asset: str,
+        refid: str,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Cancel a requested withdraw. This will only be successful if the withdraw

--- a/kraken/spot/market.py
+++ b/kraken/spot/market.py
@@ -60,11 +60,14 @@ class Market(KrakenBaseSpotAPI):
         return self
 
     @ensure_string("assets")
+    @ensure_string("extra_params")
     @lru_cache()
     def get_assets(
         self: Market,
         assets: Optional[Union[str, List[str]]] = None,
         aclass: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about one or more assets.
@@ -127,14 +130,18 @@ class Market(KrakenBaseSpotAPI):
             uri="/public/Assets",
             params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
     @ensure_string("pair")
+    @ensure_string("extra_params")
     @lru_cache()
     def get_asset_pairs(
         self: Market,
         pair: Optional[Union[str, List[str]]] = None,
         info: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about a single or multiple asset/currency pair(s).
@@ -205,10 +212,16 @@ class Market(KrakenBaseSpotAPI):
             uri="/public/AssetPairs",
             params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
     @ensure_string("pair")
-    def get_ticker(self: Market, pair: Optional[Union[str, List[str]]] = None) -> dict:
+    def get_ticker(
+        self: Market,
+        pair: Optional[Union[str, List[str]]] = None,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Returns all tickers if pair is not specified - else just
         the ticker of the ``pair``. Multiple pairs can be specified.
@@ -248,6 +261,7 @@ class Market(KrakenBaseSpotAPI):
             uri="/public/Ticker",
             params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
     def get_ohlc(
@@ -255,6 +269,8 @@ class Market(KrakenBaseSpotAPI):
         pair: str,
         interval: Union[int, str] = 1,
         since: Optional[Union[int, str]] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get the open, high, low, and close data for a specific trading pair.
@@ -300,9 +316,16 @@ class Market(KrakenBaseSpotAPI):
             uri="/public/OHLC",
             params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
-    def get_order_book(self: Market, pair: str, count: Optional[int] = 100) -> dict:
+    def get_order_book(
+        self: Market,
+        pair: str,
+        count: Optional[int] = 100,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Get the current orderbook of a specified trading pair.
 
@@ -340,6 +363,7 @@ class Market(KrakenBaseSpotAPI):
             uri="/public/Depth",
             params={"pair": pair, "count": count},
             auth=False,
+            extra_params=extra_params,
         )
 
     def get_recent_trades(
@@ -347,6 +371,8 @@ class Market(KrakenBaseSpotAPI):
         pair: str,
         since: Optional[Union[str, int]] = None,
         count: Optional[int] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get the latest trades for a specific trading pair (up to 1000).
@@ -388,12 +414,15 @@ class Market(KrakenBaseSpotAPI):
             uri="/public/Trades",
             params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
     def get_recent_spreads(
         self: Market,
         pair: str,
         since: Optional[Union[str, int]] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get the latest spreads for a specific trading pair.
@@ -430,9 +459,14 @@ class Market(KrakenBaseSpotAPI):
             uri="/public/Spread",
             params=params,
             auth=False,
+            extra_params=extra_params,
         )
 
-    def get_system_status(self: Market) -> dict:
+    def get_system_status(
+        self: Market,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Returns the system status of the Kraken Spot API.
 
@@ -453,6 +487,7 @@ class Market(KrakenBaseSpotAPI):
             method="GET",
             uri="/public/SystemStatus",
             auth=False,
+            extra_params=extra_params,
         )
 
 

--- a/kraken/spot/staking.py
+++ b/kraken/spot/staking.py
@@ -63,6 +63,8 @@ class Staking(KrakenBaseSpotAPI):
         asset: str,
         amount: Union[str, float],
         method: str,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Stake the specified asset from the Spot wallet.
@@ -101,6 +103,7 @@ class Staking(KrakenBaseSpotAPI):
             uri="/private/Stake",
             params={"asset": asset, "amount": amount, "method": method},
             auth=True,
+            extra_params=extra_params,
         )
 
     def unstake_asset(
@@ -108,6 +111,8 @@ class Staking(KrakenBaseSpotAPI):
         asset: str,
         amount: Union[str, float],
         method: Optional[str] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Unstake an asset and transfer the amount to the Spot wallet.
@@ -150,9 +155,14 @@ class Staking(KrakenBaseSpotAPI):
             uri="/private/Unstake",
             params=params,
             auth=True,
+            extra_params=extra_params,
         )
 
-    def list_stakeable_assets(self: Staking) -> List[dict]:
+    def list_stakeable_assets(
+        self: Staking,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> List[dict]:
         """
         Get a list of stakeable assets. Only assets that the user is able to stake
         will be shown.
@@ -209,9 +219,14 @@ class Staking(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/Staking/Assets",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def get_pending_staking_transactions(self: Staking) -> List[dict]:
+    def get_pending_staking_transactions(
+        self: Staking,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> List[dict]:
         """
         Get the list of pending staking transactions of the user.
 
@@ -247,9 +262,14 @@ class Staking(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/Staking/Pending",
             auth=True,
+            extra_params=extra_params,
         )
 
-    def list_staking_transactions(self: Staking) -> List[dict]:
+    def list_staking_transactions(
+        self: Staking,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> List[dict]:
         """
         List the last 1000 staking transactions of the past 90 days.
 
@@ -288,6 +308,7 @@ class Staking(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/Staking/Transactions",
             auth=True,
+            extra_params=extra_params,
         )
 
 

--- a/kraken/spot/trade.py
+++ b/kraken/spot/trade.py
@@ -88,6 +88,8 @@ class Trade(KrakenBaseSpotAPI):
         deadline: Optional[str] = None,
         validate: bool = False,
         userref: Optional[int] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Create a new order and place it on the market.
@@ -360,6 +362,7 @@ class Trade(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/AddOrder",
             params=params,
+            extra_params=extra_params,
         )
 
     def create_order_batch(
@@ -368,6 +371,8 @@ class Trade(KrakenBaseSpotAPI):
         pair: str,
         deadline: Optional[str] = None,
         validate: bool = False,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Create a batch of max 15 orders for a specific asset pair.
@@ -438,6 +443,7 @@ class Trade(KrakenBaseSpotAPI):
             uri="/private/AddOrderBatch",
             params=params,
             do_json=True,
+            extra_params=extra_params,
         )
 
     @ensure_string("oflags")
@@ -454,6 +460,8 @@ class Trade(KrakenBaseSpotAPI):
         cancel_response: Optional[bool] = None,
         validate: bool = False,
         userref: Optional[int] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Edit an open order.
@@ -541,10 +549,16 @@ class Trade(KrakenBaseSpotAPI):
             "POST",
             uri="/private/EditOrder",
             params=params,
+            extra_params=extra_params,
         )
 
     @ensure_string("txid")
-    def cancel_order(self: Trade, txid: str) -> dict:
+    def cancel_order(
+        self: Trade,
+        txid: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Cancel a specific order by ``txid``. Instead of a transaction id
         a user reference id can be passed.
@@ -572,9 +586,14 @@ class Trade(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/CancelOrder",
             params={"txid": txid},
+            extra_params=extra_params,
         )
 
-    def cancel_all_orders(self: Trade) -> dict:
+    def cancel_all_orders(
+        self: Trade,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Cancel all open orders.
 
@@ -598,9 +617,15 @@ class Trade(KrakenBaseSpotAPI):
         return self._request(  # type: ignore[return-value]
             method="POST",
             uri="/private/CancelAll",
+            extra_params=extra_params,
         )
 
-    def cancel_all_orders_after_x(self: Trade, timeout: int = 0) -> dict:
+    def cancel_all_orders_after_x(
+        self: Trade,
+        timeout: int = 0,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Cancel all orders after a timeout. This can be used as Dead Man's Switch.
 
@@ -630,9 +655,15 @@ class Trade(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/CancelAllOrdersAfter",
             params={"timeout": timeout},
+            extra_params=extra_params,
         )
 
-    def cancel_order_batch(self: Trade, orders: List[Union[str, int]]) -> dict:
+    def cancel_order_batch(
+        self: Trade,
+        orders: List[Union[str, int]],
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Cancel a a list of orders by ``txid`` or ``userref``
 
@@ -662,6 +693,7 @@ class Trade(KrakenBaseSpotAPI):
             uri="/private/CancelOrderBatch",
             params={"orders": orders},
             do_json=True,
+            extra_params=extra_params,
         )
 
     @lru_cache()

--- a/kraken/spot/user.py
+++ b/kraken/spot/user.py
@@ -60,7 +60,11 @@ class User(KrakenBaseSpotAPI):
         super().__enter__()
         return self
 
-    def get_account_balance(self: User) -> dict:
+    def get_account_balance(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Get the current balances of the user.
 
@@ -89,9 +93,14 @@ class User(KrakenBaseSpotAPI):
         return self._request(  # type: ignore[return-value]
             method="POST",
             uri="/private/Balance",
+            extra_params=extra_params,
         )
 
-    def get_balances(self: User) -> dict:
+    def get_balances(
+        self: User,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve the user's asset balances and the
         the corresponding amount held by open orders.
@@ -131,6 +140,7 @@ class User(KrakenBaseSpotAPI):
         return self._request(  # type: ignore[return-value]
             method="POST",
             uri="/private/BalanceEx",
+            extra_params=extra_params,
         )
 
     def get_balance(self: User, currency: str) -> dict:
@@ -176,7 +186,12 @@ class User(KrakenBaseSpotAPI):
             "available_balance": float(available_balance),
         }
 
-    def get_trade_balance(self: User, asset: Optional[str] = "ZUSD") -> dict:
+    def get_trade_balance(
+        self: User,
+        asset: Optional[str] = "ZUSD",
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Get the summary of all collateral balances.
 
@@ -214,12 +229,15 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/TradeBalance",
             params=params,
+            extra_params=extra_params,
         )
 
     def get_open_orders(
         self: User,
         trades: Optional[bool] = False,
         userref: Optional[int] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about the open orders.
@@ -285,6 +303,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/OpenOrders",
             params=params,
+            extra_params=extra_params,
         )
 
     def get_closed_orders(
@@ -295,6 +314,8 @@ class User(KrakenBaseSpotAPI):
         end: Optional[int] = None,
         ofs: Optional[int] = None,
         closetime: Optional[str] = "both",
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get the 50 latest closed (filled or canceled) orders.
@@ -377,6 +398,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/ClosedOrders",
             params=params,
+            extra_params=extra_params,
         )
 
     @ensure_string("txid")
@@ -386,6 +408,8 @@ class User(KrakenBaseSpotAPI):
         trades: Optional[bool] = False,
         userref: Optional[int] = None,
         consolidate_taker: Optional[bool] = True,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about one or more orders.
@@ -487,6 +511,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/QueryOrders",
             params=params,
+            extra_params=extra_params,
         )
 
     def get_trades_history(
@@ -497,6 +522,8 @@ class User(KrakenBaseSpotAPI):
         end: Optional[int] = None,
         ofs: Optional[int] = None,
         consolidate_taker: bool = True,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about the latest 50 trades and fills. Can be paginated.
@@ -564,6 +591,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/TradesHistory",
             params=params,
+            extra_params=extra_params,
         )
 
     @ensure_string("txid")
@@ -571,6 +599,8 @@ class User(KrakenBaseSpotAPI):
         self: User,
         txid: Union[str, List[str]],
         trades: Optional[bool] = False,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about specific trades/filled orders. 20 txids can be queried maximum.
@@ -618,6 +648,7 @@ class User(KrakenBaseSpotAPI):
                 "trades": trades,
                 "txid": txid,
             },
+            extra_params=extra_params,
         )
 
     @ensure_string("txid")
@@ -626,6 +657,8 @@ class User(KrakenBaseSpotAPI):
         txid: Optional[Union[str, List[str]]] = None,
         docalcs: Optional[bool] = False,
         consolidation: Optional[str] = "market",
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about the open margin positions.
@@ -679,6 +712,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/OpenPositions",
             params=params,
+            extra_params=extra_params,
         )
 
     @ensure_string("asset")
@@ -690,6 +724,8 @@ class User(KrakenBaseSpotAPI):
         start: Optional[int] = None,
         end: Optional[int] = None,
         ofs: Optional[int] = None,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about the users ledger entries. 50 results can be returned at a time.
@@ -751,6 +787,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/Ledgers",
             params=params,
+            extra_params=extra_params,
         )
 
     @ensure_string("id_")
@@ -758,6 +795,8 @@ class User(KrakenBaseSpotAPI):
         self: User,
         id_: Union[str, List[str]],
         trades: Optional[bool] = False,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get information about specific ledeger entries.
@@ -799,6 +838,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/QueryLedgers",
             params={"trades": trades, "id": id_},
+            extra_params=extra_params,
         )
 
     @ensure_string("pair")
@@ -806,6 +846,8 @@ class User(KrakenBaseSpotAPI):
         self: User,
         pair: Optional[Union[str, List[str]]] = None,
         fee_info: bool = True,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Get the 30-day user specific trading volume in USD.
@@ -867,6 +909,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/TradeVolume",
             params=params,
+            extra_params=extra_params,
         )
 
     @ensure_string("fields")
@@ -878,7 +921,8 @@ class User(KrakenBaseSpotAPI):
         fields: Optional[Union[str, List[str]]] = "all",
         starttm: Optional[int] = None,
         endtm: Optional[int] = None,
-        **kwargs: dict,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Request to export the trades or ledgers of the user.
@@ -924,7 +968,6 @@ class User(KrakenBaseSpotAPI):
             "format": format_,
             "fields": fields,
         }
-        params.update(kwargs)
         if defined(starttm):
             params["starttm"] = starttm
         if defined(endtm):
@@ -933,9 +976,15 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/AddExport",
             params=params,
+            extra_params=extra_params,
         )
 
-    def get_export_report_status(self: User, report: str) -> dict:
+    def get_export_report_status(
+        self: User,
+        report: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Get the status of the current pending report.
 
@@ -990,9 +1039,15 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/ExportStatus",
             params={"report": report},
+            extra_params=extra_params,
         )
 
-    def retrieve_export(self: User, id_: str) -> dict:
+    def retrieve_export(
+        self: User,
+        id_: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Retrieve the requested report export.
 
@@ -1030,12 +1085,15 @@ class User(KrakenBaseSpotAPI):
             uri="/private/RetrieveExport",
             params={"id": id_},
             return_raw=True,
+            extra_params=extra_params,
         )
 
     def delete_export_report(
         self: User,
         id_: str,
         type_: Optional[str] = "delete",
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Delete a report from the Kraken server.
@@ -1067,9 +1125,16 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/RemoveExport",
             params={"id": id_, "type": type_},
+            extra_params=extra_params,
         )
 
-    def create_subaccount(self: User, username: str, email: str) -> dict:
+    def create_subaccount(
+        self: User,
+        username: str,
+        email: str,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
         """
         Create a subaccount for trading. This is currently *only available
         for institutional clients*.
@@ -1096,6 +1161,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/CreateSubaccount",
             params={"username": username, "email": email},
+            extra_params=extra_params,
         )
 
     def account_transfer(
@@ -1104,6 +1170,8 @@ class User(KrakenBaseSpotAPI):
         amount: Union[str, float],
         from_: str,
         to_: str,
+        *,
+        extra_params: Optional[dict] = None,
     ) -> dict:
         """
         Transfer funds between master and subaccounts. This is currently *only
@@ -1146,6 +1214,7 @@ class User(KrakenBaseSpotAPI):
             method="POST",
             uri="/private/AccountTransfer",
             params={"asset": asset, "amount": amount, "from": from_, "to": to_},
+            extra_params=extra_params,
         )
 
 

--- a/tests/spot/test_spot_market.py
+++ b/tests/spot/test_spot_market.py
@@ -129,3 +129,16 @@ def test_get_recent_spreads(spot_market: Market) -> None:
     assert is_not_error(
         spot_market.get_recent_spreads(pair="XBTUSD", since="1616663618"),
     )
+
+
+@pytest.mark.spot()
+@pytest.mark.spot_market()
+def test_extra_parameter(spot_market: Market) -> None:
+    """
+    Checks if the extra parameter can be used to overwrite an existing one.
+    This also checks ensure_string for this parameter.
+    """
+
+    result: dict = spot_market.get_assets(assets="XBT", extra_params={"asset": "ETH"})
+    assert "XBT" not in result
+    assert "XETH" in result


### PR DESCRIPTION
# Summary

This MR adds the mentioned parameter to every function that may use these. It can be used to overwrite and extend passed values.

For example when passing the value "XBT" to the asset parameter of function "X". extra_parms can be used to overwrite this *after* all checks for XBT has been done, so passing "XBT,DOT,ETH" or so would also be possible to overwrite the value for that asset -- but keep in mind, these key value pairs must exactly match the ones of Krakens API docs and not the parameter names of the SDK. 

This parameter can also be used to extend queries in case the SDK is missing some parameters - this extending parameter solves this issue until the missing parameter was implemented. 