### PR TITLE
Add upload.pypi.org to allowed domains in publish job

### DIFF
--- a/.github/workflows/_pypi_publish.yaml
+++ b/.github/workflows/_pypi_publish.yaml
@@ -34,6 +34,7 @@ jobs:
           allowed-endpoints: >
             ghcr.io
             pypi.org
+            upload.pypi.org
             tuf-repo-cdn.sigstore.dev
             fulcio.sigstore.dev
             rekor.sigstore.dev


### PR DESCRIPTION
There was one more domain missing that is needed for uploading the release wheels to pypi.org