### PR TITLE
Fix "Futures re-subscribe to authenticated feed doesn't work"

### DIFF
--- a/.github/workflows/_codecov.yaml
+++ b/.github/workflows/_codecov.yaml
@@ -54,7 +54,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install package
-        run: python -m pip install ".[dev]"
+        run: python -m pip install ".[test]"
 
       - name: Generate coverage report
         env:

--- a/.github/workflows/_test_futures_private.yaml
+++ b/.github/workflows/_test_futures_private.yaml
@@ -43,13 +43,12 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Install dependencies
+      - name: Update Pip
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-mock
 
       - name: Install package
-        run: python -m pip install .
+        run: python -m pip install ".[test]"
 
       ##    Unit tests of the private Futures REST clients and endpoints
       ##

--- a/.github/workflows/_test_futures_private.yaml
+++ b/.github/workflows/_test_futures_private.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest pytest-mock
 
       - name: Install package
         run: python -m pip install .

--- a/.github/workflows/_test_futures_public.yaml
+++ b/.github/workflows/_test_futures_public.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest pytest-mock
 
       - name: Install package
         run: python -m pip install .

--- a/.github/workflows/_test_futures_public.yaml
+++ b/.github/workflows/_test_futures_public.yaml
@@ -33,13 +33,12 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Install dependencies
+      - name: Update Pip
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-mock
 
       - name: Install package
-        run: python -m pip install .
+        run: python -m pip install ".[test]"
 
       ##    Unit tests of the public Futures REST clients and endpoints
       ##

--- a/.github/workflows/_test_spot_private.yaml
+++ b/.github/workflows/_test_spot_private.yaml
@@ -40,13 +40,12 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Install dependencies
+      - name: Update Pip
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-mock
 
       - name: Install package
-        run: python -m pip install .
+        run: python -m pip install ".[test]"
 
       ##    Unit tests of private Spot REST clients and endpoints
       ##

--- a/.github/workflows/_test_spot_private.yaml
+++ b/.github/workflows/_test_spot_private.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest pytest-mock
 
       - name: Install package
         run: python -m pip install .

--- a/.github/workflows/_test_spot_public.yaml
+++ b/.github/workflows/_test_spot_public.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest pytest-mock
 
       - name: Install package
         run: python -m pip install .

--- a/.github/workflows/_test_spot_public.yaml
+++ b/.github/workflows/_test_spot_public.yaml
@@ -33,13 +33,12 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Install dependencies
+      - name: Update Pip
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-mock
 
       - name: Install package
-        run: python -m pip install .
+        run: python -m pip install ".[test]"
 
       ##    Unit tests of the public Spot REST clients and endpoints
       ##

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
         args:
           - --rcfile=pyproject.toml
           - -d=R0801 # ignore duplicate code
+          - j=4
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
         args:
           - --rcfile=pyproject.toml
           - -d=R0801 # ignore duplicate code
-          - j=4
+          - -j=4
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,43 @@
 #
 
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
+    hooks:
+      - id: ruff
+        args:
+          - --preview
+          - --fix
+          - --exit-non-zero-on-fix
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        args:
+          - --select=E9,F63,F7,F82
+          - --show-source
+          - --statistics
+  - repo: https://github.com/pycqa/pylint
+    rev: v3.0.1
+    hooks:
+      - id: pylint
+        name: pylint
+        types: [python]
+        exclude: ^examples/|^tests/|^setup.py$
+        args:
+          - --rcfile=pyproject.toml
+          - -d=R0801 # ignore duplicate code
+          - -j=4
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy
+        name: mypy
+        additional_dependencies: ["types-requests"]
+        pass_filenames: false
+        args:
+          - --config-file=pyproject.toml
+          - kraken
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
@@ -51,40 +88,3 @@ repos:
       - id: isort
         args:
           - --profile=black
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
-    hooks:
-      - id: ruff
-        args:
-          - --preview
-          - --fix
-          - --exit-non-zero-on-fix
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        args:
-          - --select=E9,F63,F7,F82
-          - --show-source
-          - --statistics
-  - repo: https://github.com/pycqa/pylint
-    rev: v3.0.1
-    hooks:
-      - id: pylint
-        name: pylint
-        types: [python]
-        exclude: ^examples/|^tests/|^setup.py$
-        args:
-          - --rcfile=pyproject.toml
-          - -d=R0801 # ignore duplicate code
-          - -j=4
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
-    hooks:
-      - id: mypy
-        name: mypy
-        additional_dependencies: ["types-requests"]
-        pass_filenames: false
-        args:
-          - --config-file=pyproject.toml
-          - kraken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Changelog
 
-## [Unreleased](https://github.com/btschwertfeger/python-kraken-sdk/tree/HEAD)
+## [v2.1.0](https://github.com/btschwertfeger/python-kraken-sdk/tree/v2.1.0) (2023-12-07)
 
