### PR TITLE
Resolve "Drop Support for Python < 3.11"

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -89,10 +89,10 @@ jobs:
     uses: ./.github/workflows/_build_doc.yaml
     with:
       os: "ubuntu-latest"
-      python-version: "3.11"
+      python-version: "3.12"
 
   ## ===========================================================================
-  ##          Run the Spot tests for Python 3.7 until 3.11
+  ##          Run the Spot tests for Python 3.12
   ##
   ##  (public endpoints)
   ##
@@ -103,7 +103,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -117,14 +117,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] # only ubuntu since this takes to much time ATM
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
   ## ===========================================================================
-  ##        Run the Futures tests for Python 3.7 until 3.11
+  ##        Run the Futures tests for Python 3.12
   ##
   ##  (public endpoints)
   Test-Futures-Public:
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -148,7 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/manual_build.yaml
+++ b/.github/workflows/manual_build.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/manual_test_futures.yaml
+++ b/.github/workflows/manual_test_futures.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/manual_test_spot.yaml
+++ b/.github/workflows/manual_test_spot.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -50,10 +50,10 @@ jobs:
     uses: ./.github/workflows/_build_doc.yaml
     with:
       os: "ubuntu-latest"
-      python-version: "3.11"
+      python-version: "3.12"
 
   ## ===========================================================================
-  ##          Run the Spot tests for Python 3.7 until 3.11
+  ##          Run the Spot tests for Python 3.12
   ##
   ##  (public endpoints)
   ##
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -78,14 +78,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
     secrets: inherit
 
   ## ===========================================================================
