### PR TITLE
Resolve "Trusted publishing not working with reusable workflows"

### DIFF
--- a/.github/workflows/_pypi_publish.yaml
+++ b/.github/workflows/_pypi_publish.yaml
@@ -10,6 +10,9 @@ name: PyPI Publish
 
 on:
   workflow_call:
+    secrets:
+      API_TOKEN:
+        required: true
 
 permissions: read-all
 
@@ -37,4 +40,5 @@ jobs:
       - name: Publish package distributions to PyPI (optional - testpypi)
         uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # release/v1
         with:
+          password: ${{ secrets.API_TOKEN }}
           repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/_pypi_test_publish.yaml
+++ b/.github/workflows/_pypi_test_publish.yaml
@@ -10,6 +10,9 @@ name: PyPI Publish
 
 on:
   workflow_call:
+    secrets:
+      API_TOKEN:
+        required: true
 
 permissions: read-all
 
@@ -37,4 +40,5 @@ jobs:
       - name: Publish package distributions to PyPI (optional - testpypi)
         uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # release/v1
         with:
+          password: ${{ secrets.API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -235,6 +235,8 @@ jobs:
       - CodeCov
     name: Upload development version to Test PyPI
     uses: ./.github/workflows/_pypi_test_publish.yaml
+    secrets:
+      API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
   ## ===========================================================================
   ##    Upload the python-kraken-sdk to Production PyPI
@@ -251,3 +253,5 @@ jobs:
       - CodeCov
     name: Upload release to PyPI
     uses: ./.github/workflows/_pypi_publish.yaml
+    secrets:
+      API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Adding back the upload API keys to avoid failure due to trusted publishing not working with template jobs. 