### PR TITLE
Update egress rules in CI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
+    groups:
+      all:
+        dependency-type: production

--- a/.github/workflows/_codecov.yaml
+++ b/.github/workflows/_codecov.yaml
@@ -50,21 +50,7 @@ jobs:
         uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           disable-sudo: true
-          egress-policy: audit # FIXME: block
-          allowed-endpoints: >
-            api.codecov.io:443
-            api.kraken.com:443
-            api.github.com:443
-            cli.codecov.io:443
-            demo-futures.kraken.com:443
-            files.pythonhosted.org:443
-            futures.kraken.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            pypi.org:443
-            storage.googleapis.com:443
-            ws-auth.kraken.com:443
-            ws.kraken.com:443
+          egress-policy: audit
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/_codecov.yaml
+++ b/.github/workflows/_codecov.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit # FIXME: block
           allowed-endpoints: >
             api.codecov.io:443
             api.kraken.com:443

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -201,8 +201,9 @@ jobs:
   ##
   CodeCov:
     if: |
-      (success() && github.actor == 'btschwertfeger')
-      && (github.event_name == 'push' || github.event_name == 'release')
+      success()
+      && github.actor == 'btschwertfeger'
+      && github.event_name != 'schedule'
     needs:
       - Test-Spot-Public
       - Test-Spot-Private


### PR DESCRIPTION
# Summary

To avoid failing codecov upload, the egress policy was changed from "block" to "audit".