### PR TITLE
Resolve "Spot websocket clients broken due to new websockets release"

### DIFF
--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -193,9 +193,7 @@ class SpotClient:
 
     URL: str = "https://api.kraken.com"
     TIMEOUT: int = 10
-    HEADERS: Final[dict] = {
-        "User-Agent": "python-kraken-sdk (https://github.com/btschwertfeger/python-kraken-sdk)",
-    }
+    HEADERS: Final[dict] = {"User-Agent": "btschwertfeger/python-kraken-sdk"}
 
     def __init__(  # nosec: B107
         self: SpotClient,
@@ -669,9 +667,7 @@ class FuturesClient:
     URL: str = "https://futures.kraken.com"
     SANDBOX_URL: str = "https://demo-futures.kraken.com"
     TIMEOUT: int = 10
-    HEADERS: Final[dict] = {
-        "User-Agent": "python-kraken-sdk (https://github.com/btschwertfeger/python-kraken-sdk)",
-    }
+    HEADERS: Final[dict] = {"User-Agent": "btschwertfeger/python-kraken-sdk"}
 
     def __init__(  # nosec: B107
         self: FuturesClient,
@@ -698,11 +694,7 @@ class FuturesClient:
 
         self._err_handler: ErrorHandler = ErrorHandler()
         self.__session: requests.Session = requests.Session()
-        self.__session.headers.update(
-            {
-                "User-Agent": "python-kraken-sdk (https://github.com/btschwertfeger/python-kraken-sdk)",
-            },
-        )
+        self.__session.headers.update(self.HEADERS)
         if proxy is not None:
             self.__session.proxies.update(
                 {

--- a/kraken/spot/websocket/connectors.py
+++ b/kraken/spot/websocket/connectors.py
@@ -131,7 +131,7 @@ class ConnectSpotWebsocketBase:  # pylint: disable=too-many-instance-attributes
 
         async with websockets.connect(  # pylint: disable=no-member
             f"wss://{self.__ws_endpoint}",
-            extra_headers={"User-Agent": "python-kraken-sdk"},
+            additional_headers={"User-Agent": "btschwertfeger/python-kraken-sdk"},
             ping_interval=30,
         ) as socket:
             self.LOG.info("Websocket connected!")

--- a/tests/futures/test_futures_trade.py
+++ b/tests/futures/test_futures_trade.py
@@ -196,14 +196,6 @@ def test_create_batch_order(futures_demo_trade: Trade) -> None:
                         "limitPrice": 2.00,
                         "stopPrice": 3.00,
                     },
-                    {
-                        "order": "cancel",
-                        "order_id": "e35d61dd-8a30-4d5f-a574-b5593ef0c050",
-                    },
-                    {
-                        "order": "cancel",
-                        "cliOrdId": "my_client_id",
-                    },
                 ],
                 processBefore="3033-11-08T19:56:35.441899Z",
             ),


### PR DESCRIPTION
Renaming the parameter passed to connect, as proposed in the issue fixes the problem.

Additionally, the user-agent was changed and a futures test was reduced to avoid future failure.