### PR TITLE
Update egress rules for PyPI publish

### DIFF
--- a/.github/workflows/_pypi_publish.yaml
+++ b/.github/workflows/_pypi_publish.yaml
@@ -33,7 +33,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             ghcr.io
-            test.pypi.org
+            pypi.org
             tuf-repo-cdn.sigstore.dev
             fulcio.sigstore.dev
             rekor.sigstore.dev


### PR DESCRIPTION
The pypi.org destination was missing in the upload job.