### PR TITLE
Adjust docstrings and documentation

### DIFF
--- a/docs/src/base_api/base_api.rst
+++ b/docs/src/base_api/base_api.rst
@@ -2,8 +2,8 @@
 .. Copyright (C) 2023 Benjamin Thomas Schwertfeger
 .. GitHub: https://github.com/btschwertfeger
 
-The Base Clients and Internals
-==============================
+Base Clients and Internals
+==========================
 
 The following classes and data structures are listed for completeness. Please
 avoid using them since these are internals and may change without any warning.

--- a/docs/src/examples/rest_ws_samples/futures_rest_examples.rst
+++ b/docs/src/examples/rest_ws_samples/futures_rest_examples.rst
@@ -3,7 +3,7 @@
 .. Copyright (C) 2023 Benjamin Thomas Schwertfeger
 .. GitHub: https://github.com/btschwertfeger
 
-Futures Rest
+Futures REST
 ------------
 
 The examples presented below serve to demonstrate the usage of the Futures
@@ -19,4 +19,4 @@ individual functions.
 .. literalinclude:: ../../../../examples/futures_examples.py
    :language: python
    :linenos:
-   :caption: Example usages of the REST clients
+   :caption: Example usage of Futures REST clients

--- a/docs/src/examples/rest_ws_samples/spot_rest_examples.rst
+++ b/docs/src/examples/rest_ws_samples/spot_rest_examples.rst
@@ -2,7 +2,7 @@
 .. Copyright (C) 2023 Benjamin Thomas Schwertfeger
 .. GitHub: https://github.com/btschwertfeger
 
-Spot Rest
+Spot REST
 ---------
 
 The examples presented below serve to demonstrate the usage of the Spot
@@ -18,4 +18,4 @@ individual functions.
 .. literalinclude:: ../../../../examples/spot_examples.py
    :language: python
    :linenos:
-   :caption: Example usages of the REST clients
+   :caption: Example usage of Spot REST clients

--- a/docs/src/examples/trading_bot_templates/spot_bot_templates.rst
+++ b/docs/src/examples/trading_bot_templates/spot_bot_templates.rst
@@ -5,7 +5,7 @@
 .. The spot trading bot templates
 
 Spot Trading Bot Templates
--------------------------
+--------------------------
 
 The templates presented below serve as starting points for the development of
 a trading algorithms for Spot trading on the cryptocurrency exchange `Kraken`_

--- a/kraken/futures/funding.py
+++ b/kraken/futures/funding.py
@@ -25,9 +25,11 @@ class Funding(KrakenFuturesBaseAPI):
     :type key: str, optional
     :param secret: Futures API secret key (default: ``""``)
     :type secret: str, optional
