### PR TITLE
Resolve "Rename `KrakenBaseSpotAPI` to `KrakenSpotBaseAPI` and `KrakenBaseFuturesAPI` to `KrakenFuturesBaseAPI`"

### DIFF
--- a/docs/src/base_api/base_api.rst
+++ b/docs/src/base_api/base_api.rst
@@ -10,12 +10,12 @@ avoid using them, since these are internals and may change without any warning.
 
 They are the base classes for Spot and Futures REST and websocket clients.
 
-.. autoclass:: kraken.base_api.KrakenBaseSpotAPI
+.. autoclass:: kraken.base_api.KrakenSpotBaseAPI
    :members:
    :show-inheritance:
    :inherited-members:
 
-.. autoclass:: kraken.base_api.KrakenBaseFuturesAPI
+.. autoclass:: kraken.base_api.KrakenFuturesBaseAPI
    :members:
    :show-inheritance:
    :inherited-members:

--- a/docs/src/introduction.rst
+++ b/docs/src/introduction.rst
@@ -24,8 +24,8 @@ and documented.
 - The output in the examples may differ, as these are only intended as examples
   and may change in the future.
 - If a certain endpoint is not reachable, the function
-  :func:`kraken.base_api.KrakenBaseSpotAPI._request` or
-  :func:`kraken.base_api.KrakenBaseFuturesAPI._request`,
+  :func:`kraken.base_api.KrakenSpotBaseAPI._request` or
+  :func:`kraken.base_api.KrakenFuturesBaseAPI._request`,
   which is also available in all derived REST clients, can be used to reach an
   endpoint with the appropriate parameters. Here private content can also be
   accessed, provided that either the base class or one of the clients has been

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -166,7 +166,7 @@ class KrakenErrorHandler:
         return data
 
 
-class KrakenBaseSpotAPI:
+class KrakenSpotBaseAPI:
     """
     This class the the base for all Spot clients, handles un-/signed
     requests and returns exception handled results.
@@ -186,7 +186,7 @@ class KrakenBaseSpotAPI:
     API_V: str = "/0"
 
     def __init__(
-        self: KrakenBaseSpotAPI,
+        self: KrakenSpotBaseAPI,
         key: str = "",
         secret: str = "",
         url: str = "",
@@ -210,7 +210,7 @@ class KrakenBaseSpotAPI:
         self.__session.headers.update({"User-Agent": "python-kraken-sdk"})
 
     def _request(  # noqa: PLR0913
-        self: KrakenBaseSpotAPI,
+        self: KrakenSpotBaseAPI,
         method: str,
         uri: str,
         params: Optional[dict] = None,
@@ -337,7 +337,7 @@ class KrakenBaseSpotAPI:
         )
 
     def _get_kraken_signature(
-        self: KrakenBaseSpotAPI,
+        self: KrakenSpotBaseAPI,
         url_path: str,
         data: str,
         nonce: int,
@@ -365,7 +365,7 @@ class KrakenBaseSpotAPI:
         ).decode()
 
     def __check_response_data(
-        self: KrakenBaseSpotAPI,
+        self: KrakenSpotBaseAPI,
         response: requests.Response,
         *,
         return_raw: bool = False,
@@ -399,7 +399,7 @@ class KrakenBaseSpotAPI:
         raise Exception(f"{response.status_code} - {response.text}")
 
     @property
-    def return_unique_id(self: KrakenBaseSpotAPI) -> str:
+    def return_unique_id(self: KrakenSpotBaseAPI) -> str:
         """Returns a unique uuid string
 
         :return: uuid
@@ -411,14 +411,14 @@ class KrakenBaseSpotAPI:
         return self
 
     def __exit__(
-        self: KrakenBaseSpotAPI,
+        self: KrakenSpotBaseAPI,
         *exc: object,
         **kwargs: dict[str, Any],
     ) -> None:
         pass
 
 
-class KrakenBaseFuturesAPI:
+class KrakenFuturesBaseAPI:
     """
     The base class for all Futures clients handles un-/signed requests
     and returns exception handled results.
@@ -440,7 +440,7 @@ class KrakenBaseFuturesAPI:
     SANDBOX_URL: str = "https://demo-futures.kraken.com"
 
     def __init__(
-        self: KrakenBaseFuturesAPI,
+        self: KrakenFuturesBaseAPI,
         key: str = "",
         secret: str = "",
         url: str = "",
@@ -466,7 +466,7 @@ class KrakenBaseFuturesAPI:
         self.__session.headers.update({"User-Agent": "python-kraken-sdk"})
 
     def _request(  # noqa: PLR0913
-        self: KrakenBaseFuturesAPI,
+        self: KrakenFuturesBaseAPI,
         method: str,
         uri: str,
         post_params: Optional[dict] = None,
@@ -598,7 +598,7 @@ class KrakenBaseFuturesAPI:
         )
 
     def _get_kraken_futures_signature(
-        self: KrakenBaseFuturesAPI,
+        self: KrakenFuturesBaseAPI,
         endpoint: str,
         data: str,
         nonce: str,
@@ -630,7 +630,7 @@ class KrakenBaseFuturesAPI:
         ).decode()
 
     def __check_response_data(
-        self: KrakenBaseFuturesAPI,
+        self: KrakenFuturesBaseAPI,
         response: requests.Response,
         *,
         return_raw: bool = False,
@@ -678,4 +678,4 @@ class KrakenBaseFuturesAPI:
         pass
 
 
-__all__ = ["defined", "ensure_string", "KrakenBaseSpotAPI", "KrakenBaseFuturesAPI"]
+__all__ = ["defined", "ensure_string", "KrakenSpotBaseAPI", "KrakenFuturesBaseAPI"]

--- a/kraken/futures/funding.py
+++ b/kraken/futures/funding.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 
 from typing import Optional, TypeVar
 
-from kraken.base_api import KrakenBaseFuturesAPI
+from kraken.base_api import KrakenFuturesBaseAPI
 
 Self = TypeVar("Self")
 
 
-class Funding(KrakenBaseFuturesAPI):
+class Funding(KrakenFuturesBaseAPI):
     """
     Class that implements the Kraken Futures Funding client
 

