### PR TITLE
Resolve "Rename `kraken.spot.KrakenSpotWSClient` to `kraken.spot.KrakenSpotWSClientV1`"

### DIFF
--- a/docs/src/introduction.rst
+++ b/docs/src/introduction.rst
@@ -32,7 +32,7 @@ and documented.
   initialized with valid credentials.
 - For Futures there is only one websocket client -
   :class:`kraken.futures.KrakenFuturesWSClient`. For Spot there are two:
-  :class:`kraken.spot.KrakenSpotWSClient` (for API version 1) and
+  :class:`kraken.spot.KrakenSpotWSClientV1` (for API version 1) and
   :class:`kraken.spot.KrakenSpotWSClientV2` (for API version 2).
 
 

--- a/docs/src/spot/websockets.rst
+++ b/docs/src/spot/websockets.rst
@@ -10,7 +10,7 @@ Spot Websockets
    :show-inheritance:
    :inherited-members:
 
-.. autoclass:: kraken.spot.KrakenSpotWSClient
+.. autoclass:: kraken.spot.KrakenSpotWSClientV1
    :members:
    :show-inheritance:
    :inherited-members:

--- a/examples/spot_orderbook_v1.py
+++ b/examples/spot_orderbook_v1.py
@@ -48,7 +48,7 @@ class Orderbook(OrderbookClientV1):
     This is a wrapper class that is used to overload the :func:`on_book_update`
     function. It can also be used as a base for trading strategy. Since the
     :class:`kraken.spot.OrderbookClientV1` is derived from
-    :class:`kraken.spot.KrakenSpotWSClient` it can also be used to access the
+    :class:`kraken.spot.KrakenSpotWSClientV1` it can also be used to access the
     :func:`subscribe` function and any other provided utility.
     """
 

--- a/examples/spot_trading_bot_template_v1.py
+++ b/examples/spot_trading_bot_template_v1.py
@@ -22,7 +22,7 @@ import requests
 import urllib3
 
 from kraken.exceptions import KrakenException
-from kraken.spot import Funding, KrakenSpotWSClient, Market, Staking, Trade, User
+from kraken.spot import Funding, KrakenSpotWSClientV1, Market, Staking, Trade, User
 
 logging.basicConfig(
     format="%(asctime)s %(module)s,line: %(lineno)d %(levelname)8s | %(message)s",
@@ -33,7 +33,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
-class TradingBot(KrakenSpotWSClient):
+class TradingBot(KrakenSpotWSClientV1):
     """
     Class that implements the trading strategy
 
@@ -52,7 +52,7 @@ class TradingBot(KrakenSpotWSClient):
     """
 
     def __init__(self: TradingBot, config: dict) -> None:
-        super().__init__(  # initialize the KrakenSpotWSClient
+        super().__init__(  # initialize the KrakenSpotWSClientV1
             key=config["key"],
             secret=config["secret"],
         )
@@ -160,7 +160,7 @@ class ManagedBot:
         run the loop.
 
         This variable `exception_occur` which is an attribute of the
-        KrakenSpotWSClient can be set individually but is also being set to
+        KrakenSpotWSClientV1 can be set individually but is also being set to
         `True` if the websocket connection has some fatal error. This is used to
         exit the asyncio loop - but you can also apply your own reconnect rules.
         """

--- a/examples/spot_trading_bot_template_v2.py
+++ b/examples/spot_trading_bot_template_v2.py
@@ -167,7 +167,7 @@ class ManagedBot:
         loop.
 
         The variable `exception_occur` which is an attribute of the
