### PR TITLE
Do not run tests requireing API keys when author is dependabot

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -117,6 +117,7 @@ jobs:
   ##
   ##  (private endpoints)
   Test-Spot-Private:
+    if: success() && github.actor != 'dependabot[bot]'
     needs: [Pre-Commit]
     uses: ./.github/workflows/_test_spot_private.yaml
     strategy:
@@ -149,6 +150,7 @@ jobs:
   ##
   ##  (private endpoints)
   Test-NFT-Private:
+    if: success() && github.actor != 'dependabot[bot]'
     needs: [Test-Spot-Private]
     uses: ./.github/workflows/_test_nft_private.yaml
     strategy:
@@ -180,6 +182,7 @@ jobs:
   ##
   ##  (private endpoints)
   Test-Futures-Private:
+    if: success() && github.actor != 'dependabot[bot]'
     needs: [Pre-Commit]
     uses: ./.github/workflows/_test_futures_private.yaml
     strategy:


### PR DESCRIPTION
Dependabot's pull requests do not allow running with secrets. So lets disable those jobs for dependabot.