### PR TITLE
Update the CI trigger rules to allow workflow runs on pull requests from outside this repository

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*- Copyright (C) 2023 Benjamin Thomas Schwertfeger GitHub:
+# -*- coding: utf-8 -*- Copyright (C)
+# 2023 Benjamin Thomas Schwertfeger GitHub:
 # https://github.com/btschwertfeger
 #
 # Workflow to apply pre-commit, build, test and upload the package to the test
@@ -51,6 +52,8 @@ on:
     - cron: "20 16 */7 * *"
   release:
     types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: CICD-${{ github.ref }}


### PR DESCRIPTION
Workflows did not run for pull requests from branches outside this repository. Adding another trigger rule should fix this issue.