### PR TITLE
Resolve "Documentation is somewhat incomplete"

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,7 +24,7 @@ copyright = "2023, Benjamin Thomas Schwertfeger"  # noqa: A001 # pylint: disable
 author = "Benjamin Thomas Schwertfeger"
 
 # Add the package to sys.path:
-sys.path.insert(0, str(Path("..").resolve()))
+sys.path.insert(0, str(Path("..").resolve() / "src"))
 
 rst_epilog = ""
 # Read link all targets from file


### PR DESCRIPTION
# Summary

Due to the move to the src-layout in v3.1.4, the remote documentation build via readthedocs doesn't worked well (e.g. https://readthedocs.org/api/v2/build/26976527.txt)

By updating the SYS_PATH before building the documentation via `doc/conf.py`, readthedocs is able to find the package again (see logs if this PR: https://readthedocs.org/api/v2/build/27008942.txt).

I also reviewed the review deployment of the documentation and everything looked well again.

BTW: This was no problem locally and in CI since in both environments, the package is alreayd installed. This is not the case for the environment where readthedocs builds the documentation.

Closes #347 
