### PR TITLE
Update egress policy in CI

### DIFF
--- a/.github/workflows/_codeql.yaml
+++ b/.github/workflows/_codeql.yaml
@@ -33,11 +33,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
-          # egress-policy: audit
-          disable-sudo: true
           egress-policy: block
+          disable-sudo: true
           allowed-endpoints: >
             api.github.com:443
+            api.securityscorecards.dev
             github.com:443
             uploads.github.com:443
 


### PR DESCRIPTION
The CI was failing, since the codeql action now requires access to another domain for analysis.