### PR TITLE
Add proxy support for futures and spot clients (async and sync)

### DIFF
--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -187,6 +187,8 @@ class SpotClient:
     :type secret: str, optional
     :param url: URL to access the Kraken API (default: https://api.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
     """
 
     URL: str = "https://api.kraken.com"
@@ -201,6 +203,7 @@ class SpotClient:
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
         *,
         use_custom_exceptions: bool = True,
     ) -> None:
@@ -212,6 +215,13 @@ class SpotClient:
         self._use_custom_exceptions: bool = use_custom_exceptions
         self._err_handler: ErrorHandler = ErrorHandler()
         self.__session: requests.Session = requests.Session()
+        if proxy is not None:
+            self.__session.proxies.update(
+                {
+                    "http": proxy,
+                    "https": proxy,
+                },
+            )
         self.__session.headers.update(self.HEADERS)
 
     def _prepare_request(
@@ -469,6 +479,8 @@ class SpotAsyncClient(SpotClient):
     :type secret: str, optional
     :param url: URL to access the Kraken API (default: https://api.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
     """
 
     def __init__(
@@ -476,6 +488,7 @@ class SpotAsyncClient(SpotClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
         *,
         use_custom_exceptions: bool = True,
     ) -> None:
@@ -486,6 +499,7 @@ class SpotAsyncClient(SpotClient):
             use_custom_exceptions=use_custom_exceptions,
         )
         self.__session = aiohttp.ClientSession(headers=self.HEADERS)
+        self.proxy = proxy
 
     async def request(  # type: ignore[override] # pylint: disable=invalid-overridden-method,too-many-arguments # noqa: PLR0913
         self: SpotAsyncClient,
@@ -544,34 +558,37 @@ class SpotAsyncClient(SpotClient):
 
         if method in {"GET", "DELETE"}:
             return await self.__check_response_data(  # type: ignore[return-value]
-                response=await self.__session.request(  # type: ignore[misc]
+                response=await self.__session.request(  # type: ignore[misc,call-arg]
                     method=method,
                     url=f"{url}?{query_params}" if query_params else url,
                     headers=headers,
                     timeout=timeout,
+                    proxy=self.proxy,
                 ),
                 return_raw=return_raw,
             )
 
         if do_json:
             return await self.__check_response_data(  # type: ignore[return-value]
-                response=await self.__session.request(  # type: ignore[misc]
+                response=await self.__session.request(  # type: ignore[misc,call-arg]
                     method=method,
                     url=url,
                     headers=headers,
                     json=params,
                     timeout=timeout,
+                    proxy=self.proxy,
                 ),
                 return_raw=return_raw,
             )
 
         return await self.__check_response_data(  # type: ignore[return-value]
-            response=await self.__session.request(  # type: ignore[misc]
+            response=await self.__session.request(  # type: ignore[misc,call-arg]
                 method=method,
                 url=url,
                 headers=headers,
                 data=params,
                 timeout=timeout,
+                proxy=self.proxy,
             ),
             return_raw=return_raw,
         )
@@ -646,6 +663,8 @@ class FuturesClient:
     :type url: str, optional
     :param sandbox: If set to ``True`` the URL will be https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
     """
 
     URL: str = "https://futures.kraken.com"
@@ -661,6 +680,7 @@ class FuturesClient:
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
         *,
         sandbox: bool = False,
         use_custom_exceptions: bool = True,
@@ -686,6 +706,13 @@ class FuturesClient:
                 " (https://github.com/btschwertfeger/python-kraken-sdk)",
             },
         )
+        if proxy is not None:
+            self.__session.proxies.update(
+                {
+                    "http": proxy,
+                    "https": proxy,
+                },
+            )
 
     def _prepare_request(
         self: FuturesClient,
@@ -931,6 +958,8 @@ class FuturesAsyncClient(FuturesClient):
     :param url: The URL to access the Futures Kraken API (default:
         https://futures.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
     :param sandbox: If set to ``True`` the URL will be
         https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
@@ -941,6 +970,7 @@ class FuturesAsyncClient(FuturesClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
         *,
         sandbox: bool = False,
         use_custom_exceptions: bool = True,
@@ -953,6 +983,7 @@ class FuturesAsyncClient(FuturesClient):
             use_custom_exceptions=use_custom_exceptions,
         )
         self.__session = aiohttp.ClientSession(headers=self.HEADERS)
+        self.proxy = proxy
 
     async def request(  # type: ignore[override] # pylint: disable=arguments-differ,invalid-overridden-method
         self: FuturesAsyncClient,
@@ -976,35 +1007,38 @@ class FuturesAsyncClient(FuturesClient):
 
         if method in {"GET", "DELETE"}:
             return await self.__check_response_data(
-                response=await self.__session.request(  # type: ignore[misc]
+                response=await self.__session.request(  # type: ignore[misc,call-arg]
                     method=method,
                     url=url,
                     params=query_string,
                     headers=headers,
                     timeout=timeout,
+                    proxy=self.proxy,
                 ),
                 return_raw=return_raw,
             )
 
         if method == "PUT":
             return await self.__check_response_data(
-                response=await self.__session.request(  # type: ignore[misc]
+                response=await self.__session.request(  # type: ignore[misc,call-arg]
                     method=method,
                     url=url,
                     params=encoded_payload,
                     headers=headers,
                     timeout=timeout,
+                    proxy=self.proxy,
                 ),
                 return_raw=return_raw,
             )
 
         return await self.__check_response_data(
-            response=await self.__session.request(  # type: ignore[misc]
+            response=await self.__session.request(  # type: ignore[misc,call-arg]
                 method=method,
                 url=url,
                 data=encoded_payload,
                 headers=headers,
                 timeout=timeout,
+                proxy=self.proxy,
             ),
             return_raw=return_raw,
         )

--- a/kraken/futures/funding.py
+++ b/kraken/futures/funding.py
@@ -27,6 +27,8 @@ class Funding(FuturesClient):
     :param url: Alternative URL to access the Futures Kraken API (default:
         https://futures.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
     :param sandbox: If set to ``True`` the URL will be
         https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
@@ -53,10 +55,11 @@ class Funding(FuturesClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
         *,
         sandbox: bool = False,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url, sandbox=sandbox)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy, sandbox=sandbox)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/futures/market.py
+++ b/kraken/futures/market.py
@@ -29,6 +29,8 @@ class Market(FuturesClient):
     :param url: Alternative URL to access the Futures Kraken API (default:
         https://futures.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
     :param sandbox: If set to ``True`` the URL will be
         https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
@@ -55,10 +57,11 @@ class Market(FuturesClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
         *,
         sandbox: bool = False,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url, sandbox=sandbox)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy, sandbox=sandbox)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/futures/trade.py
+++ b/kraken/futures/trade.py
@@ -28,6 +28,8 @@ class Trade(FuturesClient):
     :param url: Alternative URL to access the Futures Kraken API (default:
         https://futures.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
     :param sandbox: If set to ``True`` the URL will be
         https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
@@ -54,10 +56,11 @@ class Trade(FuturesClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
         *,
         sandbox: bool = False,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url, sandbox=sandbox)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy, sandbox=sandbox)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/futures/user.py
+++ b/kraken/futures/user.py
@@ -31,6 +31,8 @@ class User(FuturesClient):
     :param url: Alternative URL to access the Futures Kraken API (default:
         https://futures.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
     :param sandbox: If set to ``True`` the URL will be
         https://demo-futures.kraken.com (default: ``False``)
     :type sandbox: bool, optional
@@ -57,10 +59,11 @@ class User(FuturesClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
         *,
         sandbox: bool = False,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url, sandbox=sandbox)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy, sandbox=sandbox)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/nft/market.py
+++ b/kraken/nft/market.py
@@ -27,6 +27,8 @@ class Market(NFTClient):
     :type key: str, optional
     :param secret: Spot API secret key (default: ``""``)
     :type secret: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
 
     .. code-block:: python
         :linenos:
@@ -50,8 +52,9 @@ class Market(NFTClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/nft/trade.py
+++ b/kraken/nft/trade.py
@@ -50,8 +50,9 @@ class Trade(NFTClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/spot/earn.py
+++ b/kraken/spot/earn.py
@@ -29,6 +29,8 @@ class Earn(SpotClient):
     :param url: Alternative URL to access the Kraken API (default:
         https://api.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
 
     .. code-block:: python
         :linenos:
@@ -52,8 +54,9 @@ class Earn(SpotClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/spot/funding.py
+++ b/kraken/spot/funding.py
@@ -28,6 +28,8 @@ class Funding(SpotClient):
     :param url: Alternative URL to access the Kraken API (default:
         https://api.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
 
     .. code-block:: python
         :linenos:
@@ -51,8 +53,9 @@ class Funding(SpotClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/spot/market.py
+++ b/kraken/spot/market.py
@@ -29,6 +29,8 @@ class Market(SpotClient):
     :param url: Alternative URL to access the Kraken API (default:
         https://api.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
 
     .. code-block:: python
         :linenos:
@@ -52,8 +54,9 @@ class Market(SpotClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/kraken/spot/trade.py
+++ b/kraken/spot/trade.py
@@ -30,6 +30,8 @@ class Trade(SpotClient):
     :type secret: str, optional
     :param url: The URL to access the Kraken API (default: https://api.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
 
     .. code-block:: python
         :linenos:
@@ -54,8 +56,9 @@ class Trade(SpotClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy)
         self.__market: Market = Market()
 
     def __enter__(self: Self) -> Self:

--- a/kraken/spot/user.py
+++ b/kraken/spot/user.py
@@ -4,7 +4,7 @@
 #
 # (PLR0904): Too many public methods
 # ruff: noqa: PLR0904
-# pylint: disable=C0302
+# pylint: disable=too-many-lines
 
 """ Module that implements the Kraken Spot User client"""
 

--- a/kraken/spot/user.py
+++ b/kraken/spot/user.py
@@ -4,6 +4,7 @@
 #
 # (PLR0904): Too many public methods
 # ruff: noqa: PLR0904
+# pylint: disable=C0302
 
 """ Module that implements the Kraken Spot User client"""
 
@@ -33,6 +34,8 @@ class User(SpotClient):
     :param url: The URL to access the Kraken API (default:
         https://api.kraken.com)
     :type url: str, optional
+    :param proxy: proxy URL, may contain authentication information
+    :type proxy: str, optional
 
     .. code-block:: python
         :linenos:
@@ -56,8 +59,9 @@ class User(SpotClient):
         key: str = "",
         secret: str = "",
         url: str = "",
+        proxy: str | None = None,
     ) -> None:
-        super().__init__(key=key, secret=secret, url=url)
+        super().__init__(key=key, secret=secret, url=url, proxy=proxy)
 
     def __enter__(self: Self) -> Self:
         super().__enter__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
   "ruff",
   "pylint",
 ]
-test = ["pytest", "pytest-cov", "pytest-mock"]
+test = ["pytest", "pytest-cov", "pytest-mock", "pytest-asyncio", "proxy.py"]
 examples = ["matplotlib", "pandas", "numpy"]
 jupyter = ["ipykernel"] # python3 -m ipykernel install --user --name=kraken
 

--- a/tests/futures/test_futures_base_api.py
+++ b/tests/futures/test_futures_base_api.py
@@ -127,6 +127,8 @@ class TestProxyPyEmbedded(TestCase, IsolatedAsyncioTestCase):
     def get_proxy_str(self) -> str:
         return f"http://127.0.0.1:{self.PROXY.flags.port}"
 
+    @pytest.mark.futures()
+    @pytest.mark.futures_market()
     def test_futures_rest_proxies(self) -> None:
         """
         Checks if the clients can be used with a proxy.
@@ -143,6 +145,8 @@ class TestProxyPyEmbedded(TestCase, IsolatedAsyncioTestCase):
         )
 
     @pytest.mark.asyncio()
+    @pytest.mark.futures()
+    @pytest.mark.futures_market()
     async def test_futures_rest_proxies_async(self) -> None:
         """
         Checks if the async clients can be used with a proxy.

--- a/tests/spot/test_spot_base_api.py
+++ b/tests/spot/test_spot_base_api.py
@@ -233,6 +233,8 @@ class TestProxyPyEmbedded(TestCase, IsolatedAsyncioTestCase):
     def get_proxy_str(self) -> str:
         return f"http://127.0.0.1:{self.PROXY.flags.port}"
 
+    @pytest.mark.spot()
+    @pytest.mark.spot_market()
     def test_spot_rest_proxies(self) -> None:
         """
         Checks if the clients can be used with a proxy.
@@ -247,6 +249,8 @@ class TestProxyPyEmbedded(TestCase, IsolatedAsyncioTestCase):
             ),
         )
 
+    @pytest.mark.spot()
+    @pytest.mark.spot_market()
     @pytest.mark.asyncio()
     async def test_spot_rest_proxies_async(self) -> None:
         """


### PR DESCRIPTION
# Summary
For context see: #256
This PR adds support for HTTP proxies to use with spot and futures REST clients, both sync and async.
For now websockets are omitted as the `websockets` library does not support proxies. The motivation is to allow for privacy/unblocking or other security-related concerns.

## Changes / Features
A single argument, `proxy`, has been added to the constructors for all REST clients. This proxy is used for all requests placed with those clients. Tests have also been added for all four variations: `SpotClient`, `SpotAsyncClient`, `FuturesClient`, and `FuturesAsyncClient`. The most relevant changes are included in the `kraken/base_api/__init__.py` file and in the new tests.

Closes: #256