-  ##        Run the Futures tests for Python 3.7 until 3.11
+  ##        Run the Futures tests for Python 3.12
   ##
   ##  (public endpoints)
   Test-Futures-Public:
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -109,7 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![GitHub](https://badgen.net/badge/icon/github?icon=github&label)](https://github.com/btschwertfeger/python-kraken-sdk)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-orange.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Generic badge](https://img.shields.io/badge/python-3.7_|_3.8_|_3.9_|_3.10_|_3.11-blue.svg)](https://shields.io/)
+[![Generic badge](https://img.shields.io/badge/python-3.12-blue.svg)](https://shields.io/)
 [![Downloads](https://static.pepy.tech/personalized-badge/python-kraken-sdk?period=total&units=abbreviation&left_color=grey&right_color=orange&left_text=downloads)](https://pepy.tech/project/python-kraken-sdk)
 
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
@@ -55,6 +55,7 @@ General:
 - extensive example scripts (see `/examples` and `/tests`)
 - tested using the [pytest](https://docs.pytest.org/en/7.3.x/) framework
 - releases are permanently archived at [Zenodo](https://zenodo.org/badge/latestdoi/510751854)
+- releases before v2.0.0 also support Python 3.7+
 
 Documentation:
 

--- a/docs/src/introduction.rst
+++ b/docs/src/introduction.rst
@@ -65,6 +65,7 @@ General:
 - extensive examples
 - tested using the `pytest <https://docs.pytest.org/en/7.3.x/>`_ framework
 - releases are permanently archived at `Zenodo <https://zenodo.org/badge/latestdoi/510751854>`_
+- releases before v2.0.0 also support Python 3.7+
 
 
 Important Notice

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -14,7 +14,7 @@ import json
 import time
 import urllib.parse
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Optional, Type, TypeVar
 from urllib.parse import urljoin
 from uuid import uuid1
 
@@ -43,7 +43,7 @@ def ensure_string(parameter_name: str) -> Callable:
         @lru_cache()
         def get_assets(
             self: "Market",
-            assets: Optional[Union[str, List[str]]] = None,
+            assets: Optional[str | list[str]] = None,
             aclass: Optional[str] = None,
         ) -> dict:
             # If the function was called using
@@ -96,7 +96,7 @@ class KrakenErrorHandler:
         """
         return self.__kexceptions.get_exception(msg)
 
-    def check(self: KrakenErrorHandler, data: dict) -> Union[dict, Any]:
+    def check(self: KrakenErrorHandler, data: dict) -> dict | Any:
         """
         Check if the error message is a known KrakenError response and than
         raise a custom exception or return the data containing the "error".
@@ -151,7 +151,7 @@ class KrakenErrorHandler:
         :rtype: dict
         """
         if "batchStatus" in data:
-            batch_status: List[Dict[str, Any]] = data["batchStatus"]
+            batch_status: list[dict[str, Any]] = data["batchStatus"]
             for status in batch_status:
                 if "status" in status:
                     exception: Type[KrakenException] = self.__get_exception(
@@ -213,7 +213,7 @@ class KrakenBaseSpotAPI:
         params: Optional[dict] = None,
         do_json: bool = False,
         return_raw: bool = False,
-    ) -> Union[Dict[str, Any], List[str], List[Dict[str, Any]], requests.Response]:
+    ) -> dict[str, Any] | list[str] | list[dict[str, Any]] | requests.Response:
         """
         Handles the requested requests, by sending the request, handling the
         response, and returning the message or in case of an error the
@@ -351,7 +351,7 @@ class KrakenBaseSpotAPI:
         self: KrakenBaseSpotAPI,
         response: requests.Response,
         return_raw: bool = False,
-    ) -> Union[dict, list, requests.Response]:
+    ) -> dict | list | requests.Response:
         """
         Checks the response, handles the error (if exists) and returns the response data.
 
@@ -369,7 +369,7 @@ class KrakenBaseSpotAPI:
             if return_raw:
                 return response
             try:
-                data: Union[dict, list] = response.json()
+                data: dict | list = response.json()
             except ValueError as exc:
                 raise ValueError(response.content) from exc
 
@@ -395,7 +395,7 @@ class KrakenBaseSpotAPI:
     def __exit__(
         self: KrakenBaseSpotAPI,
         *exc: object,
-        **kwargs: Dict[str, Any],
+        **kwargs: dict[str, Any],
     ) -> None:
         pass
 
@@ -455,7 +455,7 @@ class KrakenBaseFuturesAPI:
         post_params: Optional[dict] = None,
         query_params: Optional[dict] = None,
         return_raw: bool = False,
-    ) -> Union[Dict[str, Any], List[Dict[str, Any]], List[str], requests.Response]:
+    ) -> dict[str, Any] | list[dict[str, Any]] | list[str] | requests.Response:
         """
         Handles the requested requests, by sending the request, handling the
         response, and returning the message or in case of an error the
@@ -490,7 +490,7 @@ class KrakenBaseFuturesAPI:
         method = method.upper()
 
         post_string: str = ""
-        strl: List[str]
+        strl: list[str]
         if post_params is not None:
             strl = [f"{key}={post_params[key]}" for key in sorted(post_params)]
             post_string = "&".join(strl)
@@ -599,7 +599,7 @@ class KrakenBaseFuturesAPI:
         self: KrakenBaseFuturesAPI,
         response: requests.Response,
         return_raw: bool = False,
-    ) -> Union[dict, requests.Response]:
+    ) -> dict | requests.Response:
         """
         Checks the response, handles the error (if exists) and returns the
         response data.
@@ -639,7 +639,7 @@ class KrakenBaseFuturesAPI:
     def __enter__(self: Self) -> Self:
         return self
 
-    def __exit__(self, *exc: object, **kwargs: Dict[str, Any]) -> None:
+    def __exit__(self, *exc: object, **kwargs: dict[str, Any]) -> None:
         pass
 
 

--- a/kraken/exceptions/__init__.py
+++ b/kraken/exceptions/__init__.py
@@ -12,7 +12,7 @@ TODO: make each Error separate
 from __future__ import annotations
 
 import functools
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional
 
 
 def docstring_message(cls: Any) -> Any:
@@ -26,9 +26,9 @@ def docstring_message(cls: Any) -> Any:
     @functools.wraps(cls.__init__)
     def wrapped_init(
         self: KrakenException,
-        msg: Optional[Union[str, dict]] = None,
+        msg: Optional[str | dict] = None,
         *args: tuple,
-        **kwargs: Dict[str, Any],
+        **kwargs: dict[str, Any],
     ) -> None:
         err_message: str = (
             self.__doc__ if not msg else f"{self.__doc__}\nDetails: {msg}"
@@ -50,11 +50,11 @@ class KrakenException(Exception):
 
     def __init__(
         self: KrakenException,
-        msg: Optional[Union[str, dict]] = None,
+        msg: Optional[str | dict] = None,
         *args: tuple,
-        **kwargs: Dict[str, Any],
+        **kwargs: dict[str, Any],
     ) -> None:
-        self.EXCEPTION_ASSIGNMENT: Dict[str, Any] = {
+        self.EXCEPTION_ASSIGNMENT: dict[str, Any] = {
             ##      Spot, Margin, and Futures trading Errors
             ##
             "EGeneral:Invalid arguments": self.KrakenInvalidArgumentsError,
@@ -113,7 +113,7 @@ class KrakenException(Exception):
 
     def get_exception(
         self: KrakenException,
-        data: Union[str, List[str]],
+        data: str | list[str],
     ) -> Optional[Any]:
         """Returns the exception given by name if available"""
         is_list: bool = isinstance(data, list)

--- a/kraken/futures/__init__.py
+++ b/kraken/futures/__init__.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # GitHub: https://github.com/btschwertfeger
+# pylint: disable=unused-import
 
 """This module provides the Kraken Futures clients"""
 
-# pylint: disable=unused-import
 from kraken.futures.funding import Funding
 from kraken.futures.market import Market
 from kraken.futures.trade import Trade

--- a/kraken/futures/funding.py
+++ b/kraken/futures/funding.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 from kraken.base_api import KrakenBaseFuturesAPI
 
@@ -100,7 +100,7 @@ class Funding(KrakenBaseFuturesAPI):
 
     def initiate_wallet_transfer(
         self: Funding,
-        amount: Union[str, float],
+        amount: str | float,
         fromAccount: str,
         toAccount: str,
         unit: str,
@@ -153,7 +153,7 @@ class Funding(KrakenBaseFuturesAPI):
 
     def initiate_subaccount_transfer(
         self: Funding,
-        amount: Union[str, float],
+        amount: str | float,
         fromAccount: str,
         fromUser: str,
         toAccount: str,
@@ -210,7 +210,7 @@ class Funding(KrakenBaseFuturesAPI):
 
     def initiate_withdrawal_to_spot_wallet(
         self: Funding,
-        amount: Union[str, float],
+        amount: str | float,
         currency: str,
         sourceWallet: Optional[str] = None,
         **kwargs: dict,

--- a/kraken/futures/market.py
+++ b/kraken/futures/market.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import List, Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 from kraken.base_api import KrakenBaseFuturesAPI, defined
 
@@ -112,10 +112,10 @@ class Market(KrakenBaseFuturesAPI):
                 'more_candles': True
             }
         """
-        ttypes: tuple = ("spot", "mark", "trade")
+        tick_types: tuple = ("spot", "mark", "trade")
         resolutions: tuple = ("1m", "5m", "15m", "30m", "1h", "4h", "12h", "1d", "1w")
-        if tick_type not in ttypes:
-            raise ValueError(f"tick_type must be in {ttypes}")
+        if tick_type not in tick_types:
+            raise ValueError(f"tick_type must be in {tick_types}")
         if resolution is not None and resolution not in resolutions:
             raise ValueError(f"resolution must be in {resolutions}")
 
@@ -132,7 +132,7 @@ class Market(KrakenBaseFuturesAPI):
         )
 
     @lru_cache()
-    def get_tick_types(self: Market) -> List[str]:
+    def get_tick_types(self: Market) -> list[str]:
         """
         Retrieve the available tick types that can be used for example to access
         the :func:`kraken.futures.Market.get_ohlc` endpoint.
@@ -142,7 +142,7 @@ class Market(KrakenBaseFuturesAPI):
         This function uses caching. Run ``get_tick_types.cache_clear()`` to clear.
 
         :return: List of available tick types
-        :rtype: List[str]
+        :rtype: list[str]
 
         .. code-block:: python
             :linenos:
@@ -155,7 +155,7 @@ class Market(KrakenBaseFuturesAPI):
         return self._request(method="GET", uri="/api/charts/v1/", auth=False)  # type: ignore[return-value]
 
     @lru_cache()
-    def get_tradeable_products(self: Market, tick_type: str) -> List[str]:
+    def get_tradeable_products(self: Market, tick_type: str) -> list[str]:
         """
         Retrieve a list containing the tradeable assets on the futures market.
 
@@ -166,7 +166,7 @@ class Market(KrakenBaseFuturesAPI):
         :param tick_type: The kind of data, based on ``mark``, ``spot``, or ``trade``
         :type tick_type: str
         :return: List of tradeable assets
-        :type: List[str]
+        :type: list[str]
 
         .. code-block:: python
             :linenos:
@@ -183,7 +183,7 @@ class Market(KrakenBaseFuturesAPI):
         )
 
     @lru_cache()
-    def get_resolutions(self: Market, tick_type: str, tradeable: str) -> List[str]:
+    def get_resolutions(self: Market, tick_type: str, tradeable: str) -> list[str]:
         """
         Retrieve the list of available resolutions for a specific asset.
 
@@ -196,7 +196,7 @@ class Market(KrakenBaseFuturesAPI):
         :param tick_type: The asset of interest
         :type tick_type: str
         :return: List of resolutions
-        :type: List[str]
+        :type: list[str]
 
         .. code-block:: python
             :linenos:
@@ -640,7 +640,7 @@ class Market(KrakenBaseFuturesAPI):
     def set_leverage_preference(
         self: Market,
         symbol: str,
-        maxLeverage: Optional[Union[str, int, float]] = None,
+        maxLeverage: Optional[str | float] = None,
     ) -> dict:
         """
         Set a new leverage preference for a specific futures contract.
@@ -652,7 +652,7 @@ class Market(KrakenBaseFuturesAPI):
         :param symbol: The symbol to set the preference
         :type symbol: str, optional
         :param maxLeverage: The maximum allowed leverage for a futures contract
-        :type maxLeverage: str | int | float, optional
+        :type maxLeverage: str | float, optional
         :return: Information about the success or fail
         :rtype: dict
 

--- a/kraken/futures/trade.py
+++ b/kraken/futures/trade.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, TypeVar, Union
+from typing import Optional, TypeVar
 
 from kraken.base_api import KrakenBaseFuturesAPI, defined
 
@@ -106,7 +106,7 @@ class Trade(KrakenBaseFuturesAPI):
             auth=True,
         )
 
