### PR TITLE
Skip test which requires to be executed from an institutional account

### DIFF
--- a/.github/workflows/_test_futures_private.yaml
+++ b/.github/workflows/_test_futures_private.yaml
@@ -42,13 +42,13 @@ jobs:
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
           disable-sudo: true
-          egress-policy: audit
-          # allowed-endpoints: >
-          #   demo-futures.kraken.com:443
-          #   files.pythonhosted.org:443
-          #   futures.kraken.com:443
-          #   github.com:443
-          #   pypi.org:443
+          egress-policy: block
+          allowed-endpoints: >
+            demo-futures.kraken.com:443
+            files.pythonhosted.org:443
+            futures.kraken.com:443
+            github.com:443
+            pypi.org:443
 
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/_test_futures_private.yaml
+++ b/.github/workflows/_test_futures_private.yaml
@@ -42,13 +42,13 @@ jobs:
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            demo-futures.kraken.com:443
-            files.pythonhosted.org:443
-            futures.kraken.com:443
-            github.com:443
-            pypi.org:443
+          egress-policy: audit
+          # allowed-endpoints: >
+          #   demo-futures.kraken.com:443
+          #   files.pythonhosted.org:443
+          #   futures.kraken.com:443
+          #   github.com:443
+          #   pypi.org:443
 
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [Unreleased](https://github.com/btschwertfeger/python-kraken-sdk/tree/HEAD)
+
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v3.0.0...HEAD)
+
+Uncategorized merged pull requests:
+
+- Bump actions/dependency-review-action from 4.3.3 to 4.3.4 [\#251](https://github.com/btschwertfeger/python-kraken-sdk/pull/251) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github/codeql-action from 3.25.11 to 3.25.12 [\#250](https://github.com/btschwertfeger/python-kraken-sdk/pull/250) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump actions/setup-python from 5.1.0 to 5.1.1 [\#249](https://github.com/btschwertfeger/python-kraken-sdk/pull/249) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump dependabot/fetch-metadata from 2.1.0 to 2.2.0 [\#248](https://github.com/btschwertfeger/python-kraken-sdk/pull/248) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump actions/download-artifact from 4.1.7 to 4.1.8 [\#247](https://github.com/btschwertfeger/python-kraken-sdk/pull/247) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github/codeql-action from 2.2.4 to 3.25.11 [\#246](https://github.com/btschwertfeger/python-kraken-sdk/pull/246) ([dependabot[bot]](https://github.com/apps/dependabot))
+- CI: Change rules for harden-runner job in codeql [\#245](https://github.com/btschwertfeger/python-kraken-sdk/pull/245) ([btschwertfeger](https://github.com/btschwertfeger))
+- Bump actions/dependency-review-action from 2.5.1 to 4.3.3 [\#243](https://github.com/btschwertfeger/python-kraken-sdk/pull/243) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v3.0.0](https://github.com/btschwertfeger/python-kraken-sdk/tree/v3.0.0) (2024-06-23)
+
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v2.3.0...v3.0.0)
+
+**Breaking changes:**
+
+- Preparations - v3.0.0 [\#230](https://github.com/btschwertfeger/python-kraken-sdk/pull/230) ([btschwertfeger](https://github.com/btschwertfeger))
+
+Uncategorized merged pull requests:
+
+- Bump actions/checkout from 4.1.6 to 4.1.7 [\#241](https://github.com/btschwertfeger/python-kraken-sdk/pull/241) ([dependabot[bot]](https://github.com/apps/dependabot))
+
 ## [v2.3.0](https://github.com/btschwertfeger/python-kraken-sdk/tree/v2.3.0) (2024-06-10)
 
 [Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v2.2.0...v2.3.0)

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ import asyncio
 from kraken.spot import SpotAsyncClient
 
 async def main():
-    async with SpotAsyncClient(key="<your-api-key>", secret="<your-secret-key>")as client:
+    async with SpotAsyncClient(key="<your-api-key>", secret="<your-secret-key>") as client:
         response = await client.request("POST", "/0/private/Balance")
         print(response)
 

--- a/tests/spot/test_spot_user.py
+++ b/tests/spot/test_spot_user.py
@@ -15,11 +15,7 @@ from unittest import mock
 
 import pytest
 
-from kraken.exceptions import (
-    KrakenAuthenticationFailedError,
-    KrakenInvalidOrderError,
-    KrakenPermissionDeniedError,
-)
+from kraken.exceptions import KrakenInvalidOrderError, KrakenPermissionDeniedError
 from kraken.spot import User
 
 from .helper import is_not_error
@@ -420,6 +416,7 @@ def test_create_subaccount_failing(spot_auth_user: User) -> None:
 @pytest.mark.spot()
 @pytest.mark.spot_auth()
 @pytest.mark.spot_user()
+@pytest.mark.skip("Subaccount actions are only available for institutional clients")
 def test_account_transfer_failing(spot_auth_user: User) -> None:
     """
     Checks the ``account_transfer`` function by creating one.
@@ -430,10 +427,9 @@ def test_account_transfer_failing(spot_auth_user: User) -> None:
 
     todo: test this using a valid account
     """
-    with pytest.raises(KrakenAuthenticationFailedError):
-        spot_auth_user.account_transfer(
-            asset="XBT",
-            amount=1.0,
-            from_="ABCD 1234 EFGH 5678",
-            to_="JKIL 9012 MNOP 3456",
-        )
+    spot_auth_user.account_transfer(
+        asset="XBT",
+        amount=1.0,
+        from_="ABCD 1234 EFGH 5678",
+        to_="JKIL 9012 MNOP 3456",
+    )


### PR DESCRIPTION
One test now fails since it must be executed from an institutional account. Since it is not scope off this SDK to check all that cases, we simply skip this test.