-        KrakenSpotWSClient can be set individually but is also being set to
+        KrakenSpotWSClientV2 can be set individually but is also being set to
         `True` if the websocket connection has some fatal error. This is used to
         exit the asyncio loop - but you can also apply your own reconnect rules.
         """

--- a/examples/spot_ws_examples_v1.py
+++ b/examples/spot_ws_examples_v1.py
@@ -18,7 +18,7 @@ import os
 from contextlib import suppress
 from typing import Union
 
-from kraken.spot import KrakenSpotWSClient
+from kraken.spot import KrakenSpotWSClientV1
 
 logging.basicConfig(
     format="%(asctime)s %(module)s,line: %(lineno)d %(levelname)8s | %(message)s",
@@ -35,7 +35,7 @@ async def main() -> None:
     key: str = os.getenv("SPOT_API_KEY")
     secret: str = os.getenv("SPOT_SECRET_KEY")
 
-    class Client(KrakenSpotWSClient):
+    class Client(KrakenSpotWSClientV1):
         """Can be used to create a custom trading strategy"""
 
         async def on_message(self: Client, message: Union[list, dict]) -> None:
@@ -107,14 +107,14 @@ if __name__ == "__main__":
 # ============================================================
 # Alternative - as ContextManager:
 
-# from kraken.spot import KrakenSpotWSClient
+# from kraken.spot import KrakenSpotWSClientV1
 # import asyncio
 
 # async def on_message(msg):
 #     print(msg)
 
 # async def main() -> None:
-#     async with KrakenSpotWSClient(callback=on_message) as session:
+#     async with KrakenSpotWSClientV1(callback=on_message) as session:
 #         await session.subscribe(subscription={"name": "ticker"}, pair=["XBT/USD"])
 
 #     while True:

--- a/kraken/spot/__init__.py
+++ b/kraken/spot/__init__.py
@@ -13,7 +13,7 @@ from kraken.spot.orderbook_v2 import OrderbookClientV2
 from kraken.spot.staking import Staking
 from kraken.spot.trade import Trade
 from kraken.spot.user import User
-from kraken.spot.websocket_v1 import KrakenSpotWSClient
+from kraken.spot.websocket_v1 import KrakenSpotWSClientV1
 from kraken.spot.websocket_v2 import KrakenSpotWSClientV2
 
 __all__ = [
@@ -24,6 +24,6 @@ __all__ = [
     "User",
     "OrderbookClientV1",
     "OrderbookClientV2",
-    "KrakenSpotWSClient",
+    "KrakenSpotWSClientV1",
     "KrakenSpotWSClientV2",
 ]

--- a/kraken/spot/orderbook_v1.py
+++ b/kraken/spot/orderbook_v1.py
@@ -15,7 +15,7 @@ from collections import OrderedDict
 from inspect import iscoroutinefunction
 from typing import Callable, Optional
 
-from kraken.spot.websocket_v1 import KrakenSpotWSClient
+from kraken.spot.websocket_v1 import KrakenSpotWSClientV1
 
 
 class OrderbookClientV1:
@@ -123,7 +123,7 @@ class OrderbookClientV1:
         self.__depth: int = depth
         self.__callback: Optional[Callable] = callback
 
-        self.ws_client: KrakenSpotWSClient = KrakenSpotWSClient(
+        self.ws_client: KrakenSpotWSClientV1 = KrakenSpotWSClientV1(
             callback=self.on_message,
         )
 

--- a/kraken/spot/websocket/__init__.py
+++ b/kraken/spot/websocket/__init__.py
@@ -24,7 +24,7 @@ Self = TypeVar("Self")
 
 class KrakenSpotWSClientBase(KrakenSpotBaseAPI):
     """
-    This is the base class for :class:`kraken.spot.KrakenSpotWSClient` and
+    This is the base class for :class:`kraken.spot.KrakenSpotWSClientV1` and
     :class:`kraken.spot.KrakenSpotWSClientV2`. It extends the REST API base
     class and is used to provide the base functionalities that are used
     for Kraken Websocket API v1 and v2.
@@ -138,7 +138,7 @@ class KrakenSpotWSClientBase(KrakenSpotBaseAPI):
         have to overwrite this function since it will receive all incoming
         messages that will be sent by Kraken.
 
-        See :class:`kraken.spot.KrakenSpotWSClient` and
+        See :class:`kraken.spot.KrakenSpotWSClientV1` and
         :class:`kraken.spot.KrakenSpotWSClientV2` for examples to use this
         function.
 

--- a/kraken/spot/websocket_v1.py
+++ b/kraken/spot/websocket_v1.py
@@ -22,7 +22,7 @@ from kraken.spot.trade import Trade
 from kraken.spot.websocket import KrakenSpotWSClientBase
 
 