-    def create_batch_order(self: Trade, batchorder_list: List[dict]) -> dict:
+    def create_batch_order(self: Trade, batchorder_list: list[dict]) -> dict:
         """
         Create multiple orders at once using the batch order endpoint.
 
@@ -115,7 +115,7 @@ class Trade(KrakenBaseFuturesAPI):
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-batch-order-management
 
         :param batchorder_list: List of order instructions (see example below - or the linked official Kraken documentation)
-        :type batchorder_list: List[dict]
+        :type batchorder_list: list[dict]
         :return: Information about the submitted request
         :rtype: dict
 
@@ -355,9 +355,9 @@ class Trade(KrakenBaseFuturesAPI):
         self: Trade,
         orderId: Optional[str] = None,
         cliOrdId: Optional[str] = None,
-        limitPrice: Optional[Union[str, int, float]] = None,
-        size: Optional[Union[str, int, float]] = None,
-        stopPrice: Optional[Union[str, int, float]] = None,
+        limitPrice: Optional[str | float] = None,
+        size: Optional[str | float] = None,
+        stopPrice: Optional[str | float] = None,
     ) -> dict:
         """
         Edit an open order.
@@ -371,11 +371,11 @@ class Trade(KrakenBaseFuturesAPI):
         :param cliOrdId: The client defined order id
         :type cliOrdId: str, optional
         :param limitPrice: The new limit price
-        :type limitPrice: str | int | float None
+        :type limitPrice: str | float None
         :param size: The new size of the position
-        :type size: str | int | float, optional
+        :type size: str | float, optional
         :param stopPrice: The stop price
-        :type stopPrice: str | int | float, optional
+        :type stopPrice: str | float, optional
         :raises ValueError: If both ``orderId`` and ``cliOrdId`` are not set
         :return: Success or failure
         :rtype: dict
@@ -423,8 +423,8 @@ class Trade(KrakenBaseFuturesAPI):
 
     def get_orders_status(
         self: Trade,
-        orderIds: Optional[Union[str, List[str]]] = None,
-        cliOrdIds: Optional[Union[str, List[str]]] = None,
+        orderIds: Optional[str | list[str]] = None,
+        cliOrdIds: Optional[str | list[str]] = None,
     ) -> dict:
         """
         Get the status of multiple orders.
@@ -434,9 +434,9 @@ class Trade(KrakenBaseFuturesAPI):
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-get-the-current-status-for-specific-orders
 
         :param orderIds: The order ids to cancel
-        :type orderIds: str | List[str], optional
+        :type orderIds: str | list[str], optional
         :param cliOrdId: The client defined order ids
-        :type cliOrdId: str | List[str], optional
+        :type cliOrdId: str | list[str], optional
         :return: Success or failure
         :rtype: dict
 
@@ -469,13 +469,13 @@ class Trade(KrakenBaseFuturesAPI):
     def create_order(  # noqa: PLR0913
         self: Trade,
         orderType: str,
-        size: Union[str, float],
+        size: str | float,
         symbol: str,
         side: str,
         cliOrdId: Optional[str] = None,
-        limitPrice: Optional[Union[str, float]] = None,
+        limitPrice: Optional[str | float] = None,
         reduceOnly: Optional[bool] = None,
-        stopPrice: Optional[Union[str, float]] = None,
+        stopPrice: Optional[str | float] = None,
         triggerSignal: Optional[str] = None,
         trailingStopDeviationUnit: Optional[str] = None,
         trailingStopMaxDeviation: Optional[str] = None,
@@ -499,7 +499,7 @@ class Trade(KrakenBaseFuturesAPI):
         :param cliOrdId: A user defined order id
         :type cliOrdId: str, optional
         :param limitPrice: Define a custom limit price
-        :type limitPrice: str |float
+        :type limitPrice: str | float, optional
         :param reduceOnly: Reduces existing positions if set to ``True``
         :type reduceOnly: bool, optional
         :param stopPrice: Define a price when to exit the order. Required for specific order types
@@ -643,7 +643,7 @@ class Trade(KrakenBaseFuturesAPI):
             }
         """
 
-        sides: Tuple[str, str] = ("buy", "sell")
+        sides: tuple[str, str] = ("buy", "sell")
         if side not in sides:
             raise ValueError(f"Invalid side. One of [{sides}] is required!")
 

--- a/kraken/futures/user.py
+++ b/kraken/futures/user.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 from kraken.base_api import KrakenBaseFuturesAPI, defined
 
@@ -251,11 +251,11 @@ class User(KrakenBaseFuturesAPI):
 
     def get_account_log(
         self: User,
-        before: Optional[Union[str, int]] = None,
-        count: Optional[Union[str, int]] = None,
-        from_: Optional[Union[str, int]] = None,
+        before: Optional[str | int] = None,
+        count: Optional[str | int] = None,
+        from_: Optional[str | int] = None,
         info: Optional[str] = None,
-        since: Optional[Union[str, int]] = None,
+        since: Optional[str | int] = None,
         sort: Optional[str] = None,
         to: Optional[str] = None,
     ) -> dict:

--- a/kraken/futures/websocket/__init__.py
+++ b/kraken/futures/websocket/__init__.py
@@ -14,7 +14,7 @@ import logging
 import traceback
 from copy import deepcopy
 from random import random
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import websockets
 
@@ -56,7 +56,7 @@ class ConnectFuturesWebsocket:
         self.__challenge_ready: bool = False
 
         self.__socket: Any = None
-        self.__subscriptions: List[dict] = []
+        self.__subscriptions: list[dict] = []
 
         self.task = asyncio.ensure_future(
             self.__run_forever(),
@@ -64,7 +64,7 @@ class ConnectFuturesWebsocket:
         )
 
     @property
-    def subscriptions(self: ConnectFuturesWebsocket) -> List[dict]:
+    def subscriptions(self: ConnectFuturesWebsocket) -> list[dict]:
         """Returns the active subscriptions"""
         return self.__subscriptions
 
@@ -296,7 +296,7 @@ class ConnectFuturesWebsocket:
             )
         return sub
 
-    def get_active_subscriptions(self: ConnectFuturesWebsocket) -> List[dict]:
+    def get_active_subscriptions(self: ConnectFuturesWebsocket) -> list[dict]:
         """Returns the active subscriptions"""
         return self.__subscriptions
 

--- a/kraken/futures/ws_client.py
+++ b/kraken/futures/ws_client.py
@@ -13,7 +13,7 @@ import hashlib
 import hmac
 import logging
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 from kraken.base_api import KrakenBaseFuturesAPI
 from kraken.exceptions import KrakenException