--- a/kraken/futures/market.py
+++ b/kraken/futures/market.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Optional, TypeVar
 
-from kraken.base_api import KrakenBaseFuturesAPI, defined, ensure_string
+from kraken.base_api import KrakenFuturesBaseAPI, defined, ensure_string
 
 Self = TypeVar("Self")
 
 
-class Market(KrakenBaseFuturesAPI):
+class Market(KrakenFuturesBaseAPI):
 
     """
     Class that implements the Kraken Futures market client

--- a/kraken/futures/trade.py
+++ b/kraken/futures/trade.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from typing import Optional, TypeVar
 
-from kraken.base_api import KrakenBaseFuturesAPI, defined
+from kraken.base_api import KrakenFuturesBaseAPI, defined
 
 Self = TypeVar("Self")
 
 
-class Trade(KrakenBaseFuturesAPI):
+class Trade(KrakenFuturesBaseAPI):
     """
     Class that implements the Kraken Futures trade client
 

--- a/kraken/futures/user.py
+++ b/kraken/futures/user.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, TypeVar
 
-from kraken.base_api import KrakenBaseFuturesAPI, defined
+from kraken.base_api import KrakenFuturesBaseAPI, defined
 
 if TYPE_CHECKING:
     import requests
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 Self = TypeVar("Self")
 
 
-class User(KrakenBaseFuturesAPI):
+class User(KrakenFuturesBaseAPI):
     """
     Class that implements the Kraken Futures user client
 

--- a/kraken/futures/ws_client.py
+++ b/kraken/futures/ws_client.py
@@ -15,14 +15,14 @@ import logging
 from copy import deepcopy
 from typing import Any, Optional, TypeVar
 
-from kraken.base_api import KrakenBaseFuturesAPI
+from kraken.base_api import KrakenFuturesBaseAPI
 from kraken.exceptions import KrakenException
 from kraken.futures.websocket import ConnectFuturesWebsocket
 
 Self = TypeVar("Self")
 
 
-class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
+class KrakenFuturesWSClient(KrakenFuturesBaseAPI):
     """
     Class to access public and (optional)
     private/authenticated websocket connection.
@@ -137,7 +137,7 @@ class KrakenFuturesWSClient(KrakenBaseFuturesAPI):
         )
 
     @property
-    def key(self: KrakenBaseFuturesAPI) -> str:
+    def key(self: KrakenFuturesBaseAPI) -> str:
         """Returns the API key"""
         return self.__key
 

--- a/kraken/spot/funding.py
+++ b/kraken/spot/funding.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from typing import Optional, TypeVar
 
-from kraken.base_api import KrakenBaseSpotAPI, defined
+from kraken.base_api import KrakenSpotBaseAPI, defined
 
 Self = TypeVar("Self")
 
 
-class Funding(KrakenBaseSpotAPI):
+class Funding(KrakenSpotBaseAPI):
     """
     Class that implements the Spot Funding client. Currently there
     are no funding endpoints that could be accesses without authentication.

--- a/kraken/spot/market.py
+++ b/kraken/spot/market.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Optional, TypeVar
 
-from kraken.base_api import KrakenBaseSpotAPI, defined, ensure_string
+from kraken.base_api import KrakenSpotBaseAPI, defined, ensure_string
 
 Self = TypeVar("Self")
 
 
-class Market(KrakenBaseSpotAPI):
+class Market(KrakenSpotBaseAPI):
     """
     Class that implements the Kraken Spot Market client. Can be used to access
     the Kraken Spot market data.

--- a/kraken/spot/staking.py
+++ b/kraken/spot/staking.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from typing import Optional, TypeVar
 
-from kraken.base_api import KrakenBaseSpotAPI, defined
+from kraken.base_api import KrakenSpotBaseAPI, defined
 
 Self = TypeVar("Self")
 
 