-class KrakenSpotWSClient(KrakenSpotWSClientBase):
+class KrakenSpotWSClientV1(KrakenSpotWSClientBase):
     """
     Class to access public and private/authenticated websocket connections.
 
@@ -61,10 +61,10 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :caption: HowTo: Use the Kraken Spot websocket client (v1)
 
         import asyncio
-        from kraken.spot import KrakenSpotWSClient
+        from kraken.spot import KrakenSpotWSClientV1
 
 
-        class Client(KrakenSpotWSClient):
+        class Client(KrakenSpotWSClientV1):
 
             async def on_message(self, message):
                 print(message)
@@ -99,14 +99,14 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :caption: HowTo: Use the websocket client (v1) as instance
 
         import asyncio
-        from kraken.spot import KrakenSpotWSClient
+        from kraken.spot import KrakenSpotWSClientV1
 
 
         async def main() -> None:
             async def on_message(message) -> None:
                 print(message)
 
-            client = KrakenSpotWSClient(callback=on_message)
+            client = KrakenSpotWSClientV1(callback=on_message)
             await client.subscribe(
                 subscription={"name": "ticker"},
                 pair=["XBT/USD"]
@@ -128,13 +128,13 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :caption: HowTo: Use the websocket client (v1) as context manager
 
         import asyncio
-        from kraken.spot import KrakenSpotWSClient
+        from kraken.spot import KrakenSpotWSClientV1
 
         async def on_message(message):
             print(message)
 
         async def main() -> None:
-            async with KrakenSpotWSClient(
+            async with KrakenSpotWSClientV1(
                 key="api-key",
                 secret="secret-key",
                 callback=on_message
@@ -156,7 +156,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
     """
 
     def __init__(
-        self: KrakenSpotWSClient,
+        self: KrakenSpotWSClientV1,
         key: str = "",
         secret: str = "",
         callback: Optional[Callable] = None,
@@ -174,7 +174,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         )
 
     async def send_message(  # pylint: disable=arguments-differ
-        self: KrakenSpotWSClient,
+        self: KrakenSpotWSClientV1,
         message: dict,
         *,
         private: bool = False,
@@ -215,7 +215,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         await socket.send(json.dumps(message))
 
     async def subscribe(  # pylint: disable=arguments-differ
-        self: KrakenSpotWSClient,
+        self: KrakenSpotWSClientV1,
         subscription: dict,
         pair: Optional[list[str]] = None,
     ) -> None:
@@ -237,7 +237,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :type pair: list[str], optional
 
         Initialize your client as described in
-        :class:`kraken.spot.KrakenSpotWSClient` to run the following example:
+        :class:`kraken.spot.KrakenSpotWSClientV1` to run the following example:
 
         .. code-block:: python
             :linenos:
@@ -287,7 +287,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
             # await self.send_message(payload, private=False)
 
     async def unsubscribe(  # pylint: disable=arguments-differ
-        self: KrakenSpotWSClient,
+        self: KrakenSpotWSClientV1,
         subscription: dict,
         pair: Optional[list[str]] = None,
     ) -> None:
@@ -309,7 +309,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :type pair: list[str], optional
 
         Initialize your client as described in
-        :class:`kraken.spot.KrakenSpotWSClient` to run the following example:
+        :class:`kraken.spot.KrakenSpotWSClientV1` to run the following example:
 
         .. code-block:: python
             :linenos:
@@ -359,7 +359,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
             # await self.send_message(payload, private=False)
 
     @property
-    def public_channel_names(self: KrakenSpotWSClient) -> list[str]:
+    def public_channel_names(self: KrakenSpotWSClientV1) -> list[str]:
         """
         Returns the public subscription names
 
@@ -370,7 +370,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         return ["ticker", "spread", "book", "ohlc", "trade", "*"]
 
     @property
-    def private_channel_names(self: KrakenSpotWSClient) -> list[str]:
+    def private_channel_names(self: KrakenSpotWSClientV1) -> list[str]:
         """
         Returns the private subscription names
 
@@ -382,7 +382,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
 
     @ensure_string("oflags")
     async def create_order(  # noqa: PLR0913
-        self: KrakenSpotWSClient,
+        self: KrakenSpotWSClientV1,
         ordertype: str,
         side: str,
         pair: str,
@@ -473,7 +473,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :rtype: None
 
         Initialize your client as described in
-        :class:`kraken.spot.KrakenSpotWSClient` to run the following example:
+        :class:`kraken.spot.KrakenSpotWSClientV1` to run the following example:
 
         .. code-block:: python
             :linenos:
@@ -549,7 +549,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
 
     @ensure_string("oflags")
     async def edit_order(  # noqa: PLR0913
-        self: KrakenSpotWSClient,
+        self: KrakenSpotWSClientV1,
         orderid: str,
         reqid: Optional[str | int] = None,
         pair: Optional[str] = None,
@@ -600,7 +600,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :rtype: None
 
         Initialize your client as described in
-        :class:`kraken.spot.KrakenSpotWSClient` to run the following example:
+        :class:`kraken.spot.KrakenSpotWSClientV1` to run the following example:
 
         .. code-block:: python
             :linenos:
@@ -648,7 +648,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
 
         await self.send_message(message=payload, private=True)
 
-    async def cancel_order(self: KrakenSpotWSClient, txid: list[str]) -> None:
+    async def cancel_order(self: KrakenSpotWSClientV1, txid: list[str]) -> None:
         """
         Cancel a specific order or a list of orders.
 
@@ -664,7 +664,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :return: None
 
         Initialize your client as described in
-        :class:`kraken.spot.KrakenSpotWSClient` to run the following example:
+        :class:`kraken.spot.KrakenSpotWSClientV1` to run the following example:
 
         .. code-block:: python
             :linenos:
@@ -681,7 +681,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
             private=True,
         )
 
-    async def cancel_all_orders(self: KrakenSpotWSClient) -> None:
+    async def cancel_all_orders(self: KrakenSpotWSClientV1) -> None:
         """
         Cancel all open Spot orders.
 
@@ -695,7 +695,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :return: None
 
         Initialize your client as described in
-        :class:`kraken.spot.KrakenSpotWSClient` to run the following example:
+        :class:`kraken.spot.KrakenSpotWSClientV1` to run the following example:
 
         .. code-block:: python
             :linenos:
@@ -710,7 +710,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         await self.send_message(message={"event": "cancelAll"}, private=True)
 
     async def cancel_all_orders_after(
-        self: KrakenSpotWSClient,
+        self: KrakenSpotWSClientV1,
         timeout: int = 0,
     ) -> None:
         """
@@ -729,7 +729,7 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         :return: None
 
         Initialize your client as described in
-        :class:`kraken.spot.KrakenSpotWSClient` to run the following example:
+        :class:`kraken.spot.KrakenSpotWSClientV1` to run the following example:
 
         .. code-block:: python
             :linenos:
@@ -747,4 +747,4 @@ class KrakenSpotWSClient(KrakenSpotWSClientBase):
         )
 
 
-__all__ = ["KrakenSpotWSClient"]
+__all__ = ["KrakenSpotWSClientV1"]

--- a/kraken/spot/websocket_v2.py
+++ b/kraken/spot/websocket_v2.py
@@ -28,7 +28,7 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
 
     - https://docs.kraken.com/websockets-v2
 
-    … please use :class:`KrakenSpotWSClient` for accessing the Kraken's
+    … please use :class:`kraken.spot.KrakenSpotWSClientV1` for accessing the Kraken's
     Websocket API v1.
 
     This class holds up to two websocket connections, one private

--- a/tests/spot/helper.py
+++ b/tests/spot/helper.py
@@ -19,7 +19,7 @@ from time import time
 from typing import Any, Union
 
 from kraken.spot import (
-    KrakenSpotWSClient,
+    KrakenSpotWSClientV1,
     KrakenSpotWSClientV2,
     OrderbookClientV1,
     OrderbookClientV2,
@@ -40,9 +40,9 @@ async def async_wait(seconds: float = 1.0) -> None:
         await sleep(0.2)
 
 
-class SpotWebsocketClientV1TestWrapper(KrakenSpotWSClient):
+class SpotWebsocketClientV1TestWrapper(KrakenSpotWSClientV1):
     """
-    Class that creates an instance to test the KrakenSpotWSClient.
+    Class that creates an instance to test the KrakenSpotWSClientV1.
 
     It writes the messages to the log and a file. The log is used
     within the tests, the log file is for local debugging.

--- a/tests/spot/test_spot_orderbook_v1.py
+++ b/tests/spot/test_spot_orderbook_v1.py
@@ -67,7 +67,7 @@ def test_get_first() -> None:
 @pytest.mark.wip()
 @pytest.mark.spot()
 @pytest.mark.spot_orderbook()
-@mock.patch("kraken.spot.orderbook_v1.KrakenSpotWSClient", return_value=None)
+@mock.patch("kraken.spot.orderbook_v1.KrakenSpotWSClientV1", return_value=None)
 @mock.patch(
     "kraken.spot.orderbook_v1.OrderbookClientV1.remove_book",
     return_value=mock.AsyncMock(),


### PR DESCRIPTION
# Summary

As the linked issue mentions - the spot websocket client for Krakens API v1 was renamed.