-    :param url: Alternative URL to access the Futures Kraken API (default: https://futures.kraken.com)
+    :param url: Alternative URL to access the Futures Kraken API (default:
+        https://futures.kraken.com)
     :type url: str, optional
-    :param sandbox: If set to ``True`` the URL will be https://demo-futures.kraken.com (default: ``False``)
+    :param sandbox: If set to ``True`` the URL will be
+        https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -68,7 +70,8 @@ class Funding(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve information about the historical funding rates of a specific ``symbol``
+        Retrieve information about the historical funding rates of a specific
+        ``symbol``
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-historical-funding-rates-historicalfundingrates
 
@@ -115,10 +118,11 @@ class Funding(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Submit a wallet transfer request to transfer funds between margin accounts.
+        Submit a wallet transfer request to transfer funds between margin
+        accounts.
 
-        Requires the ``General API - Full Access`` and ``Withdrawal API - Full access``
-        permissions in the API key settings.
+        Requires the ``General API - Full Access`` and ``Withdrawal API - Full
+        access`` permissions in the API key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-transfers-initiate-wallet-transfer
 
@@ -175,8 +179,8 @@ class Funding(KrakenFuturesBaseAPI):
         """
         Submit a request to transfer funds between the regular and subaccount.
 
-        Requires the ``General API - Full Access`` and ``Withdrawal API - Full access``
-        permissions in the API key settings.
+        Requires the ``General API - Full Access`` and ``Withdrawal API - Full
+        access`` permissions in the API key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-transfers-initiate-sub-account-transfer
 
@@ -232,8 +236,8 @@ class Funding(KrakenFuturesBaseAPI):
         """
         Enables the transfer of funds between the futures and spot wallet.
 
-        Requires the ``General API - Full Access`` and ``Withdrawal API - Full access``
-        permissions in the API key settings.
+        Requires the ``General API - Full Access`` and ``Withdrawal API - Full
+        access`` permissions in the API key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-transfers-initiate-withdrawal-to-spot-wallet
 
@@ -243,7 +247,8 @@ class Funding(KrakenFuturesBaseAPI):
         :type currency: str
         :param sourceWallet: The wallet to withdraw from (default: ``cash``)
         :type sourceWallet: str, optional
-        :raises ValueError: If this function is called within the sandbox/demo environment
+        :raises ValueError: If this function is called within the sandbox/demo
+            environment
 
         .. code-block:: python
             :linenos:

--- a/kraken/futures/market.py
+++ b/kraken/futures/market.py
@@ -17,7 +17,6 @@ Self = TypeVar("Self")
 
 
 class Market(KrakenFuturesBaseAPI):
-
     """
     Class that implements the Kraken Futures market client
 
@@ -28,9 +27,11 @@ class Market(KrakenFuturesBaseAPI):
     :type key: str, optional
     :param secret: Futures API secret key (default: ``""``)
     :type secret: str, optional
-    :param url: Alternative URL to access the Futures Kraken API (default: https://futures.kraken.com)
+    :param url: Alternative URL to access the Futures Kraken API (default:
+        https://futures.kraken.com)
     :type url: str, optional
-    :param sandbox: If set to ``True`` the URL will be https://demo-futures.kraken.com (default: ``False``)
+    :param sandbox: If set to ``True`` the URL will be
+        https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -75,13 +76,14 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve the open, high, low, and close data for a specific symbol and resolution.
-        It is also possible to filter by time.
+        Retrieve the open, high, low, and close data for a specific symbol and
+        resolution. It is also possible to filter by time.
 
         - https://docs.futures.kraken.com/#http-api-charts-ohlc-get-ohlc
         - https://support.kraken.com/hc/en-us/articles/4403284627220-OHLC
 
-        :param tick_type: The kind of data, based on ``mark``, ``spot``, or ``trade``
+        :param tick_type: The kind of data, based on ``mark``, ``spot``, or
+            ``trade``
         :type tick_type: str
         :param symbol: The asset pair to get the ohlc from
         :type symbol: str
@@ -149,7 +151,8 @@ class Market(KrakenFuturesBaseAPI):
 
         - https://docs.futures.kraken.com/#http-api-charts-ohlc-get-tick-types
 
-        This function uses caching. Run ``get_tick_types.cache_clear()`` to clear.
+        This function uses caching. Run ``get_tick_types.cache_clear()`` to
+        clear.
 
         :return: List of available tick types
         :rtype: list[str]
@@ -182,9 +185,11 @@ class Market(KrakenFuturesBaseAPI):
 
         - https://docs.futures.kraken.com/#http-api-charts-ohlc-get-tradeable-products
 
-        This function uses caching. Run ``get_tradeable_products.cache_clear()`` to clear.
+        This function uses caching. Run ``get_tradeable_products.cache_clear()``
+        to clear.
 
-        :param tick_type: The kind of data, based on ``mark``, ``spot``, or ``trade``
+        :param tick_type: The kind of data, based on ``mark``, ``spot``, or
+            ``trade``
         :type tick_type: str
         :return: List of tradeable assets
         :type: list[str]
@@ -218,9 +223,11 @@ class Market(KrakenFuturesBaseAPI):
 
         - https://docs.futures.kraken.com/#http-api-charts-ohlc-get-resolutions
 
-        This function uses caching. Run ``get_resolutions.cache_clear()`` to clear.
+        This function uses caching. Run ``get_resolutions.cache_clear()`` to
+        clear.
 
-        :param tick_type: The kind of data, based on ``mark``, ``spot``, or ``trade``
+        :param tick_type: The kind of data, based on ``mark``, ``spot``, or
+            ``trade``
         :type tick_type: str
         :param tick_type: The asset of interest
         :type tick_type: str
@@ -256,9 +263,11 @@ class Market(KrakenFuturesBaseAPI):
 
         - https://support.kraken.com/hc/en-us/articles/360049269572-Fee-Schedules
 
-        This function uses caching. Run ``get_fee_schedules.cache_clear()`` to clear.
+        This function uses caching. Run ``get_fee_schedules.cache_clear()`` to
+        clear.
 
-        :return: Dictionary containing information about the fees for wide range of tradeable assets
+        :return: Dictionary containing information about the fees for wide range
+            of tradeable assets
         :rtype: dict
 
         .. code-block:: python
@@ -299,7 +308,8 @@ class Market(KrakenFuturesBaseAPI):
         """
         Get the personal volumes per fee schedule
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-fee-schedules-get-fee-schedule-volumes
 
@@ -333,9 +343,11 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Get the orderbook of a specific asset/symbol. Even if the official kraken documentation
-        states that the parameter ``symbol`` is not required, they will always respond with an error
-        message, so it is recommended to use the ``symbol`` parameter until they don't fix this issue.
+        Get the orderbook of a specific asset/symbol. Even if the official
+        kraken documentation states that the parameter ``symbol`` is not
+        required, they will always respond with an error message, so it is
+        recommended to use the ``symbol`` parameter until they don't fix this
+        issue.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-market-data-get-orderbook
 
@@ -442,7 +454,8 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve more specific information about the tradeable assets on the Futures market
+        Retrieve more specific information about the tradeable assets on the
+        Futures market
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-instrument-details-get-instruments
 
@@ -579,7 +592,8 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve the trade history (max 100 entries), can be filtered using the parameters.
+        Retrieve the trade history (max 100 entries), can be filtered using the
+        parameters.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-market-data-get-trade-history
 
@@ -637,7 +651,8 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve information about the historical funding rates for a specific asset.
+        Retrieve information about the historical funding rates for a specific
+        asset.
 
         - https://support.kraken.com/hc/en-us/articles/360061979852-Historical-Funding-Rates
 
@@ -685,7 +700,8 @@ class Market(KrakenFuturesBaseAPI):
         """
         Get the current leverage preferences of the user.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-multi-collateral-get-the-leverage-setting-for-a-market
 
@@ -723,7 +739,8 @@ class Market(KrakenFuturesBaseAPI):
         """
         Set a new leverage preference for a specific futures contract.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-multi-collateral-set-the-leverage-setting-for-a-market
 
@@ -761,10 +778,11 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Get the current PNL (profit & loss) preferences. This can be used to define the currency
-        in which the profits and losses are realized.
+        Get the current PNL (profit & loss) preferences. This can be used to
+        define the currency in which the profits and losses are realized.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-multi-collateral-get-pnl-currency-preference-for-a-market
 
@@ -795,11 +813,12 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Modify or set the current PNL preference of the user. This can be used to define a
-        specific currency that should be used to realize profits and losses. The default is
-        the quote currency of the futures contract.
+        Modify or set the current PNL preference of the user. This can be used
+        to define a specific currency that should be used to realize profits and
+        losses. The default is the quote currency of the futures contract.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-multi-collateral-set-pnl-currency-preference-for-a-market
 
@@ -839,7 +858,8 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Method that uses as a gateway for the methods :func:`kraken.futures.Market.get_public_execution_events`,
+        Method that uses as a gateway for the methods
+        :func:`kraken.futures.Market.get_public_execution_events`,
         :func:`kraken.futures.Market.get_public_order_events`, and
         :func:`kraken.futures.Market.get_public_mark_price_events`.
 
@@ -847,7 +867,8 @@ class Market(KrakenFuturesBaseAPI):
         :type endpoint: str
         :param before: Filter by time
         :type before: int, optional
-        :param continuation_token: Token that can be used to continue requesting historical events
+        :param continuation_token: Token that can be used to continue requesting
+            historical events
         :type continuation_token: str, optional
         :param since: Filter by a specifying a start point
         :type since: int, optional
@@ -855,7 +876,8 @@ class Market(KrakenFuturesBaseAPI):
         :type sort: str, optional
         :param tradeable: The asset to filter for
         :type tradeable: str, optional
-        :param auth: If the request is accessing a private endpoint (default: ``True``)
+        :param auth: If the request is accessing a private endpoint (default:
+            ``True``)
         :type auth: bool
         """
         params: dict = {}
@@ -889,8 +911,8 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve information about the public execution events. The returned ``continuation_token``
-        can be used to request more data.
+        Retrieve information about the public execution events. The returned
+        ``continuation_token`` can be used to request more data.
 
         - https://docs.futures.kraken.com/#http-api-history-market-history-get-public-execution-events
 
@@ -900,7 +922,8 @@ class Market(KrakenFuturesBaseAPI):
         :type tradeable: str
         :param before: Filter by time
         :type before: int | None, optional
-        :param continuation_token: Token that can be used to continue requesting historical events
+        :param continuation_token: Token that can be used to continue requesting
+            historical events
         :type continuation_token: str | None, optional
         :param since: Filter by a specifying a start point
         :type since: int | None, optional
@@ -982,8 +1005,9 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve information about the public order events - filled, closed, opened, etc, for
-        a specific contract.The returned ``continuation_token`` can be used to request more data.
+        Retrieve information about the public order events - filled, closed,
+        opened, etc, for a specific contract.The returned ``continuation_token``
+        can be used to request more data.
 
         - https://docs.futures.kraken.com/#http-api-history-market-history-get-public-order-events
 
@@ -993,7 +1017,8 @@ class Market(KrakenFuturesBaseAPI):
         :type tradeable: str
         :param before: Filter by time
         :type before: int, optional
-        :param continuation_token: Token that can be used to continue requesting historical events
+        :param continuation_token: Token that can be used to continue requesting
+            historical events
         :type continuation_token: str, optional
         :param since: Filter by a specifying a start point
         :type since: int, optional
@@ -1056,8 +1081,8 @@ class Market(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve information about public mark price events. The returned ``continuation_token``
-        can be used to request more data.
+        Retrieve information about public mark price events. The returned
+        ``continuation_token`` can be used to request more data.
 
         - https://docs.futures.kraken.com/#http-api-history-market-history-get-public-mark-price-events
 
@@ -1067,7 +1092,8 @@ class Market(KrakenFuturesBaseAPI):
         :type tradeable: str
         :param before: Filter by time
         :type before: int | None, optional
-        :param continuation_token: Token that can be used to continue requesting historical events
+        :param continuation_token: Token that can be used to continue requesting
+            historical events
         :type continuation_token: str | None, optional
         :param since: Filter by a specifying a start point
         :type since: int | None, optional

--- a/kraken/futures/trade.py
+++ b/kraken/futures/trade.py
@@ -26,9 +26,11 @@ class Trade(KrakenFuturesBaseAPI):
     :type key: str, optional
     :param secret: Futures API secret key (default: ``""``)
     :type secret: str, optional
-    :param url: Alternative URL to access the Futures Kraken API (default: https://futures.kraken.com)
+    :param url: Alternative URL to access the Futures Kraken API (default:
+        https://futures.kraken.com)
     :type url: str, optional
-    :param sandbox: If set to ``True`` the URL will be https://demo-futures.kraken.com (default: ``False``)
+    :param sandbox: If set to ``True`` the URL will be
+        https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -71,7 +73,8 @@ class Trade(KrakenFuturesBaseAPI):
         """
         Return the current fills of the user.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-historical-data-get-your-fills
 
@@ -122,11 +125,13 @@ class Trade(KrakenFuturesBaseAPI):
         """
         Create multiple orders at once using the batch order endpoint.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-batch-order-management
 
-        :param batchorder_list: List of order instructions (see example below - or the linked official Kraken documentation)
+        :param batchorder_list: List of order instructions (see example below -
+            or the linked official Kraken documentation)
         :type batchorder_list: list[dict]
         :return: Information about the submitted request
         :rtype: dict
@@ -235,7 +240,8 @@ class Trade(KrakenFuturesBaseAPI):
         """
         Cancels all open orders, can be filtered by symbol.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-cancel-all-orders
 
@@ -287,12 +293,13 @@ class Trade(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        The Death Man's Switch can be used to cancel all orders after a specific timeout.
-        If the timeout is set to 60, all orders will be cancelled after 60 seconds. The timeout
-        can be pushed back by accessing this endpoint over and over again. Set the timeout to zero
-        to reset.
+        The Death Man's Switch can be used to cancel all orders after a specific
+        timeout. If the timeout is set to 60, all orders will be cancelled after
+        60 seconds. The timeout can be pushed back by accessing this endpoint
+        over and over again. Set the timeout to zero to reset.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-dead-man-39-s-switch
 
@@ -332,9 +339,11 @@ class Trade(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        This endpoint can be used to cancel a specific order by ``order_id`` or ``cliOrdId``.
+        This endpoint can be used to cancel a specific order by ``order_id`` or
+        ``cliOrdId``.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-cancel-order
 
@@ -392,7 +401,8 @@ class Trade(KrakenFuturesBaseAPI):
         """
         Edit an open order.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-send-order
 
@@ -462,7 +472,8 @@ class Trade(KrakenFuturesBaseAPI):
         """
         Get the status of multiple orders.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-get-the-current-status-for-specific-orders
 
@@ -519,11 +530,13 @@ class Trade(KrakenFuturesBaseAPI):
         """
         Create and place an order on the futures market.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-send-order
 
-        :param orderType: The order type, one of ``lmt``, ``post``, ``ioc``, ``mkt``, ``stp``, ``take_profit``, ``trailing_stop``
+        :param orderType: The order type, one of ``lmt``, ``post``, ``ioc``,
+            ``mkt``, ``stp``, ``take_profit``, ``trailing_stop``
             (https://support.kraken.com/hc/en-us/sections/200577136-Order-types)
         :type orderType: str
         :param size: The volume of the position
@@ -538,9 +551,11 @@ class Trade(KrakenFuturesBaseAPI):
         :type limitPrice: str | float, optional
         :param reduceOnly: Reduces existing positions if set to ``True``
         :type reduceOnly: bool, optional
-        :param stopPrice: Define a price when to exit the order. Required for specific order types
+        :param stopPrice: Define a price when to exit the order. Required for
+            specific order types
         :type stopPrice: str, optional
-        :param triggerSignal: Define a trigger for specific orders (must be one of ``mark``, ``index``, ``last``)
+        :param triggerSignal: Define a trigger for specific orders (must be one
+            of ``mark``, ``index``, ``last``)
         :type triggerSignal: str, optional
         :param trailingStopDeviationUnit: See referenced Kraken documentation
         :type trailingStopDeviationUnit: str, optional

--- a/kraken/futures/user.py
+++ b/kraken/futures/user.py
@@ -29,9 +29,11 @@ class User(KrakenFuturesBaseAPI):
     :type key: str, optional
     :param secret: Futures API secret key (default: ``""``)
     :type secret: str, optional
-    :param url: Alternative URL to access the Futures Kraken API (default: https://futures.kraken.com)
+    :param url: Alternative URL to access the Futures Kraken API (default:
+        https://futures.kraken.com)
     :type url: str, optional
-    :param sandbox: If set to ``True`` the URL will be https://demo-futures.kraken.com (default: ``False``)
+    :param sandbox: If set to ``True`` the URL will be
+        https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -73,7 +75,8 @@ class User(KrakenFuturesBaseAPI):
         """
         Lists the current wallet balances of the user.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-account-information-get-wallets
 
@@ -166,7 +169,8 @@ class User(KrakenFuturesBaseAPI):
         """
         List the subaccounts of the user.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-account-information-get-subaccounts
 
@@ -200,9 +204,11 @@ class User(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve information about the percentile of the open position in case of unwinding.
+        Retrieve information about the percentile of the open position in case
+        of unwinding.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-account-information-get-position-percentile-of-unwind-queue
 
@@ -239,7 +245,8 @@ class User(KrakenFuturesBaseAPI):
         """
         Retrieve the latest notifications from the Kraken Futures API
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-general-get-notifications
 
@@ -283,14 +290,16 @@ class User(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Get the historical events of the user's account. This is not available in the
-        Kraken demo/sandbox environment.
+        Get the historical events of the user's account. This is not available
+        in the Kraken demo/sandbox environment.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-history-account-history-get-account-log
 
-        :param before: Filter to only return results before a specific timestamp or date
+        :param before: Filter to only return results before a specific timestamp
+            or date
         :type before: str | int, optional
         :param count: Defines the maximum number of results (max: ``500``)
         :type count: str | int, optional
@@ -373,10 +382,11 @@ class User(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> requests.Response:
         """
-        Return the account log as csv, for example to export it. This is not available in the
-        Kraken demo/sandbox environment.
+        Return the account log as csv, for example to export it. This is not
+        available in the Kraken demo/sandbox environment.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-history-account-log-get-recent-account-log-csv
 
@@ -413,7 +423,8 @@ class User(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Method that uses as a gateway for the methods :func:`kraken.futures.User.get_execution_events`,
+        Method that uses as a gateway for the methods
+        :func:`kraken.futures.User.get_execution_events`,
         :func:`kraken.futures.User.get_order_events`, and
         :func:`kraken.futures.User.get_trigger_events`
 
@@ -421,7 +432,8 @@ class User(KrakenFuturesBaseAPI):
         :type endpoint: str
         :param before: Filter by time
         :type before: int, optional
-        :param continuation_token: Token that can be used to continue requesting historical events
+        :param continuation_token: Token that can be used to continue requesting
+            historical events
         :type continuation_token: str, optional
         :param since: Filter by a specifying a start point
         :type since: int, optional
@@ -429,7 +441,8 @@ class User(KrakenFuturesBaseAPI):
         :type sort: str, optional
         :param tradeable: The asset to filter for
         :type tradeable: str, optional
-        :param auth: If the request is accessing a private endpoint (default: ``True``)
+        :param auth: If the request is accessing a private endpoint (default:
+            ``True``)
         :type auth: bool
         """
         params: dict = {}
@@ -463,16 +476,18 @@ class User(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve the order/position execution events of this user. The returned ``continuation_token``
-        can be used to request more data.
+        Retrieve the order/position execution events of this user. The returned
+        ``continuation_token`` can be used to request more data.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-history-account-history-get-execution-events
 
         :param before: Filter by time
         :type before: int, optional
-        :param continuation_token: Token that can be used to continue requesting historical events
+        :param continuation_token: Token that can be used to continue requesting
+            historical events
         :type continuation_token: str, optional
         :param since: Filter by a specifying a start point
         :type since: int, optional
@@ -557,15 +572,14 @@ class User(KrakenFuturesBaseAPI):
                                 'uid': 'f7d5571c-6d10-4cf1-944a-048d25682ed0',
                                 'usdValue': '2301.56789'
                             },
-                            }
-                        },
+                        }
+                    },
                     'timestamp': 1605126171852,
                     'uid': 'f7d5571c-6d10-4cf1-944a-048d25682ed0'
-                }, ...
-            ],
-            'len': 0,
-            'serverTime': '2023-04-06T21:11:31.677Z'
-        }
+                }, ...],
+                'len': 0,
+                'serverTime': '2023-04-06T21:11:31.677Z'
+            }
         """
         return self._get_historical_events(
             endpoint="/api/history/v2/executions",
@@ -588,16 +602,19 @@ class User(KrakenFuturesBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retriev information about the user-specific order events including opened, closed, filled, etc.
-        The returned ``continuation_token`` can be used to request more data.
+        Retriev information about the user-specific order events including
+        opened, closed, filled, etc. The returned ``continuation_token`` can be
+        used to request more data.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-history-market-history-get-order-events
 
         :param before: Filter by time
         :type before: int, optional
-        :param continuation_token: Token that can be used to continue requesting historical events
+        :param continuation_token: Token that can be used to continue requesting
+            historical events
         :type continuation_token: str, optional
         :param since: Filter by a specifying a start point
         :type since: int, optional
@@ -640,11 +657,10 @@ class User(KrakenFuturesBaseAPI):
                     },
                     'timestamp': 1605126171852,
                     'uid': 'f7d5571c-6d10-4cf1-944a-048d25682ed0'
-                }, ...
-            ],
-            'len': 10,
-            'serverTime': '2023-04-05T12:31:42.677Z'
-        }
+                }, ...],
+                'len': 10,
+                'serverTime': '2023-04-05T12:31:42.677Z'
+            }
         """
         return self._get_historical_events(
             endpoint="/api/history/v2/orders",
@@ -671,13 +687,15 @@ class User(KrakenFuturesBaseAPI):
 
         The returned ``continuation_token`` can be used to request more data.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-history-market-history-get-trigger-events
 
         :param before: Filter by time
         :type before: int, optional
-        :param continuation_token: Token that can be used to continue requesting historical events
+        :param continuation_token: Token that can be used to continue requesting
+            historical events
         :type continuation_token: str, optional
         :param since: Filter by a specifying a start point
         :type since: int, optional
@@ -694,7 +712,12 @@ class User(KrakenFuturesBaseAPI):
 
             >>> from kraken.futures import User
             >>> user = User(key="api-key", secret="secret-key")
-            >>> user.get_trigger_events(tradeable="PF_SOLUSD", since=1668989233, before=1668999999, sort="asc")
+            >>> user.get_trigger_events(
+            ...     tradeable="PF_SOLUSD",
+            ...     since=1668989233,
+            ...     before=1668999999,
+            ...     sort="asc"
+            ... )
             {
                 "accountUid": "f7d5571c-6d10-4cf1-944a-048d25682ed0",
                 "continuationToken": "c3RyaW5n",
@@ -728,11 +751,10 @@ class User(KrakenFuturesBaseAPI):
                     },
                     "timestamp": 1605126171852,
                     "uid": "f7d5571c-6d10-4cf1-944a-048d25682ed0"
-                }, ...
-            ],
-            "len": 10,
-            "serverTime": "2022-03-31T20:38:53.677Z"
-        }
+                }, ...],
+                "len": 10,
+                "serverTime": "2022-03-31T20:38:53.677Z"
+            }
         """
         return self._get_historical_events(
             endpoint="/api/history/v2/triggers",
@@ -752,7 +774,8 @@ class User(KrakenFuturesBaseAPI):
         """
         List the open positions of the user.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-account-information-get-open-positions
 
