### PR TITLE
Resolve "Subscribing to "balances" channel using KrakenSpotWSClientV2 fails"

### DIFF
--- a/kraken/spot/websocket_v2.py
+++ b/kraken/spot/websocket_v2.py
@@ -547,7 +547,7 @@ class KrakenSpotWSClientV2(KrakenSpotWSClientBase):
         :return: List of available private channel names
         :rtype: list[str]
         """
-        return ["executions"]
+        return ["executions", "balances"]
 
     @property
     def private_methods(self: KrakenSpotWSClientV2) -> list[str]:

--- a/tests/spot/test_spot_websocket_v2.py
+++ b/tests/spot/test_spot_websocket_v2.py
@@ -149,7 +149,7 @@ def test_access_private_client_attributes(
         auth_client: SpotWebsocketClientV2TestWrapper = (
             SpotWebsocketClientV2TestWrapper(key=spot_api_key, secret=spot_secret_key)
         )
-        assert auth_client.private_channel_names == ["executions"]
+        assert auth_client.private_channel_names == ["executions", "balances"]
         assert auth_client.private_methods == [
             "add_order",
             "batch_add",


### PR DESCRIPTION
As mentioned in the issue, the balances channel was missing in the list of channels that need authentication, causing the client to try to subscribe to it via the public channel.

The new balances channel was added in this documentation: https://docs.kraken.com/api/docs/websocket-v2/balances