### PR TITLE
Skip NFT auction unit tests

### DIFF
--- a/.github/workflows/_pre_commit.yaml
+++ b/.github/workflows/_pre_commit.yaml
@@ -30,4 +30,6 @@ jobs:
             registry.npmjs.org:443
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: "3.12"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ if __name__ == "__main__":
 
 <a name="futuresusage"></a>
 
-# Futures Clients
+# 📍 Futures Clients
 
 The Kraken Spot API can be accessed by executing requests to the endpoints
 directly using the `request` method provided by any client. This is demonstrated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ dev = [
   "types-requests",
   # linting
   "ruff",
-  "pylint",
 ]
 test = ["pytest", "pytest-cov", "pytest-mock", "pytest-asyncio", "proxy.py"]
 examples = ["matplotlib", "pandas", "numpy"]
@@ -128,6 +127,7 @@ markers = [
   "nft_market: … NFT Market endpoint.",
   "nft_trade: … NFT Trade endpoint.",
 ]
+
 [tool.coverage.run]
 source = ["kraken"]
 omit = ["*tests*"]

--- a/tests/nft/test_nft_trade.py
+++ b/tests/nft/test_nft_trade.py
@@ -37,6 +37,7 @@ def test_nft_trade_contextmanager(nft_auth_trade: Trade) -> None:
 @pytest.mark.nft
 @pytest.mark.nft_auth
 @pytest.mark.nft_trade
+@pytest.mark.skip(reason="NFT auctions restricted in Germany")
 def test_nft_trade_create_auction(nft_auth_trade: Trade) -> None:
     """Checks the ``create_auction`` endpoint."""
 
@@ -57,6 +58,7 @@ def test_nft_trade_create_auction(nft_auth_trade: Trade) -> None:
 @pytest.mark.nft
 @pytest.mark.nft_auth
 @pytest.mark.nft_trade
+@pytest.mark.skip(reason="NFT auctions restricted in Germany")
 def test_nft_trade_modify_auction(nft_auth_trade: Trade) -> None:
     """
     Checks the ``modify_auction`` endpoint.
@@ -78,6 +80,7 @@ def test_nft_trade_modify_auction(nft_auth_trade: Trade) -> None:
 @pytest.mark.nft
 @pytest.mark.nft_auth
 @pytest.mark.nft_trade
+@pytest.mark.skip(reason="NFT auctions restricted in Germany")
 def test_nft_trade_cancel_auction(nft_auth_trade: Trade) -> None:
     """Checks the ``cancel_auction`` endpoint."""
 


### PR DESCRIPTION
The NFT auction tests doesn't need to run in CI, so lets skip them.