@@ -185,7 +185,7 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
     async def subscribe(
         self: KrakenFuturesWSClient,
         feed: str,
-        products: Optional[List[str]] = None,
+        products: Optional[list[str]] = None,
     ) -> None:
         """
         Subscribe to a Futures websocket channel/feed. For some feeds authentication is required.
@@ -242,7 +242,7 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
     async def unsubscribe(
         self: KrakenFuturesWSClient,
         feed: str,
-        products: Optional[List[str]] = None,
+        products: Optional[list[str]] = None,
     ) -> None:
         """
         Subscribe to a Futures websocket channel/feed. For some feeds
@@ -299,7 +299,7 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
             raise ValueError(f"Feed: {feed} not found. Not unsubscribing it.")
 
     @staticmethod
-    def get_available_public_subscription_feeds() -> List[str]:
+    def get_available_public_subscription_feeds() -> list[str]:
         """
         Return all available public feeds that can be un-/subscribed using the
         Kraken Futures API.
@@ -321,7 +321,7 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
         return ["trade", "book", "ticker", "ticker_lite", "heartbeat"]
 
     @staticmethod
-    def get_available_private_subscription_feeds() -> List[str]:
+    def get_available_private_subscription_feeds() -> list[str]:
         """
         Return all available private feeds that can be un-/subscribed to/from
         using the Kraken Futures API
@@ -377,7 +377,7 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
             and self.__secret != ""
         )
 
-    def get_active_subscriptions(self: KrakenFuturesWSClient) -> List[dict]:
+    def get_active_subscriptions(self: KrakenFuturesWSClient) -> list[dict]:
         """
         Returns the list of active subscriptions.
 
@@ -414,7 +414,7 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
     async def __aexit__(
         self: KrakenFuturesWSClient,
         *exc: object,
-        **kwargs: Dict[str, Any],
+        **kwargs: dict[str, Any],
     ) -> None:
         pass
 

--- a/kraken/spot/__init__.py
+++ b/kraken/spot/__init__.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # GitHub: https://github.com/btschwertfeger
+# pylint: disable=unused-import
 
 """Module that provides the Spot REST clients and utility functions."""
 
-# pylint: disable=unused-import
 from kraken.spot.funding import Funding
 from kraken.spot.market import Market
 from kraken.spot.orderbook import OrderbookClient

--- a/kraken/spot/funding.py
+++ b/kraken/spot/funding.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 from kraken.base_api import KrakenBaseSpotAPI, defined
 
@@ -58,7 +58,7 @@ class Funding(KrakenBaseSpotAPI):
         super().__enter__()
         return self
 
-    def get_deposit_methods(self: Funding, asset: str) -> List[dict]:
+    def get_deposit_methods(self: Funding, asset: str) -> list[dict]:
         """
         Get the available deposit methods for a specific asset.
 
@@ -67,7 +67,7 @@ class Funding(KrakenBaseSpotAPI):
         :param asset: Asset being deposited
         :type asset: str
         :return: List of available deposit methods of the asset
-        :rtype: List[dict]
+        :rtype: list[dict]
 
         .. code-block:: python
             :linenos:
@@ -99,7 +99,7 @@ class Funding(KrakenBaseSpotAPI):
         asset: str,
         method: str,
         new: Optional[bool] = False,
-    ) -> List[dict]:
+    ) -> list[dict]:
         """
         Get the deposit addresses for a specific asset. New deposit addresses can be generated.
 
@@ -114,7 +114,7 @@ class Funding(KrakenBaseSpotAPI):
         :param new: Generate a new deposit address (default: ``False``)
         :type new: bool, optional
         :return: The user and asset specific deposit addresses
-        :rtype: List[dict]
+        :rtype: list[dict]
 
         .. code-block:: python
             :linenos:
@@ -147,7 +147,7 @@ class Funding(KrakenBaseSpotAPI):
         self: Funding,
         asset: Optional[str] = None,
         method: Optional[str] = None,
-    ) -> List[dict]:
+    ) -> list[dict]:
         """
         Get information about the recent deposit status. The look back period is 90 days and
         only the last 25 deposits will be returned.
@@ -161,7 +161,7 @@ class Funding(KrakenBaseSpotAPI):
         :param method: Filter by deposit method
         :type method: str, optional
         :return: The user specific deposit history
-        :rtype: List[dict]
+        :rtype: list[dict]
 
         .. code-block:: python
             :linenos:
@@ -222,7 +222,7 @@ class Funding(KrakenBaseSpotAPI):
         self: Funding,
         asset: str,
         key: str,
-        amount: Union[str, float],
+        amount: str | float,
     ) -> dict:
         """
         Get information about a possible withdraw, including fee and limit information.
@@ -270,7 +270,7 @@ class Funding(KrakenBaseSpotAPI):
         self: Funding,
         asset: str,
         key: str,
-        amount: Union[str, float],
+        amount: str | float,
     ) -> dict:
         """
         Create a new withdraw. The key must be the name of the withdraw key
@@ -312,7 +312,7 @@ class Funding(KrakenBaseSpotAPI):
         self: Funding,
         asset: Optional[str] = None,
         method: Optional[str] = None,
-    ) -> List[dict]:
+    ) -> list[dict]:
         """
         Get information about the recent withdraw status, including withdraws of the
         past 90 days but at max 500 results.
@@ -324,7 +324,7 @@ class Funding(KrakenBaseSpotAPI):
         :param method: Filter by withdraw method (default: ``None``)
         :type method: str, optional
         :return: Withdrawal information
-        :rtype: List[dict]
+        :rtype: list[dict]
 
         .. code-block:: python
             :linenos:
@@ -395,7 +395,7 @@ class Funding(KrakenBaseSpotAPI):
         asset: str,
         from_: str,
         to_: str,
-        amount: Union[str, float],
+        amount: str | float,
     ) -> dict:
         """
         Transfer assets between the Spot and Futures wallet.

--- a/kraken/spot/market.py
+++ b/kraken/spot/market.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import List, Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 from kraken.base_api import KrakenBaseSpotAPI, defined, ensure_string
 
@@ -63,7 +63,7 @@ class Market(KrakenBaseSpotAPI):
     @lru_cache()
     def get_assets(
         self: Market,
-        assets: Optional[Union[str, List[str]]] = None,
+        assets: Optional[str | list[str]] = None,
         aclass: Optional[str] = None,
     ) -> dict:
         """
@@ -75,7 +75,7 @@ class Market(KrakenBaseSpotAPI):
         This function uses caching. Run ``get_assets.cache_clear()`` to clear.
 
         :param assets: Filter by asset(s)
-        :type assets: str | List[str], optional
+        :type assets: str | list[str], optional
         :param aclass: Filter by asset class
         :type aclass: str, optional
         :return: Information about the requested assets
@@ -133,7 +133,7 @@ class Market(KrakenBaseSpotAPI):
     @lru_cache()
     def get_asset_pairs(
         self: Market,
-        pair: Optional[Union[str, List[str]]] = None,
+        pair: Optional[str | list[str]] = None,
         info: Optional[str] = None,
     ) -> dict:
         """
@@ -145,7 +145,7 @@ class Market(KrakenBaseSpotAPI):
         This function uses caching. Run ``get_asset_pairs.cache_clear()`` to clear.
 
         :param pair: Filter by asset pair(s)
