### PR TITLE
Resolve "Mark `kraken.spot.KrakenSpotWSClientV1` as deprecated"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,9 +7,9 @@ include README.md LICENSE pyproject.toml
 
 graft kraken
 
+prune .cache
+prune .github
 prune doc
 prune examples
 prune tests
 prune venv
-prune .github
-prune .cache

--- a/kraken/spot/websocket_v1.py
+++ b/kraken/spot/websocket_v1.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import warnings
 from copy import deepcopy
 from typing import Any, Callable, Optional
 
@@ -164,6 +165,13 @@ class KrakenSpotWSClientV1(KrakenSpotWSClientBase):
         no_public: bool = False,
         beta: bool = False,
     ):
+        warnings.warn(
+            "The Kraken websocket API v1 is marked as deprecated and "
+            "its support could be removed in the future. "
+            "Please migrate to websocket API v2.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(
             key=key,
             secret=secret,

--- a/kraken/spot/websocket_v1.py
+++ b/kraken/spot/websocket_v1.py
@@ -25,6 +25,8 @@ from kraken.spot.websocket import KrakenSpotWSClientBase
 
 class KrakenSpotWSClientV1(KrakenSpotWSClientBase):
     """
+    .. deprecated:: v2.2.0
+
     Class to access public and private/authenticated websocket connections.
 
     **This client only supports the Kraken Websocket API v1.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,10 @@ junit_family = "xunit2"
 testpaths = ["tests"]
 
 [tool.pytest.ini_options]
+filterwarnings = [
+  "ignore:The Kraken websocket API v1 is marked as deprecated*:DeprecationWarning",
+]
+
 cache_dir = ".cache/pytest"
 markers = [
   "wip: Used to run a specific test by hand.",
@@ -107,7 +111,6 @@ markers = [
   "futures_funding: … Futures Funding endpoint.",
   "futures_websocket: … Futures Websocket endpoint.",
 ]
-
 [tool.coverage.run]
 source = ["kraken"]
 omit = ["*tests*"]
@@ -119,6 +122,7 @@ skip_empty = true
 [tool.codespell]
 skip = "CHANGELOG.md,examples/market_client_example.ipynb"
 check-filenames = true
+
 
 # ========= T Y P I N G ========================================================
 #

--- a/tests/spot/test_spot_orderbook_v1.py
+++ b/tests/spot/test_spot_orderbook_v1.py
@@ -30,9 +30,7 @@ if TYPE_CHECKING:
 @pytest.mark.spot_websocket()
 @pytest.mark.spot_orderbook()
 def test_create_public_bot(caplog: Any) -> None:
-    """
-    Checks if the websocket client can be instantiated.
-    """
+    """Checks if the websocket client can be instantiated."""
 
     async def create_bot() -> None:
         orderbook: OrderbookClientV1Wrapper = OrderbookClientV1Wrapper()


### PR DESCRIPTION
As the related issue notes - the websocket API v1 will most probably be replaced by API v2, so marking it as deprecated is required.