@@ -796,7 +819,8 @@ class User(KrakenFuturesBaseAPI):
         """
         Retrieve the open orders.
 
-        Requires at least the ``General API - Read Only`` permission in the API key settings.
+        Requires at least the ``General API - Read Only`` permission in the API
+        key settings.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-get-open-orders
 
@@ -886,10 +910,11 @@ class User(KrakenFuturesBaseAPI):
         """
         Checks if trading is enabled or disabled on the specified subaccount.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
-        This endpoint is only available for institutional clients and is not tested so far and
-        results in ``KrakenAuthenticationError``.
+        This endpoint is only available for institutional clients and is not
+        tested so far and results in ``KrakenAuthenticationError``.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-other-check-if-a-subaccount-has-trading-enabled-or-disabled
 
@@ -926,10 +951,11 @@ class User(KrakenFuturesBaseAPI):
         """
         Enable or disable trading on a subaccount.
 
-        Requires the ``General API - Full Access`` permission in the API key settings.
+        Requires the ``General API - Full Access`` permission in the API key
+        settings.
 
-        This endpoint is only available for institutional clients and is not tested so far and
-        always results in ``INTERNAL_SERVER_ERROR``.
+        This endpoint is only available for institutional clients and is not
+        tested so far and always results in ``INTERNAL_SERVER_ERROR``.
 
         - https://docs.futures.kraken.com/#http-api-trading-v3-api-other-enable-or-disable-trading-on-a-subaccount
 

--- a/kraken/futures/websocket/__init__.py
+++ b/kraken/futures/websocket/__init__.py
@@ -26,12 +26,14 @@ if TYPE_CHECKING:
 
 class ConnectFuturesWebsocket:
     """
-    This class is only called by the :class:`kraken.futures.KrakenFuturesWSClient`
-    to establish the websocket connection.
+    This class is only called by the
+    :class:`kraken.futures.KrakenFuturesWSClient` to establish the websocket
+    connection.
 
     :param client: The Futures websocket client that instantiates this class
     :type client: :class:`kraken.futures.KrakenFuturesWSClient`
-    :param endpoint: The endpoint to access (either the live Kraken API or the sandbox environment)
+    :param endpoint: The endpoint to access (either the live Kraken API or the
+        sandbox environment)
     :type endpoint: str
     :param callback: The function that is used to receive the message objects
     :type callback: function
@@ -209,7 +211,8 @@ class ConnectFuturesWebsocket:
 
         :param message: The message as dictionary
         :type message: dict