-        :type pair: str | List[str], optional
+        :type pair: str | list[str], optional
         :param info: Filter by info, can be one of: ``info`` (all info), ``leverage``
             (leverage info), ``fees`` (fee info), and ``margin`` (margin info)
         :type info: str, optional
@@ -208,7 +208,7 @@ class Market(KrakenBaseSpotAPI):
         )
 
     @ensure_string("pair")
-    def get_ticker(self: Market, pair: Optional[Union[str, List[str]]] = None) -> dict:
+    def get_ticker(self: Market, pair: Optional[str | list[str]] = None) -> dict:
         """
         Returns all tickers if pair is not specified - else just
         the ticker of the ``pair``. Multiple pairs can be specified.
@@ -216,7 +216,7 @@ class Market(KrakenBaseSpotAPI):
         https://docs.kraken.com/rest/#operation/getTickerInformation
 
         :param pair: Filter by pair(s)
-        :type pair: str | List[str], optional
+        :type pair: str | list[str], optional
         :return: The ticker(s) including ask, bid, close, volume, vwap, high, low, todays open and more
         :rtype: dict
 
@@ -253,8 +253,8 @@ class Market(KrakenBaseSpotAPI):
     def get_ohlc(
         self: Market,
         pair: str,
-        interval: Union[int, str] = 1,
-        since: Optional[Union[int, str]] = None,
+        interval: int | str = 1,
+        since: Optional[int | str] = None,
     ) -> dict:
         """
         Get the open, high, low, and close data for a specific trading pair.
@@ -345,7 +345,7 @@ class Market(KrakenBaseSpotAPI):
     def get_recent_trades(
         self: Market,
         pair: str,
-        since: Optional[Union[str, int]] = None,
+        since: Optional[str | int] = None,
         count: Optional[int] = None,
     ) -> dict:
         """
@@ -393,7 +393,7 @@ class Market(KrakenBaseSpotAPI):
     def get_recent_spreads(
         self: Market,
         pair: str,
-        since: Optional[Union[str, int]] = None,
+        since: Optional[str | int] = None,
     ) -> dict:
         """
         Get the latest spreads for a specific trading pair.

--- a/kraken/spot/orderbook.py
+++ b/kraken/spot/orderbook.py
@@ -13,7 +13,7 @@ from asyncio import sleep as asyncio_sleep
 from binascii import crc32
 from collections import OrderedDict
 from inspect import iscoroutinefunction
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Optional
 
 from kraken.spot import Market
 from kraken.spot.websocket_v2 import KrakenSpotWSClientV2
@@ -116,7 +116,7 @@ class OrderbookClient:
         callback: Optional[Callable] = None,
     ) -> None:
         super().__init__()
-        self.__book: Dict[str, dict] = {}
+        self.__book: dict[str, dict] = {}
         self.__depth: int = depth
         self.__callback: Optional[Callable] = callback
 
@@ -125,7 +125,7 @@ class OrderbookClient:
             callback=self.on_message,
         )
 
-    async def on_message(self: OrderbookClient, message: Union[list, dict]) -> None:
+    async def on_message(self: OrderbookClient, message: list | dict) -> None:
         """
         The on_message function is implemented within the KrakenSpotWSClient
         class and used as callback to receive all messages sent by the
@@ -235,7 +235,7 @@ class OrderbookClient:
         else:
             print(message)  # noqa: T201
 
-    async def add_book(self: OrderbookClient, pairs: List[str]) -> None:
+    async def add_book(self: OrderbookClient, pairs: list[str]) -> None:
         """
         Add an orderbook to this client. The feed will be subscribed
         and updates will be published to the :func:`on_book_update` function.
@@ -249,7 +249,7 @@ class OrderbookClient:
             params={"channel": "book", "depth": self.__depth, "symbol": pairs},
         )
 
-    async def remove_book(self: OrderbookClient, pairs: List[str]) -> None:
+    async def remove_book(self: OrderbookClient, pairs: list[str]) -> None:
         """
         Unsubscribe from a subscribed orderbook.
 
@@ -314,7 +314,7 @@ class OrderbookClient:
 
     def __update_book(
         self: OrderbookClient,
-        orders: List[dict],
+        orders: list[dict],
         side: str,
         symbol: str,
         timestamp: Optional[str] = None,

--- a/kraken/spot/staking.py
+++ b/kraken/spot/staking.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 from kraken.base_api import KrakenBaseSpotAPI, defined
 
@@ -61,7 +61,7 @@ class Staking(KrakenBaseSpotAPI):
     def stake_asset(
         self: Staking,
         asset: str,
-        amount: Union[str, float],
+        amount: str | float,
         method: str,
     ) -> dict:
         """
@@ -106,7 +106,7 @@ class Staking(KrakenBaseSpotAPI):
     def unstake_asset(
         self: Staking,
         asset: str,
-        amount: Union[str, float],
+        amount: str | float,
         method: Optional[str] = None,
     ) -> dict:
         """
@@ -152,7 +152,7 @@ class Staking(KrakenBaseSpotAPI):
             auth=True,
         )
 
-    def list_stakeable_assets(self: Staking) -> List[dict]:
+    def list_stakeable_assets(self: Staking) -> list[dict]:
         """
         Get a list of stakeable assets. Only assets that the user is able to stake
         will be shown.
@@ -211,7 +211,7 @@ class Staking(KrakenBaseSpotAPI):
             auth=True,
         )
 
-    def get_pending_staking_transactions(self: Staking) -> List[dict]:
+    def get_pending_staking_transactions(self: Staking) -> list[dict]:
         """
         Get the list of pending staking transactions of the user.
 
@@ -249,7 +249,7 @@ class Staking(KrakenBaseSpotAPI):
             auth=True,
         )
 
-    def list_staking_transactions(self: Staking) -> List[dict]:
+    def list_staking_transactions(self: Staking) -> list[dict]:
         """
         List the last 1000 staking transactions of the past 90 days.
 

--- a/kraken/spot/trade.py
+++ b/kraken/spot/trade.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from decimal import Decimal
 from functools import lru_cache
 from math import floor
-from typing import List, Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 from kraken.base_api import KrakenBaseSpotAPI, defined, ensure_string
 from kraken.spot.market import Market
@@ -69,22 +69,22 @@ class Trade(KrakenBaseSpotAPI):
         ordertype: str,
         side: str,
         pair: str,
-        volume: Union[str, float],
-        price: Optional[Union[str, float]] = None,
-        price2: Optional[Union[str, float]] = None,
+        volume: str | float,
+        price: Optional[str | float] = None,
+        price2: Optional[str | float] = None,
         truncate: bool = False,
         trigger: Optional[str] = None,
         leverage: Optional[str] = None,
         reduce_only: Optional[bool] = False,
         stptype: Optional[str] = "cancel-newest",
-        oflags: Optional[Union[str, List[str]]] = None,
+        oflags: Optional[str | list[str]] = None,
         timeinforce: Optional[str] = None,
         displayvol: Optional[str] = None,
         starttm: Optional[str] = "0",
         expiretm: Optional[str] = None,
         close_ordertype: Optional[str] = None,