-class Staking(KrakenBaseSpotAPI):
+class Staking(KrakenSpotBaseAPI):
     """
     Class that implements the Kraken Spot Staking client. Currently there
     are no staking endpoints that could be accesses without authentication.

--- a/kraken/spot/trade.py
+++ b/kraken/spot/trade.py
@@ -13,13 +13,13 @@ from functools import lru_cache
 from math import floor
 from typing import Optional, TypeVar
 
-from kraken.base_api import KrakenBaseSpotAPI, defined, ensure_string
+from kraken.base_api import KrakenSpotBaseAPI, defined, ensure_string
 from kraken.spot.market import Market
 
 Self = TypeVar("Self")
 
 
-class Trade(KrakenBaseSpotAPI):
+class Trade(KrakenSpotBaseAPI):
     """
     Class that implements the Kraken Trade Spot client
 

--- a/kraken/spot/user.py
+++ b/kraken/spot/user.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Optional, TypeVar
 
-from kraken.base_api import KrakenBaseSpotAPI, defined, ensure_string
+from kraken.base_api import KrakenSpotBaseAPI, defined, ensure_string
 
 Self = TypeVar("Self")
 
 
-class User(KrakenBaseSpotAPI):
+class User(KrakenSpotBaseAPI):
     """
     Class that implements the Kraken Spot User client
 

--- a/kraken/spot/websocket/__init__.py
+++ b/kraken/spot/websocket/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Optional, Type, TypeVar
 
-from kraken.base_api import KrakenBaseSpotAPI
+from kraken.base_api import KrakenSpotBaseAPI
 from kraken.spot.websocket.connectors import (
     ConnectSpotWebsocketV1,
     ConnectSpotWebsocketV2,
@@ -22,7 +22,7 @@ from kraken.spot.websocket.connectors import (
 Self = TypeVar("Self")
 
 
-class KrakenSpotWSClientBase(KrakenBaseSpotAPI):
+class KrakenSpotWSClientBase(KrakenSpotBaseAPI):
     """
     This is the base class for :class:`kraken.spot.KrakenSpotWSClient` and
     :class:`kraken.spot.KrakenSpotWSClientV2`. It extends the REST API base

--- a/tests/futures/test_futures_base_api.py
+++ b/tests/futures/test_futures_base_api.py
@@ -8,7 +8,7 @@
 
 import pytest
 
-from kraken.base_api import KrakenBaseFuturesAPI
+from kraken.base_api import KrakenFuturesBaseAPI
 from kraken.exceptions import KrakenException
 from kraken.futures import Funding, Market, Trade, User
 
@@ -16,21 +16,21 @@ from .helper import is_success
 
 
 @pytest.mark.futures()
-def test_KrakenBaseFuturesAPI_without_exception() -> None:
+def test_KrakenFuturesBaseAPI_without_exception() -> None:
     """
     Checks first if the expected error will be raised and than
-    creates a new KrakenBaseFuturesAPI instance that do not raise
+    creates a new KrakenFuturesBaseAPI instance that do not raise
     the custom Kraken exceptions. This new instance than executes
     the same request and the returned response gets evaluated.
     """
     with pytest.raises(KrakenException.KrakenRequiredArgumentMissingError):
-        KrakenBaseFuturesAPI(
+        KrakenFuturesBaseAPI(
             key="fake",
             secret="fake",
         )._request(method="POST", uri="/derivatives/api/v3/sendorder", auth=True)
 
     result: dict = (
-        KrakenBaseFuturesAPI(key="fake", secret="fake", use_custom_exceptions=False)  # type: ignore[union-attr]
+        KrakenFuturesBaseAPI(key="fake", secret="fake", use_custom_exceptions=False)  # type: ignore[union-attr]
         ._request(method="POST", uri="/derivatives/api/v3/sendorder", auth=True)
         .json()
     )

--- a/tests/spot/test_spot_base_api.py
+++ b/tests/spot/test_spot_base_api.py
@@ -8,7 +8,7 @@
 
 import pytest
 
-from kraken.base_api import KrakenBaseSpotAPI
+from kraken.base_api import KrakenSpotBaseAPI
 from kraken.exceptions import KrakenException
 from kraken.spot import Funding, Market, Staking, Trade, User
 
@@ -16,20 +16,20 @@ from .helper import is_not_error
 
 
 @pytest.mark.spot()
-def test_KrakenBaseSpotAPI_without_exception() -> None:
+def test_KrakenSpotBaseAPI_without_exception() -> None:
     """
     Checks first if the expected error will be raised and than
-    creates a new KrakenBaseSpotAPI instance that do not raise
+    creates a new KrakenSpotBaseAPI instance that do not raise
     the custom Kraken exceptions. This new instance than executes
     the same request and the returned response gets evaluated.
     """
     with pytest.raises(KrakenException.KrakenInvalidAPIKeyError):
-        KrakenBaseSpotAPI(
+        KrakenSpotBaseAPI(
             key="fake",
             secret="fake",
         )._request(method="POST", uri="/private/AddOrder", auth=True)
 
-    assert KrakenBaseSpotAPI(
+    assert KrakenSpotBaseAPI(
         key="fake",
         secret="fake",
         use_custom_exceptions=False,


### PR DESCRIPTION
# Summary

The base clients were renamed.