-        :param private: If the message requires authentication (default: ``False``)
+        :param private: If the message requires authentication (default:
+            ``False``)
         :type private: bool, optional
         :rtype: Coroutine
         """

--- a/kraken/futures/ws_client.py
+++ b/kraken/futures/ws_client.py
@@ -39,8 +39,8 @@ class KrakenFuturesWSClient(KrakenFuturesBaseAPI):
     :type secret: str, optional
     :param url: Set a custom URL (default: ``futures.kraken.com/ws/v1``)
     :type url: str, optional
-    :param sandbox: Use the Kraken Futures demo environment
-        (URL will switch to ``demo-futures.kraken.com/ws/v1``, default: ``False``)
+    :param sandbox: Use the Kraken Futures demo environment (URL will switch to
+        ``demo-futures.kraken.com/ws/v1``, default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -148,7 +148,8 @@ class KrakenFuturesWSClient(KrakenFuturesBaseAPI):
         :param challenge: The challenge/message to sign
         :type challenge: str
         :return: The signed message
-        :raises kraken.exceptions.KrakenAuthenticationError: If the credentials are not valid
+        :raises kraken.exceptions.KrakenAuthenticationError: If the credentials
+            are not valid
         :rtype: str
         """
         if not self.is_auth:
@@ -166,13 +167,15 @@ class KrakenFuturesWSClient(KrakenFuturesBaseAPI):
 
     async def on_message(self: KrakenFuturesWSClient, message: dict) -> None:
         """
-        Method that serves as the default callback function Calls the defined callback function (if defined)
-        or overload this function.
+        Method that serves as the default callback function Calls the defined
+        callback function (if defined) or overload this function.
 
-        This is the default method  which just logs the messages. In production you want to overload this
-        with your custom methods, as shown in the Example of :class:`kraken.futures.KrakenFuturesWSClient`.
+        This is the default method  which just logs the messages. In production
+        you want to overload this with your custom methods, as shown in the
+        Example of :class:`kraken.futures.KrakenFuturesWSClient`.
 
-        :param message: The message that was send by Kraken via the websocket connection.
+        :param message: The message that was send by Kraken via the websocket
+            connection.
         :type message: dict
         :rtype: None
         """
@@ -188,7 +191,8 @@ class KrakenFuturesWSClient(KrakenFuturesBaseAPI):
         products: Optional[list[str]] = None,
     ) -> None:
         """
-        Subscribe to a Futures websocket channel/feed. For some feeds authentication is required.
+        Subscribe to a Futures websocket channel/feed. For some feeds
+        authentication is required.
 
         - https://docs.futures.kraken.com/#websocket-api-websocket-api-introduction-subscriptions
 
@@ -196,8 +200,8 @@ class KrakenFuturesWSClient(KrakenFuturesBaseAPI):
         :type feed: str
         :param products: The products/futures contracts to subscribe to
         :type products: list[str], optional
-        :raises TypeError: If the parameters don't match the requirements set
-            by the Kraken API
+        :raises TypeError: If the parameters don't match the requirements set by
+            the Kraken API
 
         Initialize your client as described in
         :class:`kraken.futures.KrakenFuturesWSClient` to run the following
@@ -210,8 +214,9 @@ class KrakenFuturesWSClient(KrakenFuturesBaseAPI):
             >>> await bot.subscribe(feed='ticker', products=["XBTUSD", "DOT/EUR"])
 
         Success or failures are sent over the websocket connection and can be
-        received via the default :func:`kraken.futures.KrakenFuturesWSClient.on_message`
-        or a custom callback function.
+        received via the default
+        :func:`kraken.futures.KrakenFuturesWSClient.on_message` or a custom
+        callback function.
         """
 
         message: dict = {"event": "subscribe", "feed": feed}

--- a/kraken/spot/funding.py
+++ b/kraken/spot/funding.py
@@ -17,16 +17,18 @@ Self = TypeVar("Self")
 
 class Funding(KrakenSpotBaseAPI):
     """
-    Class that implements the Spot Funding client. Currently there
-    are no funding endpoints that could be accesses without authentication.
+    Class that implements the Spot Funding client. Currently there are no
+    funding endpoints that could be accesses without authentication.
 
     :param key: Spot API public key (default: ``""``)
     :type key: str, optional
     :param secret: Spot API secret key (default: ``""``)
     :type secret: str, optional
-    :param url: Alternative URL to access the Kraken API (default: https://api.kraken.com)
+    :param url: Alternative URL to access the Kraken API (default:
+        https://api.kraken.com)
     :type url: str, optional
-    :param sandbox: Use the sandbox (not supported for Spot trading so far, default: ``False``)
+    :param sandbox: Use the sandbox (not supported for Spot trading so far,
+        default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -109,7 +111,8 @@ class Funding(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> list[dict]:
         """
-        Get the deposit addresses for a specific asset. New deposit addresses can be generated.
+        Get the deposit addresses for a specific asset. New deposit addresses
+        can be generated.
 
         Requires the ``Deposit funds`` API key permission.
 