-        close_price: Optional[Union[str, float]] = None,
-        close_price2: Optional[Union[str, float]] = None,
+        close_price: Optional[str | float] = None,
+        close_price2: Optional[str | float] = None,
         deadline: Optional[str] = None,
         validate: bool = False,
         userref: Optional[int] = None,
@@ -364,7 +364,7 @@ class Trade(KrakenBaseSpotAPI):
 
     def create_order_batch(
         self: Trade,
-        orders: List[dict],
+        orders: list[dict],
         pair: str,
         deadline: Optional[str] = None,
         validate: bool = False,
@@ -445,9 +445,9 @@ class Trade(KrakenBaseSpotAPI):
         self: Trade,
         txid: str,
         pair: str,
-        volume: Optional[Union[str, int, float]] = None,
-        price: Optional[Union[str, int, float]] = None,
-        price2: Optional[Union[str, int, float]] = None,
+        volume: Optional[str | float] = None,
+        price: Optional[str | float] = None,
+        price2: Optional[str | float] = None,
         truncate: bool = False,
         oflags: Optional[str] = None,
         deadline: Optional[str] = None,
@@ -468,11 +468,11 @@ class Trade(KrakenBaseSpotAPI):
         :param pair: The asset pair of the order
         :type pair: str
         :param volume: Set a new volume
-        :type volume: str | int | float, optional
+        :type volume: str | float, optional
         :param price: Set a new price
-        :type price: str | int | float, optional
+        :type price: str | float, optional
         :param price2: Set a new second price
-        :type price2: str | int | float, optional
+        :type price2: str | float, optional
         :param truncate: If enabled: round the ``price`` and ``volume`` to Kraken's
             maximum allowed decimal places. See https://support.kraken.com/hc/en-us/articles/4521313131540
             fore more information about decimals.
@@ -632,7 +632,7 @@ class Trade(KrakenBaseSpotAPI):
             params={"timeout": timeout},
         )
 
-    def cancel_order_batch(self: Trade, orders: List[Union[str, int]]) -> dict:
+    def cancel_order_batch(self: Trade, orders: list[str | int]) -> dict:
         """
         Cancel a a list of orders by ``txid`` or ``userref``
 
@@ -642,7 +642,7 @@ class Trade(KrakenBaseSpotAPI):
         - https://docs.kraken.com/rest/#operation/cancelOrderBatch
 
         :param orders: List of orders to cancel
-        :type orders: List[str | int]
+        :type orders: list[str | int]
         :return: Success or failure - Number of closed orders
         :rtype: dict
 
@@ -667,7 +667,7 @@ class Trade(KrakenBaseSpotAPI):
     @lru_cache()
     def truncate(
         self: Trade,
-        amount: Union[Decimal, float, str],
+        amount: Decimal | float | str,
         amount_type: str,
         pair: str,
     ) -> str:

--- a/kraken/spot/user.py
+++ b/kraken/spot/user.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import List, Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 from kraken.base_api import KrakenBaseSpotAPI, defined, ensure_string
 
@@ -382,7 +382,7 @@ class User(KrakenBaseSpotAPI):
     @ensure_string("txid")
     def get_orders_info(
         self: User,
-        txid: Union[List[str], str],
+        txid: list[str] | str,
         trades: Optional[bool] = False,
         userref: Optional[int] = None,
         consolidate_taker: Optional[bool] = True,
@@ -397,7 +397,7 @@ class User(KrakenBaseSpotAPI):
 
         :param txid: A transaction id of a specific order, a list of txids or a
             string containing a comma delimited list of txids
-        :type txid: str | List[str]
+        :type txid: str | list[str]
         :param trades: Include trades in the result or not (default: ``False``)
         :type trades: bool, optional
         :param userref: Filter results by user reference id
@@ -569,7 +569,7 @@ class User(KrakenBaseSpotAPI):
     @ensure_string("txid")
     def get_trades_info(
         self: User,
-        txid: Union[str, List[str]],
+        txid: str | list[str],
         trades: Optional[bool] = False,
     ) -> dict:
         """
@@ -581,7 +581,7 @@ class User(KrakenBaseSpotAPI):
         - https://docs.kraken.com/rest/#operation/getTradesInfo
 
         :param txid: txid or list of txids or comma delimited list of txids as string
-        :type txid: str | List[str]
+        :type txid: str | list[str]
         :param trades: Include trades related to position in result (default: ``False``)
         :type trades: bool
 
@@ -623,7 +623,7 @@ class User(KrakenBaseSpotAPI):
     @ensure_string("txid")
     def get_open_positions(
         self: User,
-        txid: Optional[Union[str, List[str]]] = None,
+        txid: Optional[str | list[str]] = None,
         docalcs: Optional[bool] = False,
         consolidation: Optional[str] = "market",
     ) -> dict:
@@ -635,7 +635,7 @@ class User(KrakenBaseSpotAPI):
         - https://docs.kraken.com/rest/#operation/getOpenPositions
 
         :param txid: Filter by txid or list of txids or comma delimited list of txids as string
-        :type txid: str | List[str], optional
+        :type txid: str | list[str], optional
         :param docalcs: Include profit and loss calculation into the result (default: ``False``)
         :type docalcs: bool, optional
         :param consolidation: Consolidate positions by market/pair (default: ``market``)
