### PR TITLE
Resolve "Add `processBefore` parameter to `kraken.futures.Trade.`{`cancel_order`,`edit_order`,`create_order`,`create_batch_order`}"

### DIFF
--- a/kraken/futures/trade.py
+++ b/kraken/futures/trade.py
@@ -119,6 +119,7 @@ class Trade(KrakenFuturesBaseAPI):
     def create_batch_order(
         self: Trade,
         batchorder_list: list[dict],
+        processBefore: Optional[str] = None,
         *,
         extra_params: Optional[dict] = None,
     ) -> dict:
@@ -133,6 +134,8 @@ class Trade(KrakenFuturesBaseAPI):
         :param batchorder_list: List of order instructions (see example below -
             or the linked official Kraken documentation)
         :type batchorder_list: list[dict]
+        :param processBefore: Process before timestamp otherwise reject
+        :type processBefore: str, optional
         :return: Information about the submitted request
         :rtype: dict
 
@@ -223,10 +226,14 @@ class Trade(KrakenFuturesBaseAPI):
             }
         """
         batchorder: dict = {"batchOrder": batchorder_list}
+        params = {"json": f"{batchorder}"}
+        if processBefore:
+            params["processBefore"] = processBefore
+
         return self._request(  # type: ignore[return-value]
             method="POST",
             uri="/derivatives/api/v3/batchorder",
-            post_params={"json": f"{batchorder}"},
+            post_params=params,
             auth=True,
             extra_params=extra_params,
         )
@@ -335,6 +342,7 @@ class Trade(KrakenFuturesBaseAPI):
         self: Trade,
         order_id: Optional[str] = None,
         cliOrdId: Optional[str] = None,
+        processBefore: Optional[str] = None,
         *,
         extra_params: Optional[dict] = None,
     ) -> dict:
@@ -351,6 +359,8 @@ class Trade(KrakenFuturesBaseAPI):
         :type order_id: str, optional
         :param cliOrdId: The client defined order id
         :type cliOrdId: str, optional
+        :param processBefore: Process before timestamp otherwise reject
+        :type processBefore: str, optional
         :raises ValueError: If both ``order_id`` and ``cliOrdId`` are not set
         :return: Success or failure
         :rtype: dict
@@ -377,6 +387,8 @@ class Trade(KrakenFuturesBaseAPI):
             params["order_id"] = order_id
         elif defined(cliOrdId):
             params["cliOrdId"] = cliOrdId
+        elif defined(processBefore):
+            params["processBefore"] = processBefore
         else:
             raise ValueError("Either order_id or cliOrdId must be set!")
 
@@ -395,6 +407,7 @@ class Trade(KrakenFuturesBaseAPI):
         limitPrice: Optional[str | float] = None,
         size: Optional[str | float] = None,
         stopPrice: Optional[str | float] = None,
+        processBefore: Optional[str] = None,
         *,
         extra_params: Optional[dict] = None,
     ) -> dict:
@@ -416,6 +429,8 @@ class Trade(KrakenFuturesBaseAPI):
         :type size: str | float, optional
         :param stopPrice: The stop price
         :type stopPrice: str | float, optional
+        :param processBefore: Process before timestamp otherwise reject
+        :type processBefore: str, optional
         :raises ValueError: If both ``orderId`` and ``cliOrdId`` are not set
         :return: Success or failure
         :rtype: dict
@@ -453,6 +468,8 @@ class Trade(KrakenFuturesBaseAPI):
             params["size"] = size
         if defined(stopPrice):
             params["stopPrice"] = stopPrice
+        if defined(processBefore):
+            params["processBefore"] = processBefore
 
         return self._request(  # type: ignore[return-value]
             method="POST",
@@ -524,6 +541,7 @@ class Trade(KrakenFuturesBaseAPI):
         triggerSignal: Optional[str] = None,
         trailingStopDeviationUnit: Optional[str] = None,
         trailingStopMaxDeviation: Optional[str] = None,
+        processBefore: Optional[str] = None,
         *,
         extra_params: Optional[dict] = None,
     ) -> dict:
@@ -561,6 +579,8 @@ class Trade(KrakenFuturesBaseAPI):
         :type trailingStopDeviationUnit: str, optional
         :param trailingStopMaxDeviation: See referenced Kraken documentation
         :type trailingStopMaxDeviation: str, optional
+        :param processBefore: Process before timestamp otherwise reject
+        :type processBefore: str, optional
         :return: Success or failure
         :rtype: dict
 
@@ -721,6 +741,8 @@ class Trade(KrakenFuturesBaseAPI):
             params["trailingStopDeviationUnit"] = trailingStopDeviationUnit
         if defined(trailingStopMaxDeviation):
             params["trailingStopMaxDeviation"] = trailingStopMaxDeviation
+        if defined(processBefore):
+            params["processBefore"] = processBefore
 
         return self._request(  # type: ignore[return-value]
             method="POST",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,7 @@ ignore-names = [
   "TIMEOUT",
   "URL",
   "HEADERS",
+  "processBefore",
 ]
 
 [tool.ruff.pylint]
@@ -534,6 +535,7 @@ good-names = [
   "TIMEOUT",
   "URL",
   "HEADERS",
+  "processBefore",
 ]
 
 # Good variable names regexes, separated by a comma. If names match any regex,

--- a/tests/futures/test_futures_trade.py
+++ b/tests/futures/test_futures_trade.py
@@ -97,6 +97,7 @@ def test_create_order(futures_demo_trade) -> None:
             limitPrice=1,
             stopPrice=10,
             reduceOnly=True,
+            processBefore="3033-11-08T19:56:35.441899Z",
         )
 
     with suppress(KrakenInsufficientAvailableFundsError):
@@ -202,6 +203,7 @@ def test_create_batch_order(futures_demo_trade) -> None:
                         "cliOrdId": "my_client_id",
                     },
                 ],
+                processBefore="3033-11-08T19:56:35.441899Z",
             ),
         )
 
@@ -223,6 +225,7 @@ def test_edit_order(futures_demo_trade) -> None:
             cliOrdId="myclientorderid",
             size=111.0,
             stopPrice=1000,
+            processBefore="3033-11-08T19:56:35.441899Z",
         ),
     )
 
@@ -246,7 +249,12 @@ def test_cancel_order(futures_demo_trade) -> None:
     """
     Checks the ``cancel_order`` endpoint.
     """
-    assert is_success(futures_demo_trade.cancel_order(cliOrdId="my_another_client_id"))
+    assert is_success(
+        futures_demo_trade.cancel_order(
+            cliOrdId="my_another_client_id",
+            processBefore="3033-11-08T19:56:35.441899Z",
+        ),
+    )
     assert is_success(futures_demo_trade.cancel_order(order_id="1234"))
 
 


### PR DESCRIPTION
Added the new parameters.

This PR must wait before merge until #189 is merged, since the still broken futures tests will fail and block the merge.