@@ -163,8 +166,8 @@ class Funding(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> list[dict] | dict:
         """
-        Get information about the recent deposit status. The look back period is 90 days and
-        only the last 25 deposits will be returned.
+        Get information about the recent deposit status. The look back period is
+        90 days and only the last 25 deposits will be returned.
 
         Requires the ``Query funds`` and ``Deposit funds`` API key permissions.
 
@@ -254,9 +257,10 @@ class Funding(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Get information about a possible withdraw, including fee and limit information.
-        The ``key`` must be the name of the key defined in the account. You can add
-        a new key for any asset listed on Kraken here: https://www.kraken.com/u/funding/withdraw.
+        Get information about a possible withdraw, including fee and limit
+        information. The ``key`` must be the name of the key defined in the
+        account. You can add a new key for any asset listed on Kraken here:
+        https://www.kraken.com/u/funding/withdraw.
 
         Requires the ``Query funds`` and ``Withdraw funds`` API key permissions.
 
@@ -268,7 +272,8 @@ class Funding(KrakenSpotBaseAPI):
         :type key: str
         :param amount: The amount to withdraw
         :type amount: str | float
-        :return: Information about a possible withdraw including the fee and amount.
+        :return: Information about a possible withdraw including the fee and
+            amount.
         :rtype: dict
 
         .. code-block:: python
@@ -357,8 +362,8 @@ class Funding(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> list[dict]:
         """
-        Get information about the recent withdraw status, including withdraws of the
-        past 90 days but at max 500 results.
+        Get information about the recent withdraw status, including withdraws of
+        the past 90 days but at max 500 results.
 
         - https://docs.kraken.com/rest/#operation/getStatusRecentWithdrawals
 
@@ -411,8 +416,8 @@ class Funding(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Cancel a requested withdraw. This will only be successful if the withdraw
-        is not being processed so far.
+        Cancel a requested withdraw. This will only be successful if the
+        withdraw is not being processed so far.
 
         Requires the ``Withdraw funds`` API key permissions.
 

--- a/kraken/spot/market.py
+++ b/kraken/spot/market.py
@@ -25,9 +25,11 @@ class Market(KrakenSpotBaseAPI):
     :type key: str, optional
     :param secret: Spot API secret key (default: ``""``)
     :type secret: str, optional
-    :param url: Alternative URL to access the Kraken API (default: https://api.kraken.com)
+    :param url: Alternative URL to access the Kraken API (default:
+        https://api.kraken.com)
     :type url: str, optional
-    :param sandbox: Use the sandbox (not supported for Spot trading so far, default: ``False``)
+    :param sandbox: Use the sandbox (not supported for Spot trading so far,
+        default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -70,8 +72,8 @@ class Market(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Get information about one or more assets.
-        If ``assets`` is not specified, all assets will be returned.
+        Get information about one or more assets. If ``assets`` is not
+        specified, all assets will be returned.
 
         - https://docs.kraken.com/rest/#operation/getAssetInfo
 
@@ -144,17 +146,19 @@ class Market(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Get information about a single or multiple asset/currency pair(s).
-        If ``pair`` is left blank, all currency pairs will be returned.
+        Get information about a single or multiple asset/currency pair(s). If
+        ``pair`` is left blank, all currency pairs will be returned.
 
         - https://docs.kraken.com/rest/#operation/getTradableAssetPairs
 
-        This function uses caching. Run ``get_asset_pairs.cache_clear()`` to clear.
+        This function uses caching. Run ``get_asset_pairs.cache_clear()`` to
+        clear.
 
         :param pair: Filter by asset pair(s)
         :type pair: str | list[str], optional
-        :param info: Filter by info, can be one of: ``info`` (all info), ``leverage``
-            (leverage info), ``fees`` (fee info), and ``margin`` (margin info)
+        :param info: Filter by info, can be one of: ``info`` (all info),
+            ``leverage`` (leverage info), ``fees`` (fee info), and ``margin``
+            (margin info)
         :type info: str, optional
         :return: Information about the asset pair
         :rtype: dict
@@ -223,14 +227,15 @@ class Market(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Returns all tickers if pair is not specified - else just
-        the ticker of the ``pair``. Multiple pairs can be specified.
+        Returns all tickers if pair is not specified - else just the ticker of
+        the ``pair``. Multiple pairs can be specified.
 
         https://docs.kraken.com/rest/#operation/getTickerInformation
 
         :param pair: Filter by pair(s)
         :type pair: str | list[str], optional
-        :return: The ticker(s) including ask, bid, close, volume, vwap, high, low, todays open and more
+        :return: The ticker(s) including ask, bid, close, volume, vwap, high,
+            low, todays open and more
         :rtype: dict
 
         .. code-block:: python
@@ -274,7 +279,7 @@ class Market(KrakenSpotBaseAPI):
     ) -> dict:
         """
         Get the open, high, low, and close data for a specific trading pair.
-        Returns at max 720 time stamps per request.
+        Returns at max 720 time steps per request.
 
         - https://docs.kraken.com/rest/#operation/getOHLCData
 
@@ -333,7 +338,8 @@ class Market(KrakenSpotBaseAPI):
 
         :param pair: The pair to get the orderbook from
         :type pair: str
-        :param count: Number of asks and bids, must be one of {1..500} (default: ``100``)
+        :param count: Number of asks and bids, must be one of {1..500} (default:
+            ``100``)
         :type count: int, optional
 
         :return:

--- a/kraken/spot/orderbook_v1.py
+++ b/kraken/spot/orderbook_v1.py
@@ -205,7 +205,8 @@ class OrderbookClientV1:
 
         :param pair: The currency pair of the orderbook that has been updated.
         :type pair: str
-        :param message: The message sent by Kraken causing the orderbook to update.
+        :param message: The message sent by Kraken causing the orderbook to
+            update.
         :type message: str
         """
 
@@ -219,8 +220,8 @@ class OrderbookClientV1:
 
     async def add_book(self: OrderbookClientV1, pairs: list[str]) -> None:
         """
-        Add an orderbook to this client. The feed will be subscribed
-        and updates will be published to the :func:`on_book_update` function.
+        Add an orderbook to this client. The feed will be subscribed and updates
+        will be published to the :func:`on_book_update` function.
 
         :param pairs: The pair(s) to subscribe to
         :type pairs: list[str]
@@ -257,10 +258,10 @@ class OrderbookClientV1:
     def exception_occur(self: OrderbookClientV1) -> bool:
         """
         Can be used to determine if any critical error occurred within the
-        websocket connection. If so, the function will return ``True``
-        and the client instance is most likely not useable anymore. So this
-        is the switch lets the user know, when to delete the current one and
-        create a new one.
+        websocket connection. If so, the function will return ``True`` and the
+        client instance is most likely not useable anymore. So this is the
+        switch lets the user know, when to delete the current one and create a
+        new one.
 
         :return: ``True`` if any critical error occurred else ``False``
         :rtype: bool
@@ -276,11 +277,11 @@ class OrderbookClientV1:
         :return: The orderbook of that ``pair``.
         :rtype: dict
 
-        .. code-block::python
+        .. code-block:: python
             :linenos:
             :caption: OrderbookClientV1: Get ask and bid
 
-            …
+            # …
             class Orderbook(OrderbookClientV1):
 
                 async def on_book_update(
@@ -303,9 +304,8 @@ class OrderbookClientV1:
         snapshot: list,
     ) -> None:
         """
-        This functions updates the local orderbook based on the
-        information provided in ``data`` and assigns/update the
-        asks and bids in book.
+        This functions updates the local orderbook based on the information
+        provided in ``data`` and assigns/update the asks and bids in book.
 
         The ``data`` here looks like:
         [
@@ -318,8 +318,7 @@ class OrderbookClientV1:
         … where the first value is the ask or bid price, the second
           represents the volume and the last one is the timestamp.
 
-        :param side: The side to assign the data to,
-            either ``ask`` or ``bid``
+        :param side: The side to assign the data to, either ``ask`` or ``bid``
         :type side: str
         :param data: The data that needs to be assigned.
         :type data: list
@@ -384,9 +383,9 @@ class OrderbookClientV1:
     @staticmethod
     def get_first(values: tuple) -> float:
         """
-        This function is used as callback for the ``sorted`` method
-        to sort a tuple/list by its first value and while ensuring
-        that the values are floats and comparable.
+        This function is used as callback for the ``sorted`` method to sort a
+        tuple/list by its first value and while ensuring that the values are
+        floats and comparable.
 
         :param values: A tuple of string values
         :type values: tuple

--- a/kraken/spot/orderbook_v2.py
+++ b/kraken/spot/orderbook_v2.py
@@ -31,12 +31,10 @@ class OrderbookClientV2:
     multiple order books for Spot trading on the Kraken cryptocurrency exchange.
     It uses websockets to subscribe to book feeds and receives book updates,
     calculates the checksum and will publish the raw message to the
-    :func:`on_book_update` function or to the specified callback
-    function.
+    :func:`on_book_update` function or to the specified callback function.
 
-    :func:`get` can be used to access a specific book of this
-    client - they will always be up-to date when used from within
-    :func:`on_book_update`.
+    :func:`get` can be used to access a specific book of this client - they will
+    always be up-to date when used from within :func:`on_book_update`.
 
     The client will resubscribe to the book feed(s) if any errors occur and
     publish the changes to the mentioned function(s). This is required to
@@ -281,10 +279,10 @@ class OrderbookClientV2:
     def exception_occur(self: OrderbookClientV2) -> bool:
         """
         Can be used to determine if any critical error occurred within the
-        websocket connection. If so, the function will return ``True``
-        and the client instance is most likely not useable anymore. So this
-        is the switch lets the user know, when to delete the current one and
-        create a new one.
+        websocket connection. If so, the function will return ``True`` and the
+        client instance is most likely not useable anymore. So this is the
+        switch lets the user know, when to delete the current one and create a
+        new one.
 
         :return: ``True`` if any critical error occurred else ``False``
         :rtype: bool
@@ -328,9 +326,9 @@ class OrderbookClientV2:
         timestamp: Optional[str] = None,
     ) -> None:
         """
-        This functions updates the local orderbook based on the
-        information provided in ``orders`` and assigns or updates the
-        asks and bids of the book.
+        This functions updates the local orderbook based on the information
+        provided in ``orders`` and assigns or updates the asks and bids of the
+        book.
 
         :param orders: List of asks or bids like [{"price":1, "qty": 2}]
         :type orders: list[dict]

--- a/kraken/spot/staking.py
+++ b/kraken/spot/staking.py
@@ -17,16 +17,18 @@ Self = TypeVar("Self")
 
 class Staking(KrakenSpotBaseAPI):
     """
-    Class that implements the Kraken Spot Staking client. Currently there
-    are no staking endpoints that could be accesses without authentication.
+    Class that implements the Kraken Spot Staking client. Currently there are no
+    staking endpoints that could be accesses without authentication.
 
     :param key: Spot API public key (default: ``""``)
     :type key: str, optional
     :param secret: Spot API secret key (default: ``""``)
     :type secret: str, optional
-    :param url: Alternative URL to access the Kraken API (default: https://api.kraken.com)
+    :param url: Alternative URL to access the Kraken API (default:
+        https://api.kraken.com)
     :type url: str, optional
-    :param sandbox: Use the sandbox (not supported for Spot trading so far, default: ``False``)
+    :param sandbox: Use the sandbox (not supported for Spot trading so far,
+        default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -164,8 +166,8 @@ class Staking(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> list[dict]:
         """
-        Get a list of stakeable assets. Only assets that the user is able to stake
-        will be shown.
+        Get a list of stakeable assets. Only assets that the user is able to
+        stake will be shown.
 
         Requires the ``Withdraw funds`` and ``Query funds`` API key permissions.
 

--- a/kraken/spot/trade.py
+++ b/kraken/spot/trade.py
@@ -94,14 +94,15 @@ class Trade(KrakenSpotBaseAPI):
         """
         Create a new order and place it on the market.
 
-        Requires the ``Create and modify orders`` permission in
-        the API key settings.
+        Requires the ``Create and modify orders`` permission in the API key
+        settings.
 
         - https://docs.kraken.com/rest/#operation/addOrder
 
-        :param ordertype: The kind of the order, one of: ``market``, ``limit``, ``take-profit``,
-            ``stop-loss-limit``, ``take-profit-limit`` and ``settle-position``
-            (see: https://support.kraken.com/hc/en-us/sections/200577136-Order-types)
+        :param ordertype: The kind of the order, one of: ``market``, ``limit``,
+            ``take-profit``, ``stop-loss-limit``, ``take-profit-limit`` and
+            ``settle-position`` (see:
+            https://support.kraken.com/hc/en-us/sections/200577136-Order-types)
         :type ordertype: str
         :param side: ``buy`` or ``sell``
         :type side: str
@@ -109,17 +110,23 @@ class Trade(KrakenSpotBaseAPI):
         :type pair: str
         :param volume: The volume of the position to create
         :type volume: str | float
-        :param price: The limit price for ``limit`` orders and the trigger price for orders with
-            ``ordertype`` one of ``stop-loss``, ``stop-loss-limit``, ``take-profit``, and ``take-profit-limit``
+        :param price: The limit price for ``limit`` orders and the trigger price
+            for orders with ``ordertype`` one of ``stop-loss``,
+            ``stop-loss-limit``, ``take-profit``, and ``take-profit-limit``
         :type price: str | float, optional
-        :param price2: The limit price for ``stop-loss-limit`` and ``take-profit-limit`` orders
-            The price2 can also be set to absolut or relative changes.
-                * Prefixed using ``+`` or ``-`` defines the change in the quote asset
-                * Prefixed by # is the same as ``+`` and ``-`` but the sign is set automatically
-                * The percentage sign ``%`` can be used to define relative changes.
+        :param price2: The limit price for ``stop-loss-limit`` and
+            ``take-profit-limit`` orders The price2 can also be set to absolut
+            or relative changes.
+                * Prefixed using ``+`` or ``-`` defines the change in the quote
+                  asset
+                * Prefixed by ``#`` is the same as ``+`` or ``-`` but the sign
+                  is set automatically
+                * The percentage sign (``%``) can be used to define relative
+                  changes.
         :type price2: str | float, optional
-        :param trigger: What triggers the position of ``stop-loss``, ``stop-loss-limit``, ``take-profit``, and
-            ``take-profit-limit`` orders. Will also be used for associated conditional close orders.
+        :param trigger: What triggers the position of ``stop-loss``,
+            ``stop-loss-limit``, ``take-profit``, and ``take-profit-limit``
+            orders. Will also be used for associated conditional close orders.
             Kraken will use ``last`` if nothing is specified.
         :type trigger: str, optional
         :param leverage: The leverage
@@ -128,36 +135,44 @@ class Trade(KrakenSpotBaseAPI):
             ``cancel-oldest``, ``cancel-both`` (default: ``cancel-newest``)
         :type stptype: str, optional
         :param oflags: Order flags like ``post``, ``fcib``, ``fciq``, ``nomp``,
-            ``viqc`` (see the referenced Kraken documentation for more information)
+            ``viqc`` (see the referenced Kraken documentation for more
+            information)
         :type oflags: str | list[str], optional
         :param timeinforce: how long the order remains in the orderbook, one of:
-            ``GTC``, ``IOC``, ``GTD`` (see the referenced Kraken documentation for more information)
+            ``GTC``, ``IOC``, ``GTD`` (see the referenced Kraken documentation
+            for more information)
         :type timeinforce: str, optional
-        :param displayvol: Define how much of the volume is visible in the orderbook (iceberg)
+        :param displayvol: Define how much of the volume is visible in the
+            orderbook (iceberg)
         :type displayvol: str | float, optional
-        :param starttim: Unix timestamp or seconds defining the start time (default: ``"0"``)
+        :param starttim: Unix timestamp or seconds defining the start time
+            (default: ``"0"``)
         :type starttim: str, optional
-        :param expiretm: Unix timestamp or time in seconds defining the expiration of the order,
-            (default: ``"0"`` - i.e., no expiration)
+        :param expiretm: Unix timestamp or time in seconds defining the
+            expiration of the order, (default: ``"0"`` - i.e., no expiration)
         :type expiretm: str, optional
-        :param close_ordertype: Conditional close order type, one of: ``limit``, ``stop-loss``,
-            ``take-profit``, ``stop-loss-limit``, ``take-profit-limit``
-            (see the referenced Kraken documentation for more information)
+        :param close_ordertype: Conditional close order type, one of: ``limit``,
+            ``stop-loss``, ``take-profit``, ``stop-loss-limit``,
+            ``take-profit-limit`` (see the referenced Kraken documentation for
+            more information)
         :type close_ordertype: str, optional
         :param close_price: Conditional close price
         :type close_price: str | float, optional
-        :param close_price2: The price2 for the conditional order - see the price2 parameter description
+        :param close_price2: The price2 for the conditional order - see the
+            price2 parameter description
         :type close_price2: str | float, optional
-        :param deadline: RFC3339 timestamp + {0..60} seconds that defines when the matching
-            engine should reject the order.
+        :param deadline: RFC3339 timestamp + {0..60} seconds that defines when
+            the matching engine should reject the order.
         :type deadline: str, optional
-        :param truncate: If enabled: round the ``price`` and ``volume`` to Kraken's
-            maximum allowed decimal places. See https://support.kraken.com/hc/en-us/articles/4521313131540
-            fore more information about decimals.
+        :param truncate: If enabled: round the ``price`` and ``volume`` to
+            Kraken's maximum allowed decimal places. See
+            https://support.kraken.com/hc/en-us/articles/4521313131540 fore more
+            information about decimals.
         :type truncate: bool, optional
         :param reduce_only: Reduce existing orders (default: ``False``)
         :type reduce_only: bool, optional
-        :param validate: Validate the order without placing on the market (default: ``False``)
+        :param validate: Validate the order without placing on the market
+            (default: ``False``)
         :type validate: bool, optional
         :param userref: User reference id for example to group orders
         :type userref: int, optional
@@ -231,69 +246,50 @@ class Trade(KrakenSpotBaseAPI):
             :linenos:
             :caption: Spot Trade: Create stop-loss-limit and take-profit-limit orders
 
-            '''
-            When the price hits $25000:
+            ''' When the price hits $25000:
                1. A limit buy order will be placed at $24000 with 2x leverage.
-               2. When the limit order gets closed/filled at $24000
-                  The stop-loss-limit part is done and the tale-profit-limit
-                  part begins.
+               2. When the limit order gets closed/filled at $24000 The
+                  stop-loss-limit part is done and the tale-profit-limit part
+                  begins.
                3. When the price hits $27000 a limit order will be placed at
-                  $26800 to sell 1.2 BTC. This ensures that the asset will
-                  be sold for $26800 or better.
-            '''
-            >>> from kraken.spot import Trade
-            >>> trade = Trade(key="api-key", secret="secret-key")
-            >>> from datetime import datetime, timedelta, timezone
-            >>> deadline = (
-            ...     datetime.now(timezone.utc) + timedelta(seconds=20)
-            ... ).isoformat()
-            >>> trade.create_order(
-            ...     ordertype="stop-loss-limit",
-            ...     pair="XBTUSD",
-            ...     side="buy",
-            ...     volume=1.2,
-            ...     price=24000,
-            ...     price2=25000,
-            ...     validate=True, # just validate the input, do not place on the market
-            ...     trigger="last",
-            ...     timeinforce="GTC",
-            ...     leverage=4,
-            ...     deadline=deadline,
-            ...     close_ordertype="take-profit-limit",
-            ...     close_price=27000,
-            ...     close_price2=26800,
-            ... )
-            {
+                  $26800 to sell 1.2 BTC. This ensures that the asset will be
+                  sold for $26800 or better.
+            ''' >>> from kraken.spot import Trade >>> trade =
+            Trade(key="api-key", secret="secret-key") >>> from datetime import
+            datetime, timedelta, timezone >>> deadline = ( ...
+            datetime.now(timezone.utc) + timedelta(seconds=20) ... ).isoformat()
+            >>> trade.create_order( ...     ordertype="stop-loss-limit", ...
+            pair="XBTUSD", ...     side="buy", ...     volume=1.2, ...
+            price=24000, ...     price2=25000, ...     validate=True, # just
+            validate the input, do not place on the market ...
+            trigger="last", ...     timeinforce="GTC", ...     leverage=4, ...
+            deadline=deadline, ...     close_ordertype="take-profit-limit", ...
+            close_price=27000, ...     close_price2=26800, ... ) {
                 'descr': {
-                    'order': 'buy 0.00100000 XBTUSD @ stop loss 24000.0 -> limit 25000.0 with 2:1 leverage',
-                    'close': 'close position @ take profit 27000.0 -> limit 26800.0'
+                    'order': 'buy 0.00100000 XBTUSD @ stop loss 24000.0 -> limit
+                    25000.0 with 2:1 leverage', 'close': 'close position @ take
+                    profit 27000.0 -> limit 26800.0'
                 }
             }
 
-            '''
-            The price2 and close_price2 can also be set to absolut or relative changes.
-                * Prefixed using "+" or "-" defines the change in the quote asset
-                * Prefixed by # is the same as "+" and "-" but the sign is set automatically
-                * The the percentage sign "%" can be used to define relative changes.
-            '''
-            >>> trade.create_order(
-            ...     ordertype="stop-loss-limit",
-            ...     pair="XBTUSD",
-            ...     side="buy",
-            ...     volume=1.2,
-            ...     price=24000,
-            ...     price2="+1000",
-            ...     validate=True,
-            ...     trigger="last",
-            ...     timeinforce="GTC",
-            ...     close_ordertype="take-profit-limit",
-            ...     close_price=27000,
-            ...     close_price2="#2%",
-            ... )
-            {
+            ''' The price2 and close_price2 can also be set to absolut or
+            relative changes.
+                * Prefixed using "+" or "-" defines the change in the quote
+                  asset
+                * Prefixed by # is the same as "+" and "-" but the sign is set
+                  automatically
+                * The the percentage sign "%" can be used to define relative
+                  changes.
+            ''' >>> trade.create_order( ...     ordertype="stop-loss-limit", ...
+            pair="XBTUSD", ...     side="buy", ...     volume=1.2, ...
+            price=24000, ...     price2="+1000", ...     validate=True, ...
+            trigger="last", ...     timeinforce="GTC", ...
+            close_ordertype="take-profit-limit", ...     close_price=27000, ...
+            close_price2="#2%", ... ) {
                 'descr': {
-                    'order': 'buy 0.00100000 XBTUSD @ stop loss 24000.0 -> limit +1000.0',
-                    'close': 'close position @ take profit 27000.0 -> limit -2.0000%'
+                    'order': 'buy 0.00100000 XBTUSD @ stop loss 24000.0 -> limit
+                    +1000.0', 'close': 'close position @ take profit 27000.0 ->
+                    limit -2.0000%'
                 }
             }
         """

--- a/kraken/spot/user.py
+++ b/kraken/spot/user.py
@@ -28,9 +28,11 @@ class User(KrakenSpotBaseAPI):
     :type key: str, optional
     :param secret: Spot API secret key (default: ``""``)
     :type secret: str, optional
-    :param url: The URL to access the Kraken API (default: https://api.kraken.com)
+    :param url: The URL to access the Kraken API (default:
+        https://api.kraken.com)
     :type url: str, optional
-    :param sandbox: Use the sandbox (not supported for Spot trading so far, default: ``False``)
+    :param sandbox: Use the sandbox (not supported for Spot trading so far,
+        default: ``False``)
     :type sandbox: bool, optional
 
     .. code-block:: python
@@ -104,16 +106,15 @@ class User(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Retrieve the user's asset balances and the
-        the corresponding amount held by open orders.
+        Retrieve the user's asset balances and the the corresponding amount held
+        by open orders.
 
         Requires the ``Query funds`` permission in the API key settings.
 
-        :return: Dictionary containing the ``currency`` as keys, that
-            hold a dictionary containing the ``balance`` key
-            holding the actual balance including the value in orders
-            and the ``hold_trade`` key that represents the amount
-            held in open orders.
+        :return: Dictionary containing the ``currency`` as keys, that hold a
+            dictionary containing the ``balance`` key holding the actual balance
+            including the value in orders and the ``hold_trade`` key that
+            represents the amount held in open orders.
         :rtype: dict
 
         .. code-block:: python
@@ -197,12 +198,13 @@ class User(KrakenSpotBaseAPI):
         """
         Get the summary of all collateral balances.
 
-        Requires the ``Query funds``, ``Query open orders & trades``,
-        and ``Query closed orders & trades`` permissions in the API key settings.
+        Requires the ``Query funds``, ``Query open orders & trades``, and
+        ``Query closed orders & trades`` permissions in the API key settings.
 
         - https://docs.kraken.com/rest/#operation/getTradeBalance
 
-        :param asset: The base asset to determine the balances (default: ``ZUSD``)
+        :param asset: The base asset to determine the balances (default:
+            ``ZUSD``)
         :type asset: str, optional
 
         .. code-block:: python
@@ -416,8 +418,8 @@ class User(KrakenSpotBaseAPI):
         """
         Get information about one or more orders.
 
-        Requires the ``Query open orders & trades`` and
-        ``Query closed orders & trades`` permissions in the API key settings.
+        Requires the ``Query open orders & trades`` and ``Query closed orders &
+        trades`` permissions in the API key settings.
 
         - https://docs.kraken.com/rest/#tag/User-Data/operation/getOrdersInfo
 
@@ -530,21 +532,24 @@ class User(KrakenSpotBaseAPI):
         """
         Get information about the latest 50 trades and fills. Can be paginated.
 
-        Requires the ``Query closed orders & trades`` permission in the API key settings.
+        Requires the ``Query closed orders & trades`` permission in the API key
+        settings.
 
         - https://docs.kraken.com/rest/#operation/getTradeHistory
 
-        :param type_: Filter by type of trade, one of: ``all``,
-            ``any position``, ``closed position``, ``closing position``, and
-            ``no position`` (default: ``all``)
+        :param type_: Filter by type of trade, one of: ``all``, ``any
+            position``, ``closed position``, ``closing position``, and ``no
+            position`` (default: ``all``)
         :type type_: str, optional
         :param start: Timestamp or txid to start the search
         :type start: int, optional
         :param end: Timestamp or txid to define the last included result
         :type end: int, optional
-        :param trades: Include trades related to a position or not (default: ``False``)
+        :param trades: Include trades related to a position or not (default:
+            ``False``)
         :type trades: bool, optional
-        :param consolidate_taker: Consolidate trades by individual taker trades (default: ``True``)
+        :param consolidate_taker: Consolidate trades by individual taker trades
+            (default: ``True``)
         :type consolidate_taker: bool
 
         .. code-block:: python
@@ -605,16 +610,19 @@ class User(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Get information about specific trades/filled orders. 20 txids can be queried maximum.
+        Get information about specific trades/filled orders. 20 txids can be
+        queried maximum.
 
-        Requires the ``Query open orders & trades`` and ``Query closed orders & trades``
-        permission in the API key settings.
+        Requires the ``Query open orders & trades`` and ``Query closed orders &
+        trades`` permission in the API key settings.
 
         - https://docs.kraken.com/rest/#operation/getTradesInfo
 
-        :param txid: txid or list of txids or comma delimited list of txids as string
+        :param txid: txid or list of txids or comma delimited list of txids as
+            string
         :type txid: str | list[str]
-        :param trades: Include trades related to position in result (default: ``False``)
+        :param trades: Include trades related to position in result (default:
+            ``False``)
         :type trades: bool
 
         .. code-block:: python
@@ -665,15 +673,19 @@ class User(KrakenSpotBaseAPI):
         """
         Get information about the open margin positions.
 
-        Requires the ``Query open orders & trades`` permission in the API key settings.
+        Requires the ``Query open orders & trades`` permission in the API key
+        settings.
 
         - https://docs.kraken.com/rest/#operation/getOpenPositions
 
-        :param txid: Filter by txid or list of txids or comma delimited list of txids as string
+        :param txid: Filter by txid or list of txids or comma delimited list of
+            txids as string
         :type txid: str | list[str], optional
-        :param consolidation: Consolidate positions by market/pair (default: ``market``)
+        :param consolidation: Consolidate positions by market/pair (default:
+            ``market``)
         :type consolidation: str, optional
-        :param docalcs: Include profit and loss calculation into the result (default: ``False``)
+        :param docalcs: Include profit and loss calculation into the result
+            (default: ``False``)
         :type docalcs: bool, optional
         :return: List of open positions
         :rtype: dict
@@ -730,7 +742,8 @@ class User(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Get information about the users ledger entries. 50 results can be returned at a time.
+        Get information about the users ledger entries. 50 results can be
+        returned at a time.
 
         Requires the ``Query funds`` and ``Query ledger entries`` permissions in
         the API key settings.
@@ -742,8 +755,8 @@ class User(KrakenSpotBaseAPI):
         :param aclass: The asset class (default: ``currency`` )
         :type aclass: str
         :param type_: Ledger type, one of: ``all``, ``deposit``, ``withdrawal``,
-         ``trade``, ``margin``, ``rollover``, ``credit``, ``transfer``, ``settled``,
-         ``staking``, and ``sale`` (default: ``all``)
+         ``trade``, ``margin``, ``rollover``, ``credit``, ``transfer``,
+         ``settled``, ``staking``, and ``sale`` (default: ``all``)
         :type type_: str, optional
         :param start: Unix timestamp to start the search from
         :type start: int, optional
@@ -811,8 +824,8 @@ class User(KrakenSpotBaseAPI):
         :param id_: Ledger id as string, list of strings, or comma delimited
             list of ledger ids as string
         :type id_: str | list[str]
-        :param trades: Include trades related to a position or not
-            (default: ``False``)
+        :param trades: Include trades related to a position or not (default:
+            ``False``)
         :type trades: bool, optional
 
         .. code-block:: python
@@ -858,8 +871,8 @@ class User(KrakenSpotBaseAPI):
 
         - https://docs.kraken.com/rest/#operation/getTradeVolume
 
-        :param pair: Asset pair, list of asset pairs or comma delimited list
-            (as string) of asset pairs to filter
+        :param pair: Asset pair, list of asset pairs or comma delimited list (as
+            string) of asset pairs to filter
         :type pair: str | list[str], optional
         :param fee_info: Include fee information or not (default: ``True``)
         :type fee_info: bool, optional
@@ -930,10 +943,10 @@ class User(KrakenSpotBaseAPI):
         """
         Request to export the trades or ledgers of the user.
 
-        Requires the ``Export data`` permission. In addition for exporting trades
-        data the permissions ``Query open orders & trades`` and
-        ``Query closed orders & trades`` must be set. For exporting ledgers the
-        ``Query funds`` and ``Query ledger entries`` must be set.
+        Requires the ``Export data`` permission. In addition for exporting
+        trades data the permissions ``Query open orders & trades`` and ``Query
+        closed orders & trades`` must be set. For exporting ledgers the ``Query
+        funds`` and ``Query ledger entries`` must be set.
 
         - https://docs.kraken.com/rest/#operation/addExport
 
@@ -994,10 +1007,10 @@ class User(KrakenSpotBaseAPI):
         """
         Get the status of the current pending report.
 
-        Requires the ``Export data`` permission. In addition for exporting trades
-        data the permissions ``Query open orders & trades`` and
-        ``Query closed orders & trades`` must be set. For exporting ledgers the
-        ``Query funds`` and ``Query ledger entries`` must be set.
+        Requires the ``Export data`` permission. In addition for exporting
+        trades data the permissions ``Query open orders & trades`` and ``Query
+        closed orders & trades`` must be set. For exporting ledgers the ``Query
+        funds`` and ``Query ledger entries`` must be set.
 
         - https://docs.kraken.com/rest/#operation/exportStatus
 
@@ -1058,10 +1071,10 @@ class User(KrakenSpotBaseAPI):
         """
         Retrieve the requested report export.
 
-        Requires the ``Export data`` permission. In addition for exporting trades
-        data the permissions ``Query open orders & trades`` and
-        ``Query closed orders & trades`` must be set. For exporting ledgers the
-        ``Query funds`` and ``Query ledger entries`` must be set.
+        Requires the ``Export data`` permission. In addition for exporting
+        trades data the permissions ``Query open orders & trades`` and ``Query
+        closed orders & trades`` must be set. For exporting ledgers the ``Query
+        funds`` and ``Query ledger entries`` must be set.
 
         - https://docs.kraken.com/rest/#operation/retrieveExport
 
@@ -1108,16 +1121,17 @@ class User(KrakenSpotBaseAPI):
         """
         Delete a report from the Kraken server.
 
-        Requires the ``Export data`` permission. In addition for exporting trades
-        data the permissions ``Query open orders & trades`` and
-        ``Query closed orders & trades`` must be set. For exporting ledgers the
-        ``Query funds`` and ``Query ledger entries`` must be set.
+        Requires the ``Export data`` permission. In addition for exporting
+        trades data the permissions ``Query open orders & trades`` and ``Query
+        closed orders & trades`` must be set. For exporting ledgers the ``Query
+        funds`` and ``Query ledger entries`` must be set.
 
         - https://docs.kraken.com/rest/#operation/removeExport
 
         :param id_: The id of the report
         :type id_: str
-        :param type_: The type of the export, one of: ``cancel`` and ``delete`` (default: ``delete``)
+        :param type_: The type of the export, one of: ``cancel`` and ``delete``
+            (default: ``delete``)
         :type type_: str, optional
         :return: Success or failure
         :rtype: dict
@@ -1146,8 +1160,8 @@ class User(KrakenSpotBaseAPI):
         extra_params: Optional[dict] = None,
     ) -> dict:
         """
-        Create a subaccount for trading. This is currently *only available
-        for institutional clients*.
+        Create a subaccount for trading. This is currently *only available for
+        institutional clients*.
 
         - https://docs.kraken.com/rest/#tag/User-Subaccounts
 
@@ -1185,8 +1199,8 @@ class User(KrakenSpotBaseAPI):
     ) -> dict:
         """
         Transfer funds between master and subaccounts. This is currently *only
-        available for institutional clients and must be called by the
-        master account*.
+        available for institutional clients and must be called by the master
+        account*.
 
         - https://docs.kraken.com/rest/#tag/User-Subaccounts/operation/accountTransfer
 

--- a/kraken/spot/websocket/connectors.py
+++ b/kraken/spot/websocket/connectors.py
@@ -450,9 +450,9 @@ class ConnectSpotWebsocketV1(ConnectSpotWebsocketBase):
 class ConnectSpotWebsocketV2(ConnectSpotWebsocketBase):
     """
     This class extends the
-    :class:`kraken.spot.websocket.connectors.ConnectSpotWebsocketBase` and
-    can be instantiated to create and maintain a websocket connection using
-    the Kraken Websocket API v2.
+    :class:`kraken.spot.websocket.connectors.ConnectSpotWebsocketBase` and can
+    be instantiated to create and maintain a websocket connection using the
+    Kraken Websocket API v2.
 
     **This is an internal class and should not be used outside.**
 
@@ -462,8 +462,8 @@ class ConnectSpotWebsocketV2(ConnectSpotWebsocketBase):
     :type endpoint: str
     :param callback: Callback function that receives the websocket messages
     :type callback: function
-    :param is_auth: If the websocket connects to endpoints that
-        require authentication (default: ``False``)
+    :param is_auth: If the websocket connects to endpoints that require
+        authentication (default: ``False``)
     :type is_auth: bool, optional
     """
 

--- a/kraken/spot/websocket_v1.py
+++ b/kraken/spot/websocket_v1.py
@@ -33,11 +33,11 @@ class KrakenSpotWSClientV1(KrakenSpotWSClientBase):
     … please use :class:`KrakenSpotWSClientV2` for accessing the Kraken
     Websockets API v2.
 
-    This class holds up to two websocket connections, one private
-    and one public.
+    This class holds up to two websocket connections, one private and one
+    public.
 
-    When accessing private endpoints that need authentication make sure,
-    that the ``Access WebSockets API`` API key permission is set in the user's
+    When accessing private endpoints that need authentication make sure, that
+    the ``Access WebSockets API`` API key permission is set in the user's
     account. To place or cancel orders, querying ledger information or accessing
     live portfolio changes (fills, new orders, ...) there are separate
     permissions that must be enabled if required.
@@ -48,10 +48,10 @@ class KrakenSpotWSClientV1(KrakenSpotWSClientBase):
     :type secret: str, optional
     :param url: Set a specific URL to access the Kraken REST API
     :type url: str, optional
-    :param no_public: Disables public connection (default: ``False``).
-        If not set or set to ``False``, the client will create a public and
-        a private connection per default. If only a private connection is
-        required, this parameter should be set to ``True``.
+    :param no_public: Disables public connection (default: ``False``). If not
+        set or set to ``False``, the client will create a public and a private
+        connection per default. If only a private connection is required, this
+        parameter should be set to ``True``.
     :param beta: Use the beta websocket channels (maybe not supported anymore,
         default: ``False``)
     :type beta: bool
@@ -181,9 +181,8 @@ class KrakenSpotWSClientV1(KrakenSpotWSClientBase):
         raw: bool = False,
     ) -> None:
         """
-        Sends a message via the websocket connection. For private messages
-        the authentication token will be assigned automatically if
-        ``raw=False``.
+        Sends a message via the websocket connection. For private messages the
+        authentication token will be assigned automatically if ``raw=False``.
 
         The user can specify a ``reqid`` within the message to identify
         corresponding responses via websocket feed.
@@ -461,8 +460,8 @@ class KrakenSpotWSClientV1(KrakenSpotWSClientBase):
         :type timeinforce: str, optional
         :param truncate: If enabled: round the ``price`` and ``volume`` to
             Kraken's maximum allowed decimal places. See
-            https://support.kraken.com/hc/en-us/articles/4521313131540
-            fore more information about decimals.
+            https://support.kraken.com/hc/en-us/articles/4521313131540 fore more
+            information about decimals.
         :type truncate: bool, optional
         :param validate: Validate the order without placing on the market
             (default: ``False``)
@@ -586,8 +585,8 @@ class KrakenSpotWSClientV1(KrakenSpotWSClientBase):
         :type oflags: str | list[str], optional
         :param newuserref: Set a new user reference id
         :type newuserref: str | int, optional
-        :param truncate: If enabled: round the ``price`` and ``volume`` to Kraken's
-            maximum allowed decimal places. See
+        :param truncate: If enabled: round the ``price`` and ``volume`` to
+            Kraken's maximum allowed decimal places. See
             https://support.kraken.com/hc/en-us/articles/4521313131540 fore more
             information about decimals.
         :type truncate: bool, optional

--- a/kraken/spot/websocket_v2.py
+++ b/kraken/spot/websocket_v2.py
@@ -28,17 +28,16 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
 
     - https://docs.kraken.com/websockets-v2
 
-    … please use :class:`kraken.spot.KrakenSpotWSClientV1` for accessing the Kraken's
-    Websocket API v1.
+    … please use :class:`kraken.spot.KrakenSpotWSClientV1` for accessing the
+    Kraken's Websocket API v1.
 
-    This class holds up to two websocket connections, one private
-    and one public. The core functionalities are un-/subscribing to websocket
-    feeds and sending messages.
-    See :func:`kraken.spot.KrakenSpotWSClientV2.subscribe` and
+    This class holds up to two websocket connections, one private and one
+    public. The core functionalities are un-/subscribing to websocket feeds and
+    sending messages. See :func:`kraken.spot.KrakenSpotWSClientV2.subscribe` and
     :func:`kraken.spot.KrakenSpotWSClientV2.send_message` for more information.
 
-    When accessing private endpoints that need authentication make sure,
-    that the ``Access WebSockets API`` API key permission is set in the user's
+    When accessing private endpoints that need authentication make sure, that
+    the ``Access WebSockets API`` API key permission is set in the user's
     account. To place or cancel orders, querying ledger information or accessing
     live portfolio changes (fills, new orders, ...) there are separate
     permissions that must be enabled if required.
@@ -49,10 +48,10 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
     :type secret: str, optional
     :param url: Set a specific URL to access the Kraken REST API
     :type url: str, optional
-    :param no_public: Disables public connection (default: ``False``).
-        If not set or set to ``False``, the client will create a public and
-        a private connection per default. If only a private connection is
-        required, this parameter should be set to ``True``.
+    :param no_public: Disables public connection (default: ``False``). If not
+        set or set to ``False``, the client will create a public and a private
+        connection per default. If only a private connection is required, this
+        parameter should be set to ``True``.
     :param beta: Use the beta websocket channels (maybe not supported anymore,
         default: ``False``)
     :type beta: bool
@@ -450,6 +449,7 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
         :param req_id: Identification number that will be added to the
             response message sent by the websocket feed.
         :type req_id: int, optional
+
         Initialize your client as described in
         :class:`kraken.spot.KrakenSpotWSClientV2` to run the following example:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ write_to = "kraken/_version.py"
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 
-# ========= T E S T I N G =====================================================
+# ========= T E S T I N G ======================================================
 #
 [tool.pytest]
 junit_family = "xunit2"
@@ -112,7 +112,7 @@ omit = ["*tests*"]
 exclude_lines = ["coverage: disable", "if TYPE_CHECKING:"]
 skip_empty = true
 
-# ========= T Y P I N G =======================================================
+# ========= T Y P I N G ========================================================
 #
 [tool.mypy]
 python_version = "3.11"
@@ -177,6 +177,8 @@ strict = true
 # ========= L I N T I N G ======================================================
 #
 [tool.ruff]
+# https://beta.ruff.rs/docs/rules/
+# https://beta.ruff.rs/docs/settings/
 # src = ["kraken"]
 
 select = [
@@ -224,8 +226,7 @@ select = [
   # "FIX", # flake8-fixme
   # "TD",  # flake8-todos
   # "TRY",  # tryceratops # specify exception messages in class; not important
-] # https://beta.ruff.rs/docs/rules/
-# https://beta.ruff.rs/docs/settings/
+]
 fixable = [
   "I",
   "C4",
@@ -337,7 +338,7 @@ allow-magic-value-types = ["int"]
 # one or another interpreter, leading to false positives when analyzed.
 # analyse-fallback-blocks =
 
-# Clear in-memory caches upon conclusion of linting. Useful if running pylint in
+# Clear in-memory caches upon conclusion of linting. Useful if running PyLint in
 # a server-like mode.
 # clear-cache-post-run =
 
@@ -394,7 +395,7 @@ ignore-patterns = ["^\\.#"]
 # pygtk.require().
 # init-hook =
 
-# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# Use multiple processes to speed up PyLint. Specifying 0 will auto-detect the
 # number of processors available to use, and will cap the count on Windows to
 # avoid hangs.
 jobs = 2
@@ -412,7 +413,7 @@ limit-inference-results = 100
 persistent = true
 
 # Minimum Python version to use for version dependent checks. Will default to the
-# version used to run pylint.
+# version used to run PyLint.
 py-version = "3.11"
 
 # Discover python modules and packages in the file system subtree.
@@ -424,7 +425,7 @@ py-version = "3.11"
 # source root.
 # source-roots =
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
+# When enabled, PyLint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
 suggestion-mode = true
 
@@ -808,7 +809,7 @@ evaluation = "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refact
 # used to format the message information. See doc for all details.
 # msg-template =
 
-# Set the output format. Available formats are text, parseable, colorized, json
+# Set the output format. Available formats are text, parsable, colorized, json
 # and msvs (visual studio). You can also give a reporter class, e.g.
 # mypackage.mymodule.MyReporterClass.
 # output-format =


### PR DESCRIPTION
Some parts of the documentation and docstrings were throwing errors and warnings during sphinx build. This was fixed now.