### PR TITLE
Resolve "Add `kraken.futures.Trade.get_max_order_size`"

### DIFF
--- a/kraken/futures/trade.py
+++ b/kraken/futures/trade.py
@@ -730,5 +730,43 @@ class Trade(KrakenFuturesBaseAPI):
             extra_params=extra_params,
         )
 
+    def get_max_order_size(
+        self: Trade,
+        orderType: str,
+        symbol: str,
+        limitPrice: Optional[float] = None,
+        *,
+        extra_params: Optional[dict] = None,
+    ) -> dict:
+        """
+        Retrieve the maximum order price for a specific symbol. Can be adjusted
+        by ``limitPrice``. This endpoint only supports multi-collateral futures.
+
+        Requires at least the ``General API - Read Access`` permission in the
+        API key settings.
+
+        - https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-get-maximum-order-size
+
+        :param orderType: ``lmt`` or ``mkt``
+        :type orderType: str
+        :param symbol: The symbol to filter for
+        :type symbol: str
+        :param limitPrice: Limit price if ``orderType == lmt`` , defaults to
+            None
+        :type limitPrice: Optional[float], optional
+        """
+        params: dict = {"orderType": orderType, "symbol": symbol}
+
+        if defined(limitPrice) and orderType == "lmt":
+            params["limitPrice"] = limitPrice
+
+        return self._request(  # type: ignore[return-value]
+            method="GET",
+            uri="/derivatives/api/v3/initialmargin/maxordersize",
+            query_params=params,
+            auth=True,
+            extra_params=extra_params,
+        )
+
 
 __all__ = ["Trade"]

--- a/tests/futures/test_futures_trade.py
+++ b/tests/futures/test_futures_trade.py
@@ -271,3 +271,25 @@ def test_cancel_all_orders(futures_demo_trade) -> None:
     """
     assert is_success(futures_demo_trade.cancel_all_orders(symbol="pi_xbtusd"))
     assert is_success(futures_demo_trade.cancel_all_orders())
+
+
+@pytest.mark.futures()
+@pytest.mark.futures_auth()
+@pytest.mark.futures_trade()
+def test_get_max_order_size(futures_auth_trade) -> None:
+    """
+    Checks the ``cancel_all_orders`` endpoint.
+    """
+    assert is_success(
+        futures_auth_trade.get_max_order_size(
+            orderType="lmt",
+            symbol="PF_XBTUSD",
+            limitPrice=10000,
+        ),
+    )
+    assert is_success(
+        futures_auth_trade.get_max_order_size(
+            orderType="mkt",
+            symbol="PF_XBTUSD",
+        ),
+    )


### PR DESCRIPTION
Add the new endpoint as well as a test for that.

This PR is blocked until #189 is merged.