-[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v2.0.0...HEAD)
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v2.0.0...v2.1.0)
 
 **Implemented enhancements:**
 
 - Add `start`, `end`, and `cursor` parameters to `kraken.spot.Funding.get_recent_withdraw_status` [\#176](https://github.com/btschwertfeger/python-kraken-sdk/issues/176)
 - Add `withdraw_methods` and `withdraw_addresses` to `kraken.spot.Funding` [\#174](https://github.com/btschwertfeger/python-kraken-sdk/issues/174)
-- Add `start`, `end`, and `cursor` parameters to `kraken.spot.Funding.get_recent_withdraw_status` [\#177](https://github.com/btschwertfeger/python-kraken-sdk/pull/177) ([btschwertfeger](https://github.com/btschwertfeger))
+- Resolve "Add `start`, `end`, and `cursor` parameters to `kraken.spot.Funding.get_recent_withdraw_status`" [\#177](https://github.com/btschwertfeger/python-kraken-sdk/pull/177) ([btschwertfeger](https://github.com/btschwertfeger))
 - Resolve "Add `withdraw_methods` and `withdraw_addresses` to `kraken.spot.Funding`" [\#175](https://github.com/btschwertfeger/python-kraken-sdk/pull/175) ([btschwertfeger](https://github.com/btschwertfeger))
 
 ## [v2.0.0](https://github.com/btschwertfeger/python-kraken-sdk/tree/v2.0.0) (2023-10-22)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 Benjamin Thomas Schwertfeger
 # GitHub: https://github.com/btschwertfeger
 
-PYTHON := python
+PYTHON := venv/bin/python
 PYTEST := $(PYTHON) -m pytest
 PYTEST_OPTS := -vv --junit-xml=pytest.xml
 PYTEST_COV_OPTS := $(PYTEST_OPTS) --cov --cov-report=xml:coverage.xml --cov-report=term
@@ -53,10 +53,10 @@ test:
 .PHONY: tests
 tests: test
 
-## test-wip		Run tests marked as 'wip'
+## wip		Run tests marked as 'wip'
 ##
-.PHONY: test-wip
-test-wip:
+.PHONY: wip
+wip:
 	@rm *.log || true
 	$(PYTEST) -m "wip" -vv $(TEST_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install:
 ##
 .PHONY: dev
 dev:
-	$(PYTHON) -m pip install -e ".[dev]"
+	$(PYTHON) -m pip install -e ".[dev,test]"
 
 ## ======= T E S T I N G =======
 ## test		Run the unit tests

--- a/examples/futures_trading_bot_template.py
+++ b/examples/futures_trading_bot_template.py
@@ -17,12 +17,12 @@ import logging.config
 import os
 import sys
 import traceback
-from typing import Optional, Union
+from typing import Optional
 
 import requests
 import urllib3
 
-from kraken.exceptions import KrakenException
+from kraken.exceptions import KrakenAuthenticationError
 from kraken.futures import Funding, KrakenFuturesWSClient, Market, Trade, User
 
 logging.basicConfig(
@@ -64,7 +64,7 @@ class TradingBot(KrakenFuturesWSClient):
         self.__market: Market = Market(key=config["key"], secret=config["secret"])
         self.__funding: Funding = Funding(key=config["key"], secret=config["secret"])
 
-    async def on_message(self: TradingBot, message: Union[list, dict]) -> None:
+    async def on_message(self: TradingBot, message: list | dict) -> None:
         """Receives all messages that came form the websocket feed(s)"""
         logging.info(message)
 
@@ -90,10 +90,7 @@ class TradingBot(KrakenFuturesWSClient):
 
     def save_exit(self: TradingBot, reason: Optional[str] = "") -> None:
         """Controlled shutdown of the strategy"""
-        logging.warning(
-            "Save exit triggered, reason: {reason}",
-            extra={"reason": reason},
-        )
+        logging.warning("Save exit triggered, reason: %s", reason)
         # some ideas:
         #   * save the bots data
         #   * maybe close trades
@@ -188,7 +185,7 @@ class ManagedBot:
         except requests.exceptions.ConnectionError:
             logging.error("ConnectionError, Kraken not available.")
             return False
-        except KrakenException.KrakenAuthenticationError:
+        except KrakenAuthenticationError:
             logging.error("Invalid credentials!")
             return False
 

--- a/examples/futures_trading_bot_template.py
+++ b/examples/futures_trading_bot_template.py
@@ -88,7 +88,7 @@ class TradingBot(KrakenFuturesWSClient):
 
     # Add more functions to customize the trading strategy …
 
-    def save_exit(self: TradingBot, reason: Optional[str] = "") -> None:
+    def save_exit(self: TradingBot, reason: str = "") -> None:
         """Controlled shutdown of the strategy"""
         logging.warning("Save exit triggered, reason: %s", reason)
         # some ideas:

--- a/kraken/spot/websocket/connectors.py
+++ b/kraken/spot/websocket/connectors.py
@@ -20,7 +20,7 @@ import traceback
 from copy import deepcopy
 from random import random
 from time import time
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Final, Optional
 
 import websockets
 
@@ -175,6 +175,10 @@ class ConnectSpotWebsocketBase:
                 {"error": "Exception stopped the Kraken Spot Websocket Client!"},
             )
             self.__client.exception_occur = True
+
+    async def close_connection(self: ConnectSpotWebsocketBase) -> None:
+        """Closes the websocket connection and thus forces a reconnect"""
+        await self.socket.close()
 
     async def __reconnect(self: ConnectSpotWebsocketBase) -> None:
         """
@@ -345,7 +349,7 @@ class ConnectSpotWebsocketV1(ConnectSpotWebsocketBase):
         :type event: asyncio.Event
         """
         log_msg: str = f'Recover {"authenticated" if self.is_auth else "public"} subscriptions {self._subscriptions}'
-        self.LOG.info("%s waiting.", log_msg)
+        self.LOG.info("%s: waiting", log_msg)
         await event.wait()
 
         for sub in self._subscriptions:
@@ -362,7 +366,7 @@ class ConnectSpotWebsocketV1(ConnectSpotWebsocketBase):
             await self.client.send_message(cpy, private=private)
             self.LOG.info("%s: OK", sub)
 
-        self.LOG.info("%s done.", log_msg)
+        self.LOG.info("%s: done", log_msg)
 
     def _manage_subscriptions(
         self: ConnectSpotWebsocketV1,
@@ -501,14 +505,14 @@ class ConnectSpotWebsocketV2(ConnectSpotWebsocketBase):
         :type event: asyncio.Event
         """
         log_msg: str = f'Recover {"authenticated" if self.is_auth else "public"} subscriptions {self._subscriptions}'
-        self.LOG.info("%s waiting.", log_msg)
+        self.LOG.info("%s: waiting", log_msg)
         await event.wait()
 
         for subscription in self._subscriptions:
             await self.client.subscribe(params=subscription)
             self.LOG.info("%s: OK", subscription)
 
-        self.LOG.info("%s done.", log_msg)
+        self.LOG.info("%s: done", log_msg)
 
     def _manage_subscriptions(self: ConnectSpotWebsocketV2, message: dict) -> None:  # type: ignore[override]
         """
@@ -574,24 +578,32 @@ class ConnectSpotWebsocketV2(ConnectSpotWebsocketBase):
         # Without deepcopy, the passed message will be modified, which is *not*
         # intended.
         subscription_copy: dict = deepcopy(subscription)
+        channel: Final[str] = subscription["result"].get("channel", "")
 
-        # Subscriptions for specific symbols must contain the 'symbols' key with
-        # a value of type list[str]. The python-kraken-sdk is caching active
-        # subscriptions from that moment, the successful response arrives. These
-        # responses must be parsed to use them to resubscribe on connection
-        # losses.
-        if subscription["result"].get("channel", "") in {
-            "book",
-            "ticker",
-            "ohlc",
-            "trade",
-        } and not isinstance(
-            subscription["result"].get("symbol"),
-            list,
-        ):
-            subscription_copy["result"]["symbol"] = [
-                subscription_copy["result"]["symbol"],
-            ]
+        match channel:
+            case "book" | "ticker" | "ohlc" | "trade":
+                # Subscriptions for specific symbols must contain the 'symbols'
+                # key with a value of type list[str]. The python-kraken-sdk is
+                # caching active subscriptions from that moment, the successful
+                # response arrives. These responses must be parsed to use them
+                # to resubscribe on connection losses.
+                if not isinstance(
+                    subscription["result"].get("symbol"),
+                    list,
+                ):
+                    subscription_copy["result"]["symbol"] = [
+                        subscription_copy["result"]["symbol"],
+                    ]
+            case "executions":
+                # Kraken somehow responds with this key - but this is not
+                # accepted when subscribing (Dec 2023).
+                if subscription_copy["method"] == "unsubscribe":
+                    del subscription_copy["result"]["maxratecount"]
+
+        # Sometimes Kraken responds with hints about deprecation - we don't want
+        # to save those data as resubscribing would fail for those cases.
+        if "warnings" in subscription["result"]:
+            del subscription_copy["result"]["warnings"]
 
         return subscription_copy
 

--- a/kraken/spot/websocket/connectors.py
+++ b/kraken/spot/websocket/connectors.py
@@ -227,7 +227,7 @@ class ConnectSpotWebsocketBase:
                     await self.__callback({"error": message})
             if exception_occur:
                 break
-        self.LOG.warning("reconnect over")
+        self.LOG.warning("Connection closed")
 
     def __get_reconnect_wait(
         self: ConnectSpotWebsocketBase,

--- a/kraken/spot/websocket/connectors.py
+++ b/kraken/spot/websocket/connectors.py
@@ -597,7 +597,10 @@ class ConnectSpotWebsocketV2(ConnectSpotWebsocketBase):
             case "executions":
                 # Kraken somehow responds with this key - but this is not
                 # accepted when subscribing (Dec 2023).
-                if subscription_copy["method"] == "unsubscribe":
+                if (
+                    subscription_copy["method"] == "unsubscribe"
+                    and "maxratecount" in subscription["result"]
+                ):
                     del subscription_copy["result"]["maxratecount"]
 
         # Sometimes Kraken responds with hints about deprecation - we don't want

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,6 @@ classifiers = [
 dev = [
   # building
   "build",
-  # testing
-  "pytest",
-  "pytest-cov",
-  "pytest-mock",
   # documentation
   "sphinx",
   "sphinx-rtd-theme",
@@ -60,6 +56,7 @@ dev = [
   "ruff",
   "pylint",
 ]
+test = ["pytest", "pytest-cov", "pytest-mock"]
 examples = ["matplotlib"]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
   # testing
   "pytest",
   "pytest-cov",
+  "pytest-mock",
   # documentation
   "sphinx",
   "sphinx-rtd-theme",

--- a/tests/futures/helper.py
+++ b/tests/futures/helper.py
@@ -10,7 +10,7 @@ import logging
 from asyncio import sleep
 from pathlib import Path
 from time import time
-from typing import Any, Union
+from typing import Any
 
 from kraken.futures import KrakenFuturesWSClient
 
@@ -47,7 +47,7 @@ class FuturesWebsocketClientTestWrapper(KrakenFuturesWSClient):
     LOG: logging.Logger = logging.getLogger(__name__)
 
     def __init__(
-        self: "FuturesWebsocketClientTestWrapper",
+        self: FuturesWebsocketClientTestWrapper,
         key: str = "",
         secret: str = "",
     ) -> None:
@@ -55,8 +55,8 @@ class FuturesWebsocketClientTestWrapper(KrakenFuturesWSClient):
         self.LOG.setLevel(logging.INFO)
 
     async def on_message(
-        self: "FuturesWebsocketClientTestWrapper",
-        message: Union[list, dict],
+        self: FuturesWebsocketClientTestWrapper,
+        message: list | dict,
     ) -> None:
         """
         This is the callback function that must be implemented

--- a/tests/futures/test_futures_websocket.py
+++ b/tests/futures/test_futures_websocket.py
@@ -287,7 +287,6 @@ def test_get_active_subscriptions(caplog: Any) -> None:
         assert expected in caplog.text
 
 
-@pytest.mark.wip()
 @pytest.mark.futures()
 @pytest.mark.futures_auth()
 @pytest.mark.futures_websocket()

--- a/tests/futures/test_futures_websocket.py
+++ b/tests/futures/test_futures_websocket.py
@@ -328,7 +328,7 @@ def test_resubscribe(
     asyncio.run(check_resubscribe())
     for phrase in (
         "Websocket connected!",
-        "exception=ConnectionClosedOK(Close(code=1000, reason=''), Close(code=1000, reason=''), False)> got an exception sent 1000 (OK); then received 1000 (OK)",
+        "got an exception sent 1000 (OK); then received 1000 (OK)",
         "Connection closed",
         "Recover subscriptions [{'event': 'subscribe', 'feed': 'open_orders'}]: waiting",
         "Recover subscriptions [{'event': 'subscribe', 'feed': 'open_orders'}]: done",

--- a/tests/futures/test_futures_websocket.py
+++ b/tests/futures/test_futures_websocket.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 import pytest
@@ -169,7 +170,10 @@ def test_subscribe_private(
             await client.subscribe(feed="fills", products=["PI_XBTUSD"])
 
         await client.subscribe(feed="open_orders")
-        await async_wait(2)
+        await async_wait(seconds=2)
+
+        assert len(client.get_active_subscriptions()) == 1
+        await async_wait(seconds=1)
 
     asyncio.run(submit_subscription())
 
@@ -281,3 +285,58 @@ def test_get_active_subscriptions(caplog: Any) -> None:
         "{'event': 'unsubscribed', 'feed': 'ticker', 'product_ids': ['PI_XBTUSD']}",
     ):
         assert expected in caplog.text
+
+
+@pytest.mark.wip()
+@pytest.mark.futures()
+@pytest.mark.futures_auth()
+@pytest.mark.futures_websocket()
+def test_resubscribe(
+    futures_api_key: str,
+    futures_secret_key: str,
+    caplog: Any,
+    mocker: Any,
+) -> None:
+    """
+    Test that forces a reconnect by closing the connection to check if the
+    authenticated feeds will be resubscribed correctly.
+    """
+    caplog.set_level(logging.INFO)
+
+    async def check_resubscribe() -> None:
+        client: FuturesWebsocketClientTestWrapper = FuturesWebsocketClientTestWrapper(
+            key=futures_api_key,
+            secret=futures_secret_key,
+        )
+
+        assert client.get_active_subscriptions() == []
+        await async_wait(seconds=1)
+
+        await client.subscribe(feed="open_orders")
+        await async_wait(seconds=2)
+        assert len(client.get_active_subscriptions()) == 1
+
+        mocker.patch.object(
+            client._conn,
+            "_ConnectFuturesWebsocket__get_reconnect_wait",
+            return_value=2,
+        )
+
+        await client._conn.close_connection()
+        await async_wait(seconds=5)
+        assert len(client.get_active_subscriptions()) == 1
+
+    asyncio.run(check_resubscribe())
+    for phrase in (
+        "Websocket connected!",
+        "exception=ConnectionClosedOK(Close(code=1000, reason=''), Close(code=1000, reason=''), False)> got an exception sent 1000 (OK); then received 1000 (OK)",
+        "Connection closed",
+        "Recover subscriptions [{'event': 'subscribe', 'feed': 'open_orders'}]: waiting",
+        "Recover subscriptions [{'event': 'subscribe', 'feed': 'open_orders'}]: done",
+    ):
+        assert phrase in caplog.text
+
+    assert (
+        "{'event': 'alert', 'message': 'Failed to subscribe to authenticated feed'}"
+        not in caplog.text
+    )

--- a/tests/spot/test_spot_funding.py
+++ b/tests/spot/test_spot_funding.py
@@ -164,7 +164,6 @@ def test_wallet_transfer(spot_auth_funding: Funding) -> None:
 
 
 @pytest.mark.spot()
-@pytest.mark.wip()
 @pytest.mark.spot_auth()
 @pytest.mark.spot_funding()
 @pytest.mark.skip(reason="CI does not have withdraw permission")
@@ -187,7 +186,6 @@ def test_withdraw_methods(spot_auth_funding: Funding) -> None:
 
 
 @pytest.mark.spot()
-@pytest.mark.wip()
 @pytest.mark.spot_auth()
 @pytest.mark.spot_funding()
 @pytest.mark.skip(reason="CI does not have withdraw permission")

--- a/tests/spot/test_spot_websocket_v1.py
+++ b/tests/spot/test_spot_websocket_v1.py
@@ -489,29 +489,63 @@ def test_send_private_message_from_public_connection_failing() -> None:
     asyncio_run(test_send_message())
 
 
-# todo: Create a test that kills the websocket connection to test the reconnect.
-# from unittest import mock
-# import json
-# @pytest.mark.spot
-# @pytest.mark.spot_websocket
-# @pytest.mark.spot_websocket_v1
-# @mock.patch(
-#     "kraken.spot.websocket.json.loads",
-# )
-# def test_reconnect(mock_json_loads: mock.MagicMock, caplog: Any) -> None:
-#     mock_json_loads.side_effect = (
-#         [json.dumps({"valid": "message"})]
-#         + [AttributeError("Test Error")]
-#         + [json.dumps({"valid": "message"})] * 10000
-#     )
+@pytest.mark.spot()
+@pytest.mark.spot_auth()
+@pytest.mark.spot_websocket()
+@pytest.mark.spot_websocket_v1()
+def test_reconnect(
+    spot_api_key: str,
+    spot_secret_key: str,
+    caplog: Any,
+    mocker: Any,
+) -> None:
+    """
+    Checks if the reconnect works properly when forcing a closed connection.
+    """
+    caplog.set_level(logging.INFO)
 
-#     async def check_reconnect() -> None:
-#         client: SpotWebsocketClientV1TestWrapper = SpotWebsocketClientV1TestWrapper()
-#         await async_wait(seconds=60)
+    async def check_reconnect() -> None:
+        client: SpotWebsocketClientV1TestWrapper = SpotWebsocketClientV1TestWrapper(
+            key=spot_api_key,
+            secret=spot_secret_key,
+        )
+        await async_wait(seconds=2)
 
-#     asyncio_run(check_reconnect())
-#     # with open("x.log", "w") as f:
-#     #     f.write(caplog.text)
+        await client.subscribe(subscription={"name": "ticker"}, pair=["XBT/USD"])
+        await client.subscribe(subscription={"name": "openOrders"})
+        await async_wait(seconds=2)
+
+        for obj in (client._priv_conn, client._pub_conn):
+            mocker.patch.object(
+                obj,
+                "_ConnectSpotWebsocketBase__get_reconnect_wait",
+                return_value=2,
+            )
+        await client._pub_conn.close_connection()
+        await client._priv_conn.close_connection()
+
+        await async_wait(seconds=5)
+
+    asyncio_run(check_reconnect())
+
+    for phrase in (
+        "Recover public subscriptions []: waiting",
+        "Recover authenticated subscriptions []: waiting",
+        "Recover public subscriptions []: done",
+        "Recover authenticated subscriptions []: done",
+        "Websocket connected!",
+        "'event': 'systemStatus', 'status': 'online', 'version': '1.9.1'}",
+        "'openOrders', 'event': 'subscriptionStatus', 'status': 'subscribed',",
+        "'channelName': 'ticker', 'event': 'subscriptionStatus', 'pair': 'XBT/USD', 'status': 'subscribed', 'subscription': {'name': 'ticker'}",
+        "got an exception sent 1000 (OK); then received 1000 (OK)",
+        "Recover public subscriptions [{'event': 'subscribe', 'pair': ['XBT/USD'], 'subscription': {'name': 'ticker'}}]: waiting",
+        "Recover authenticated subscriptions [{'event': 'subscribe', 'subscription': {'name': 'openOrders'}}]: waiting",
+        "{'event': 'subscribe', 'pair': ['XBT/USD'], 'subscription': {'name': 'ticker'}}: OK",
+        "{'event': 'subscribe', 'subscription': {'name': 'openOrders'}}: OK",
+        "Recover public subscriptions [{'event': 'subscribe', 'pair': ['XBT/USD'], 'subscription': {'name': 'ticker'}}]: done",
+        "Recover authenticated subscriptions [{'event': 'subscribe', 'subscription': {'name': 'openOrders'}}]: done",
+    ):
+        assert phrase in caplog.text
 
 
 # ------------------------------------------------------------------------------
@@ -875,62 +909,3 @@ def test_cancel_all_orders_after_failing_no_connection(caplog: Any) -> None:
         "Can't cancel all orders after - Authenticated websocket not connected!"
         not in caplog.text
     )
-
-
-@pytest.mark.spot()
-@pytest.mark.spot_auth()
-@pytest.mark.spot_websocket()
-@pytest.mark.spot_websocket_v1()
-def test_reconnect(
-    spot_api_key: str,
-    spot_secret_key: str,
-    caplog: Any,
-    mocker: Any,
-) -> None:
-    """
-    Checks if the reconnect works properly when forcing a closed connection.
-    """
-    caplog.set_level(logging.INFO)
-
-    async def check_reconnect() -> None:
-        client: SpotWebsocketClientV1TestWrapper = SpotWebsocketClientV1TestWrapper(
-            key=spot_api_key,
-            secret=spot_secret_key,
-        )
-        await async_wait(seconds=2)
-
-        await client.subscribe(subscription={"name": "ticker"}, pair=["XBT/USD"])
-        await client.subscribe(subscription={"name": "openOrders"})
-        await async_wait(seconds=2)
-
-        for obj in (client._priv_conn, client._pub_conn):
-            mocker.patch.object(
-                obj,
-                "_ConnectSpotWebsocketBase__get_reconnect_wait",
-                return_value=2,
-            )
-        await client._pub_conn.close_connection()
-        await client._priv_conn.close_connection()
-
-        await async_wait(seconds=5)
-
-    asyncio_run(check_reconnect())
-
-    for phrase in (
-        "Recover public subscriptions []: waiting",
-        "Recover authenticated subscriptions []: waiting",
-        "Recover public subscriptions []: done",
-        "Recover authenticated subscriptions []: done",
-        "Websocket connected!",
-        "'event': 'systemStatus', 'status': 'online', 'version': '1.9.1'}",
-        "'openOrders', 'event': 'subscriptionStatus', 'status': 'subscribed',",
-        "'channelName': 'ticker', 'event': 'subscriptionStatus', 'pair': 'XBT/USD', 'status': 'subscribed', 'subscription': {'name': 'ticker'}",
-        "exception=ConnectionClosedOK(Close(code=1000, reason=''), Close(code=1000, reason=''), False)> got an exception sent 1000 (OK); then received 1000 (OK)",
-        "Recover public subscriptions [{'event': 'subscribe', 'pair': ['XBT/USD'], 'subscription': {'name': 'ticker'}}]: waiting",
-        "Recover authenticated subscriptions [{'event': 'subscribe', 'subscription': {'name': 'openOrders'}}]: waiting",
-        "{'event': 'subscribe', 'pair': ['XBT/USD'], 'subscription': {'name': 'ticker'}}: OK",
-        "{'event': 'subscribe', 'subscription': {'name': 'openOrders'}}: OK",
-        "Recover public subscriptions [{'event': 'subscribe', 'pair': ['XBT/USD'], 'subscription': {'name': 'ticker'}}]: done",
-        "Recover authenticated subscriptions [{'event': 'subscribe', 'subscription': {'name': 'openOrders'}}]: done",
-    ):
-        assert phrase in caplog.text

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -379,7 +379,7 @@ def test_private_unsubscribe(
     asyncio_run(check_unsubscribe())
 
     for expected in (
-        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true}, "success": true, "time_in": ',
+        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true", "success": true, "time_in": ',
         '{"method": "unsubscribe", "req_id": 987654321, "result": {"channel": "executions"}, "success": true, "time_in": ',
     ):
         assert expected in caplog.text

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -14,11 +14,11 @@ NOTE:
     finally the logs are read out and its input is checked for the expected
     output.
 
-todo: check recover subscriptions
 """
 
 from __future__ import annotations
 
+import logging
 from asyncio import run as asyncio_run
 from copy import deepcopy
 from typing import Any
@@ -285,11 +285,11 @@ def test_private_subscribe(
         await async_wait(seconds=2)
 
     asyncio_run(test_subscription())
-
-    assert (
-        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true}, "success": true, "time_in": '
-        in caplog.text
-    )
+    for phrase in (
+        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true,',  # for some reason they provide a "warnings" key
+        '"success": true, "time_in": ',
+    ):
+        assert phrase in caplog.text
 
 
 @pytest.mark.spot()
@@ -458,3 +458,63 @@ def test___transform_subscription_no_change() -> None:
             )
             == incoming_subscription
         )
+
+
+@pytest.mark.spot()
+@pytest.mark.spot_auth()
+@pytest.mark.spot_websocket()
+@pytest.mark.spot_websocket_v2()
+def test_reconnect(
+    spot_api_key: str,
+    spot_secret_key: str,
+    caplog: Any,
+    mocker: Any,
+) -> None:
+    """
+    Checks if the reconnect works properly when forcing a closed connection.
+    """
+    caplog.set_level(logging.INFO)
+
+    async def check_reconnect() -> None:
+        client: SpotWebsocketClientV2TestWrapper = SpotWebsocketClientV2TestWrapper(
+            key=spot_api_key,
+            secret=spot_secret_key,
+        )
+        await async_wait(seconds=2)
+
+        await client.subscribe(params={"channel": "ticker", "symbol": ["BTC/USD"]})
+        await client.subscribe(params={"channel": "executions"})
+        await async_wait(seconds=2)
+
+        for obj in (client._priv_conn, client._pub_conn):
+            mocker.patch.object(
+                obj,
+                "_ConnectSpotWebsocketBase__get_reconnect_wait",
+                return_value=2,
+            )
+        await client._pub_conn.close_connection()
+        await client._priv_conn.close_connection()
+
+        await async_wait(seconds=5)
+
+    asyncio_run(check_reconnect())
+
+    for phrase in (
+        "Recover public subscriptions []: waiting",
+        "Recover authenticated subscriptions []: waiting",
+        "Recover public subscriptions []: done",
+        "Recover authenticated subscriptions []: done",
+        "Websocket connected!",
+        '{"channel": "status", "data": [{"api_version": "v2", "connection_id": ',
+        '"system": "online", "version": "2.0.0"}], "type": "update"}',
+        '{"method": "subscribe", "result": {"channel": "ticker", "snapshot": true, "symbol": "BTC/USD"}, "success": true,',
+        '"channel": "ticker", "type": "snapshot", "data": [{"symbol": "BTC/USD", ',
+        "exception=ConnectionClosedOK(Close(code=1000, reason=''), Close(code=1000, reason=''), False)> got an exception sent 1000 (OK); then received 1000 (OK)",
+        "Recover public subscriptions [{'channel': 'ticker', 'snapshot': True, 'symbol': ['BTC/USD']}]: waiting",
+        "Recover public subscriptions [{'channel': 'ticker', 'snapshot': True, 'symbol': ['BTC/USD']}]: done",
+        "Recover authenticated subscriptions [{'channel': 'executions', 'snapshot': True}]: waiting",
+        "Recover authenticated subscriptions [{'channel': 'executions', 'snapshot': True}]: done",
+    ):
+        assert phrase in caplog.text
+
+    assert '"success": False' not in caplog.text

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -349,7 +349,6 @@ def test_public_unsubscribe_failure(caplog: Any) -> None:
     )
 
 
-@pytest.mark.wip()
 @pytest.mark.spot()
 @pytest.mark.spot_auth()
 @pytest.mark.spot_websocket()
@@ -375,7 +374,7 @@ def test_private_unsubscribe(
 
         await client.unsubscribe(params={"channel": "executions"}, req_id=987654321)
         await async_wait(seconds=2)
-        # todo: check if subs are removed from known list
+        # todo: check if subs are removed from known list - Dec 2023: obsolete?
 
     asyncio_run(check_unsubscribe())
 

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -379,7 +379,7 @@ def test_private_unsubscribe(
     asyncio_run(check_unsubscribe())
 
     for expected in (
-        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true"',  # , "success": true, "time_in": ',
+        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true',  # , "success": true, "time_in": ',
         '{"method": "unsubscribe", "req_id": 987654321, "result": {"channel": "executions"}, "success": true, "time_in": ',
     ):
         assert expected in caplog.text

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -379,7 +379,7 @@ def test_private_unsubscribe(
     asyncio_run(check_unsubscribe())
 
     for expected in (
-        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true", "success": true, "time_in": ',
+        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true"'  # , "success": true, "time_in": ',
         '{"method": "unsubscribe", "req_id": 987654321, "result": {"channel": "executions"}, "success": true, "time_in": ',
     ):
         assert expected in caplog.text

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -384,6 +384,7 @@ def test_private_unsubscribe(
         '{"method": "unsubscribe", "req_id": 987654321, "result": {"channel": "executions"}, "success": true, "time_in": ',
     ):
         assert expected in caplog.text
+    assert '"success": false' not in caplog.text
 
 
 @pytest.mark.spot()

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -460,6 +460,7 @@ def test___transform_subscription_no_change() -> None:
         )
 
 
+@pytest.mark.wip()
 @pytest.mark.spot()
 @pytest.mark.spot_auth()
 @pytest.mark.spot_websocket()
@@ -509,11 +510,11 @@ def test_reconnect(
         '"system": "online", "version": "2.0.0"}], "type": "update"}',
         '{"method": "subscribe", "result": {"channel": "ticker", "snapshot": true, "symbol": "BTC/USD"}, "success": true,',
         '"channel": "ticker", "type": "snapshot", "data": [{"symbol": "BTC/USD", ',
-        "exception=ConnectionClosedOK(Close(code=1000, reason=''), Close(code=1000, reason=''), False)> got an exception sent 1000 (OK); then received 1000 (OK)",
+        "got an exception sent 1000 (OK); then received 1000 (OK)",
         "Recover public subscriptions [{'channel': 'ticker', 'snapshot': True, 'symbol': ['BTC/USD']}]: waiting",
         "Recover public subscriptions [{'channel': 'ticker', 'snapshot': True, 'symbol': ['BTC/USD']}]: done",
-        "Recover authenticated subscriptions [{'channel': 'executions', 'snapshot': True}]: waiting",
-        "Recover authenticated subscriptions [{'channel': 'executions', 'snapshot': True}]: done",
+        "Recover authenticated subscriptions [{'channel': 'executions', 'maxratecount': 180, 'snapshot': True}]: waiting",
+        "Recover authenticated subscriptions [{'channel': 'executions', 'maxratecount': 180, 'snapshot': True}]: done",
     ):
         assert phrase in caplog.text
 

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -379,7 +379,7 @@ def test_private_unsubscribe(
     asyncio_run(check_unsubscribe())
 
     for expected in (
-        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true"'  # , "success": true, "time_in": ',
+        '{"method": "subscribe", "req_id": 123456789, "result": {"channel": "executions", "maxratecount": 180, "snapshot": true"',  # , "success": true, "time_in": ',
         '{"method": "unsubscribe", "req_id": 987654321, "result": {"channel": "executions"}, "success": true, "time_in": ',
     ):
         assert expected in caplog.text

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -349,6 +349,7 @@ def test_public_unsubscribe_failure(caplog: Any) -> None:
     )
 
 
+@pytest.mark.wip()
 @pytest.mark.spot()
 @pytest.mark.spot_auth()
 @pytest.mark.spot_websocket()
@@ -460,7 +461,6 @@ def test___transform_subscription_no_change() -> None:
         )
 
 
-@pytest.mark.wip()
 @pytest.mark.spot()
 @pytest.mark.spot_auth()
 @pytest.mark.spot_websocket()


### PR DESCRIPTION
# Summary

This MR fixes the mentioned bug using the suggested change - as described in #179 by setting the `__challenge_ready`-flag to `False` in case of a failed task to enforce setting a new challenge and not using the old/broken one.

More changes and additions:
- Add tests (also for the Spot websocket clients) to check that reconnect and resubscribe behaviour after a temporary connection lost
- Adjust the internal caching of subscriptions for Spot to prevent failing resubscriptions due to Krakens current subscription-response behaviour for WS V2.
