### PR TITLE
Resolve "Long lasting REST sessions get terminated"

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,13 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "btschwertfeger"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "btschwertfeger"
     ignore:
       - dependency-name: "ruff"

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -27,9 +27,11 @@ changelog:
     - title: Other Changes
       labels:
         - "*"
-      # exclude:
-      #   labels:
-      #     - dependencies
+      exclude:
+        labels:
+          - dependencies
+          - github_actions
     - title: 👒 Dependencies
       labels:
         - dependencies
+        - github_actions

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -217,6 +217,7 @@ class SpotClient:
         self._err_handler: ErrorHandler = ErrorHandler()
         self.__proxy: str | None = proxy
         self.__session_start_time: float
+        self.__session: requests.Session
         self.__create_new_session()
 
     def __create_new_session(self: SpotClient) -> None:
@@ -737,7 +738,7 @@ class FuturesClient:
 
         self.__proxy: str | None = proxy
         self.__session_start_time: float
-        self.__session: aiohttp.ClientSession
+        self.__session: requests.Session
         self.__create_new_session()
 
     def __create_new_session(self: FuturesClient) -> None:

--- a/kraken/base_api/__init__.py
+++ b/kraken/base_api/__init__.py
@@ -176,9 +176,9 @@ class SessionManager:
     """
     Manages the requests-based session for the sync Spot and Futures clients.
 
-    Kraken rejects requests that are older than 60 minutes without further
+    Kraken rejects requests that are older than a certain time without further
     information. To avoid this, the session manager creates a new session
-    every 30 minutes.
+    every 5 minutes.
     """
 
     HEADERS: Final[dict] = {"User-Agent": "btschwertfeger/python-kraken-sdk"}
@@ -187,13 +187,12 @@ class SessionManager:
         self: SessionManager,
         *,
         proxy: str | None = None,
-        max_session_age: int = 1800,
+        max_session_age: int = 300,
     ) -> None:
         """
         Initialize the session manager.
 
-        :param max_session_age: Maximum session age in seconds (default: 1800s
-            or 30 minutes)
+        :param max_session_age: Maximum session age in seconds
         :type max_session_age: int
         :param proxy: Proxy URL
         :type proxy: str, optional
@@ -229,9 +228,9 @@ class AsyncSessionManager:
     """
     Manages aiohttp-based sessions for the async Spot and Futures clients.
 
-    Kraken rejects requests that are older than 60 minutes without further
+    Kraken rejects requests that are older than a certain time without further
     information. To avoid this, the session manager creates a new session
-    every 30 minutes.
+    every 5 minutes.
     """
 
     HEADERS: Final[dict] = {"User-Agent": "btschwertfeger/python-kraken-sdk"}
@@ -240,13 +239,12 @@ class AsyncSessionManager:
         self: AsyncSessionManager,
         *,
         proxy: str | None = None,
-        max_session_age: int = 1800,
+        max_session_age: int = 300,
     ) -> None:
         """
         Initialize the session manager.
 
-        :param max_session_age: Maximum session age in seconds (default: 1800s
-            or 30 minutes)
+        :param max_session_age: Maximum session age in seconds
         :type max_session_age: int
         :param proxy: Proxy URL
         :type proxy: str, optional

--- a/kraken/spot/trade.py
+++ b/kraken/spot/trade.py
@@ -256,17 +256,31 @@ class Trade(SpotClient):
                3. When the price hits $27000 a limit order will be placed at
                   $26800 to sell 1.2 BTC. This ensures that the asset will be
                   sold for $26800 or better.
-            ''' >>> from kraken.spot import Trade >>> trade =
-            Trade(key="api-key", secret="secret-key") >>> from datetime import
-            datetime, timedelta, timezone >>> deadline = ( ...
-            datetime.now(timezone.utc) + timedelta(seconds=20) ... ).isoformat()
-            >>> trade.create_order( ...     ordertype="stop-loss-limit", ...
-            pair="XBTUSD", ...     side="buy", ...     volume=1.2, ...
-            price=24000, ...     price2=25000, ...     validate=True, # just
-            validate the input, do not place on the market ...
-            trigger="last", ...     timeinforce="GTC", ...     leverage=4, ...
-            deadline=deadline, ...     close_ordertype="take-profit-limit", ...
-            close_price=27000, ...     close_price2=26800, ... ) {
+            '''
+
+            >>> from kraken.spot import Trade
+            >>> trade = Trade(key="api-key", secret="secret-key")
+            >>> from datetime import datetime, timedelta, timezone
+            >>> deadline = (
+            ...     datetime.now(timezone.utc) + timedelta(seconds=20)
+            ... ).isoformat()
+            >>> trade.create_order(
+            ...     ordertype="stop-loss-limit",
+            ...     pair="XBTUSD",
+            ...     side="buy",
+            ...     volume=1.2,
+            ...     price=24000,
+            ...     price2=25000,
+            ...     validate=True, # just validate the input, do not place on the market
+            ...     trigger="last",
+            ...     timeinforce="GTC",
+            ...     leverage=4,
+            ...     deadline=deadline,
+            ...     close_ordertype="take-profit-limit",
+            ...     close_price=27000,
+            ...     close_price2=26800,
+            ... )
+            {
                 'descr': {
                     'order': 'buy 0.00100000 XBTUSD @ stop loss 24000.0 -> limit
                     25000.0 with 2:1 leverage', 'close': 'close position @ take
@@ -282,12 +296,22 @@ class Trade(SpotClient):
                   automatically
                 * The the percentage sign "%" can be used to define relative
                   changes.
-            ''' >>> trade.create_order( ...     ordertype="stop-loss-limit", ...
-            pair="XBTUSD", ...     side="buy", ...     volume=1.2, ...
-            price=24000, ...     price2="+1000", ...     validate=True, ...
-            trigger="last", ...     timeinforce="GTC", ...
-            close_ordertype="take-profit-limit", ...     close_price=27000, ...
-            close_price2="#2%", ... ) {
+            '''
+            >>> trade.create_order(
+            ...     ordertype="stop-loss-limit",
+            ...     pair="XBTUSD",
+            ...     side="buy",
+            ...     volume=1.2,
+            ...     price=24000,
+            ...     price2="+1000",
+            ...     validate=True,
+            ...     trigger="last",
+            ...     timeinforce="GTC",
+            ...     close_ordertype="take-profit-limit",
+            ...     close_price=27000,
+            ...     close_price2="#2%",
+            ... )
+            {
                 'descr': {
                     'order': 'buy 0.00100000 XBTUSD @ stop loss 24000.0 -> limit
                     +1000.0', 'close': 'close position @ take profit 27000.0 ->


### PR DESCRIPTION
The Kraken API *sometimes* doesn't respond properly for sessions longer than 300 seconds. For this reason, REST client sessions will be recreated if they are too old. 

I tested this for about a week now and did not encountered any errors related to old sessions, so this seems to fix the issue.

Additional changes:

* Disable setting me as default reviewer for dependabot