@@ -684,7 +684,7 @@ class User(KrakenBaseSpotAPI):
     @ensure_string("asset")
     def get_ledgers_info(
         self: User,
-        asset: Optional[Union[str, List[str]]] = "all",
+        asset: Optional[str | list[str]] = "all",
         aclass: Optional[str] = "currency",
         type_: Optional[str] = "all",
         start: Optional[int] = None,
@@ -700,7 +700,7 @@ class User(KrakenBaseSpotAPI):
         - https://docs.kraken.com/rest/#operation/getLedgers
 
         :param asset: The asset(s) to filter for (default: ``all``)
-        :type asset: str | List[str]
+        :type asset: str | list[str]
         :param aclass: The asset class (default: ``currency`` )
         :type aclass: str
         :param type_: Ledger type, one of: ``all``, ``deposit``, ``withdrawal``,
@@ -756,7 +756,7 @@ class User(KrakenBaseSpotAPI):
     @ensure_string("id_")
     def get_ledgers(
         self: User,
-        id_: Union[str, List[str]],
+        id_: str | list[str],
         trades: Optional[bool] = False,
     ) -> dict:
         """
@@ -769,7 +769,7 @@ class User(KrakenBaseSpotAPI):
 
         :param id_: Ledger id as string, list of strings, or comma delimited
             list of ledger ids as string
-        :type id_: str | List[str]
+        :type id_: str | list[str]
         :param trades: Include trades related to a position or not
             (default: ``False``)
         :type trades: bool, optional
@@ -804,7 +804,7 @@ class User(KrakenBaseSpotAPI):
     @ensure_string("pair")
     def get_trade_volume(
         self: User,
-        pair: Optional[Union[str, List[str]]] = None,
+        pair: Optional[str | list[str]] = None,
         fee_info: bool = True,
     ) -> dict:
         """
@@ -816,7 +816,7 @@ class User(KrakenBaseSpotAPI):
 
         :param pair: Asset pair, list of asset pairs or comma delimited list
             (as string) of asset pairs to filter
-        :type pair: str | List[str], optional
+        :type pair: str | list[str], optional
         :param fee_info: Include fee information or not (default: ``True``)
         :type fee_info: bool, optional
 
@@ -875,7 +875,7 @@ class User(KrakenBaseSpotAPI):
         report: str,
         description: str,
         format_: Optional[str] = "CSV",
-        fields: Optional[Union[str, List[str]]] = "all",
+        fields: Optional[str | list[str]] = "all",
         starttm: Optional[int] = None,
         endtm: Optional[int] = None,
         **kwargs: dict,
@@ -896,7 +896,7 @@ class User(KrakenBaseSpotAPI):
             ``CSV`` and ``TSV`` (default: ``CSV``)
         :type format_: str
         :param fields: Fields to include in the report (default: ``all``)
-        :type fields: str | List[str], optional
+        :type fields: str | list[str], optional
         :param starttm: Unix timestamp to start
         :type starttm: int, optional
         :param endtm: Unix timestamp of the last result
@@ -949,7 +949,7 @@ class User(KrakenBaseSpotAPI):
         :param report: Kind of report, one of: ``trades``, ``ledgers``
         :type report: str
         :return: Information about the pending report
-        :rtype: List[dict]
+        :rtype: list[dict]
 
         .. code-block:: python
             :linenos:
@@ -1101,7 +1101,7 @@ class User(KrakenBaseSpotAPI):
     def account_transfer(
         self: "User",
         asset: str,
-        amount: Union[str, float],
+        amount: str | float,
         from_: str,
         to_: str,
     ) -> dict:

--- a/kraken/spot/websocket/__init__.py
+++ b/kraken/spot/websocket/__init__.py
@@ -11,7 +11,7 @@ Module that provides the base class for the Kraken Websocket clients v1 and v2.
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Optional, Type, TypeVar
 
 from kraken.base_api import KrakenBaseSpotAPI
 from kraken.spot.websocket.connectors import (
@@ -67,11 +67,9 @@ class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
         self._is_auth: bool = bool(key and secret)
         self.__callback: Optional[Callable] = callback
         self.exception_occur: bool = False
-        self._pub_conn: Optional[
-            Union[ConnectSpotWebsocketV1, ConnectSpotWebsocketV2]
-        ] = None
+        self._pub_conn: Optional[ConnectSpotWebsocketV1 | ConnectSpotWebsocketV2] = None
         self._priv_conn: Optional[
-            Union[ConnectSpotWebsocketV1, ConnectSpotWebsocketV2]
+            ConnectSpotWebsocketV1 | ConnectSpotWebsocketV2
         ] = None
 
         self.__connect(version=api_version, beta=beta, no_public=no_public)
@@ -79,7 +77,7 @@ class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
     # --------------------------------------------------------------------------
     # Internals
     def __connect(
-        self: "KrakenSpotWSClientBase",
+        self: KrakenSpotWSClientBase,
         version: str,
         beta: bool,
         no_public: bool,
@@ -90,9 +88,8 @@ class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
         :param version: The Websocket API version to use (one of ``v1``, ``v2``)
         :type version: str
         """
-        ConnectSpotWebsocket: Union[
-            Type[ConnectSpotWebsocketV1],
-            Type[ConnectSpotWebsocketV2],
+        ConnectSpotWebsocket: Type[ConnectSpotWebsocketV1] | Type[
+            ConnectSpotWebsocketV2
         ]
 
         if version == "v1":
@@ -132,7 +129,7 @@ class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
 
     async def on_message(
         self: KrakenSpotWSClientBase,
-        message: Union[dict, list],
+        message: dict | list,
     ) -> None:
         """
         Calls the defined callback function (if defined). In most cases you
@@ -203,7 +200,7 @@ class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
     @property
     def active_public_subscriptions(
         self: KrakenSpotWSClientBase,
-    ) -> Union[List[dict], Any]:
+    ) -> list[dict] | Any:
         """
         Returns the active public subscriptions
 
@@ -218,7 +215,7 @@ class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
     @property
     def active_private_subscriptions(
         self: KrakenSpotWSClientBase,
-    ) -> Union[List[dict], Any]:
+    ) -> list[dict] | Any:
         """
         Returns the active private subscriptions
 
@@ -267,7 +264,7 @@ class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
         raise NotImplementedError("Must be overloaded!")  # coverage: disable
 
     @property
-    def public_channel_names(self: KrakenSpotWSClientBase) -> List[str]:
+    def public_channel_names(self: KrakenSpotWSClientBase) -> list[str]:
         """
         This function must be overloaded and return a list of names that can be
         subscribed to (for unauthenticated connections).
@@ -275,7 +272,7 @@ class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
         raise NotImplementedError("Must be overloaded!")  # coverage: disable
 
     @property
-    def private_channel_names(self: KrakenSpotWSClientBase) -> List[str]:
+    def private_channel_names(self: KrakenSpotWSClientBase) -> list[str]:
         """
         This function must be overloaded and return a list of names that can be
         subscribed to (for authenticated connections).

--- a/kraken/spot/websocket/connectors.py
+++ b/kraken/spot/websocket/connectors.py
@@ -20,7 +20,7 @@ import traceback
 from copy import deepcopy
 from random import random
 from time import time
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import websockets
 
@@ -74,9 +74,9 @@ class ConnectSpotWebsocketBase:
 
         self.__is_auth: bool = is_auth
 
-        self._last_ping: Optional[Union[int, float]] = None
+        self._last_ping: Optional[int | float] = None
         self.socket: Optional[Any] = None
-        self._subscriptions: List[dict] = []
+        self._subscriptions: list[dict] = []
         self.task: asyncio.Task = asyncio.create_task(self.__run_forever())
 
     @property
@@ -90,7 +90,7 @@ class ConnectSpotWebsocketBase:
         return self.__client
 
     @property
-    def subscriptions(self: ConnectSpotWebsocketBase) -> List[dict]:
+    def subscriptions(self: ConnectSpotWebsocketBase) -> list[dict]:
         """Returns a copy of active subscriptions"""
         return deepcopy(self._subscriptions)
 
@@ -200,7 +200,7 @@ class ConnectSpotWebsocketBase:
         await asyncio.sleep(reconnect_wait)
 
         event: asyncio.Event = asyncio.Event()
-        tasks: List[asyncio.Task] = [
+        tasks: list[asyncio.Task] = [
             asyncio.create_task(self._recover_subscriptions(event)),
             asyncio.create_task(self.__run(event)),
         ]
@@ -231,7 +231,7 @@ class ConnectSpotWebsocketBase:
     def __get_reconnect_wait(
         self: ConnectSpotWebsocketBase,
         attempts: int,
-    ) -> Union[float, Any]:
+    ) -> float | Any:
         """
         Get some random wait time that increases by any attempt.
 
@@ -258,7 +258,7 @@ class ConnectSpotWebsocketBase:
 
     def _manage_subscriptions(
         self: ConnectSpotWebsocketBase,
-        message: Union[dict, list],
+        message: dict | list,
     ) -> None:
         """Function that is to be overloaded.
 
@@ -364,7 +364,7 @@ class ConnectSpotWebsocketV1(ConnectSpotWebsocketBase):
 
     def _manage_subscriptions(
         self: ConnectSpotWebsocketV1,
-        message: Union[dict, list],
+        message: dict | list,
     ) -> None:
         """
         Checks if the message contains events about un-/subscriptions

--- a/kraken/spot/websocket_v1.py
+++ b/kraken/spot/websocket_v1.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 from copy import deepcopy
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Optional
 
 from kraken.base_api import defined, ensure_string
 from kraken.exceptions import KrakenException
@@ -215,7 +215,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
     async def subscribe(  # pylint: disable=arguments-differ
         self: KrakenSpotWSClient,
         subscription: dict,
-        pair: Optional[List[str]] = None,
+        pair: Optional[list[str]] = None,
     ) -> None:
         """
         Subscribe to a channel
@@ -287,7 +287,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
     async def unsubscribe(  # pylint: disable=arguments-differ
         self: KrakenSpotWSClient,
         subscription: dict,
-        pair: Optional[List[str]] = None,
+        pair: Optional[list[str]] = None,
     ) -> None:
         """
         Unsubscribe from a feed
@@ -357,7 +357,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
             # await self.send_message(payload, private=False)
 
     @property
-    def public_channel_names(self: KrakenSpotWSClient) -> List[str]:
+    def public_channel_names(self: KrakenSpotWSClient) -> list[str]:
         """
         Returns the public subscription names
 
@@ -368,7 +368,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         return ["ticker", "spread", "book", "ohlc", "trade", "*"]
 
     @property
-    def private_channel_names(self: KrakenSpotWSClient) -> List[str]:
+    def private_channel_names(self: KrakenSpotWSClient) -> list[str]:
         """
         Returns the private subscription names
 
@@ -384,21 +384,21 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         ordertype: str,
         side: str,
         pair: str,
-        volume: Union[str, float],
-        price: Optional[Union[str, float]] = None,
-        price2: Optional[Union[str, float]] = None,
+        volume: str | float,
+        price: Optional[str | float] = None,
+        price2: Optional[str | float] = None,
         truncate: bool = False,
-        leverage: Optional[Union[str, float]] = None,
-        oflags: Optional[Union[str, List[str]]] = None,
-        starttm: Optional[Union[str, int]] = None,
-        expiretm: Optional[Union[str, int]] = None,
+        leverage: Optional[str | float] = None,
+        oflags: Optional[str | list[str]] = None,
+        starttm: Optional[str | int] = None,
+        expiretm: Optional[str | int] = None,
         deadline: Optional[str] = None,
-        userref: Optional[Union[str, int]] = None,
+        userref: Optional[str | int] = None,
         validate: bool = False,
         close_ordertype: Optional[str] = None,
-        close_price: Optional[Union[str, int, float]] = None,
-        close_price2: Optional[Union[str, int, float]] = None,
-        timeinforce: Optional[Union[str, int]] = None,
+        close_price: Optional[str | float] = None,
+        close_price2: Optional[str | float] = None,
+        timeinforce: Optional[str | int] = None,
     ) -> None:
         """
         Create an order and submit it.
@@ -548,14 +548,14 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
     async def edit_order(  # noqa: PLR0913
         self: KrakenSpotWSClient,
         orderid: str,
-        reqid: Optional[Union[str, int]] = None,
+        reqid: Optional[str | int] = None,
         pair: Optional[str] = None,
-        price: Optional[Union[str, int, float]] = None,
-        price2: Optional[Union[str, int, float]] = None,
+        price: Optional[str | float] = None,
+        price2: Optional[str | float] = None,
         truncate: bool = False,
-        volume: Optional[Union[str, int, float]] = None,
-        oflags: Optional[Union[str, List[str]]] = None,
-        newuserref: Optional[Union[str, int]] = None,
+        volume: Optional[str | float] = None,
+        oflags: Optional[str | list[str]] = None,
+        newuserref: Optional[str | int] = None,
         validate: bool = False,
     ) -> None:
         """
@@ -644,7 +644,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
 
         await self.send_message(message=payload, private=True)
 
-    async def cancel_order(self: KrakenSpotWSClient, txid: List[str]) -> None:
+    async def cancel_order(self: KrakenSpotWSClient, txid: list[str]) -> None:
         """
         Cancel a specific order or a list of orders.
 

--- a/kraken/spot/websocket_v2.py
+++ b/kraken/spot/websocket_v2.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Optional
 
 from kraken.base_api import defined
 from kraken.exceptions import KrakenException
@@ -508,7 +508,7 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
         await self.send_message(message=payload)
 
     @property
-    def public_channel_names(self: KrakenSpotWSClientV2) -> List[str]:
+    def public_channel_names(self: KrakenSpotWSClientV2) -> list[str]:
         """
         Returns the list of valid values for ``channel`` when un-/subscribing
         from/to public feeds without authentication.
@@ -529,7 +529,7 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
         return ["book", "instrument", "ohlc", "ticker", "trade"]
 
     @property
-    def private_channel_names(self: KrakenSpotWSClientV2) -> List[str]:
+    def private_channel_names(self: KrakenSpotWSClientV2) -> list[str]:
         """
         Returns the list of valid values for ``channel`` when un-/subscribing
         from/to private feeds that need authentication.
@@ -546,7 +546,7 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
         return ["executions"]
 
     @property
-    def private_methods(self: KrakenSpotWSClientV2) -> List[str]:
+    def private_methods(self: KrakenSpotWSClientV2) -> list[str]:
         """
         Returns the list of available methods - parameters are  similar to the
         REST API trade methods.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 description = "Collection of REST and websocket clients to interact with the Kraken cryptocurrency exchange."
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.12"
 dependencies = ["asyncio>=3.4", "requests", "websockets"]
 keywords = ["crypto", "trading", "kraken", "exchange", "api"]
 classifiers = [
@@ -28,11 +28,7 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP",
   "Topic :: Utilities",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Framework :: AsyncIO",
   "Natural Language :: English",
   "Operating System :: MacOS",
@@ -116,7 +112,7 @@ skip_empty = true
 # ========= T Y P I N G =======================================================
 #
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.12"
 
 # junit_xml = "mypy.xml"
 files = ["kraken/**/*.py"]
@@ -392,7 +388,7 @@ persistent = true
 
 # Minimum Python version to use for version dependent checks. Will default to the
 # version used to run pylint.
-py-version = "3.11"
+py-version = "3.12"
 
 # Discover python modules and packages in the file system subtree.
 # recursive =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ python_version = "3.12"
 files = ["kraken/**/*.py"]
 exclude = ["tests/*/*.py"]
 
-cache_dir = ".mypy_cache"
+cache_dir = ".cache/mypy"
 sqlite_cache = true
 cache_fine_grained = true
 


### PR DESCRIPTION
# Summary


follow up:

* rename KrakenBaseSpotAPI to KrakenSpotBaseAPI (and for futures too…)