### PR TITLE
Resolve "`async_close` and `stop` market as deprecated, but no alternative is provided"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,43 @@
 
 ## [Unreleased](https://github.com/btschwertfeger/python-kraken-sdk/tree/HEAD)
 
-[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v3.1.3...HEAD)
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v3.1.5...HEAD)
+
+Uncategorized merged pull requests:
+
+- Update copyright header [\#354](https://github.com/btschwertfeger/python-kraken-sdk/pull/354) ([btschwertfeger](https://github.com/btschwertfeger))
+- Bump github/codeql-action from 3.28.5 to 3.28.9 [\#353](https://github.com/btschwertfeger/python-kraken-sdk/pull/353) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump actions/setup-python from 5.3.0 to 5.4.0 [\#351](https://github.com/btschwertfeger/python-kraken-sdk/pull/351) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Update egress rules in CI [\#349](https://github.com/btschwertfeger/python-kraken-sdk/pull/349) ([btschwertfeger](https://github.com/btschwertfeger))
+
+## [v3.1.5](https://github.com/btschwertfeger/python-kraken-sdk/tree/v3.1.5) (2025-01-29)
+
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v3.1.4...v3.1.5)
+
+**Fixed bugs:**
+
+- Resolve "Documentation is somewhat incomplete" [\#348](https://github.com/btschwertfeger/python-kraken-sdk/pull/348) ([btschwertfeger](https://github.com/btschwertfeger))
+
+Uncategorized merged pull requests:
+
+- Bump codecov/codecov-action from 5.2.0 to 5.3.1 [\#346](https://github.com/btschwertfeger/python-kraken-sdk/pull/346) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github/codeql-action from 3.28.2 to 3.28.5 [\#345](https://github.com/btschwertfeger/python-kraken-sdk/pull/345) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump pypa/gh-action-pypi-publish from 1.12.3 to 1.12.4 [\#344](https://github.com/btschwertfeger/python-kraken-sdk/pull/344) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump dependabot/fetch-metadata from 2.2.0 to 2.3.0 [\#343](https://github.com/btschwertfeger/python-kraken-sdk/pull/343) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v3.1.4](https://github.com/btschwertfeger/python-kraken-sdk/tree/v3.1.4) (2025-01-25)
+
+[Full Changelog](https://github.com/btschwertfeger/python-kraken-sdk/compare/v3.1.3...v3.1.4)
 
 Uncategorized merged pull requests:
 
 - Bump github/codeql-action from 3.28.1 to 3.28.2 [\#341](https://github.com/btschwertfeger/python-kraken-sdk/pull/341) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump codecov/codecov-action from 5.1.2 to 5.2.0 [\#340](https://github.com/btschwertfeger/python-kraken-sdk/pull/340) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Update the documentation [\#339](https://github.com/btschwertfeger/python-kraken-sdk/pull/339) ([btschwertfeger](https://github.com/btschwertfeger))
 - Bump step-security/harden-runner from 2.10.3 to 2.10.4 [\#338](https://github.com/btschwertfeger/python-kraken-sdk/pull/338) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump step-security/harden-runner from 2.10.2 to 2.10.3 [\#337](https://github.com/btschwertfeger/python-kraken-sdk/pull/337) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump github/codeql-action from 3.28.0 to 3.28.1 [\#336](https://github.com/btschwertfeger/python-kraken-sdk/pull/336) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Switch to src-layout [\#342](https://github.com/btschwertfeger/python-kraken-sdk/pull/342) ([btschwertfeger](https://github.com/btschwertfeger))
+- Update the documentation [\#339](https://github.com/btschwertfeger/python-kraken-sdk/pull/339) ([btschwertfeger](https://github.com/btschwertfeger))
 
 ## [v3.1.3](https://github.com/btschwertfeger/python-kraken-sdk/tree/v3.1.3) (2025-01-05)
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ regarding the use of this software.
 
 General:
 
-- command-line interface
-- access both public and private, REST and websocket endpoints
-- responsive error handling and custom exceptions
-- extensive example scripts (see `/examples` and `/tests`)
-- tested using the [pytest](https://docs.pytest.org/en/7.3.x/) framework
-- releases are permanently archived at [Zenodo](https://zenodo.org/badge/latestdoi/510751854)
+- Command-line interface
+- Access both public and private, REST and websocket endpoints
+- Responsive error handling and custom exceptions
+- Extensive example scripts (see `/examples` and `/tests`)
+- Tested using the [pytest](https://docs.pytest.org/en/7.3.x/) framework
+- Releases are permanently archived at [Zenodo](https://zenodo.org/badge/latestdoi/510751854)
 
 Available Clients:
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,10 @@ async def main():
         response = await client.request("POST", "/0/private/Balance")
         print(response)
     finally:
-        await client.async_close()
+        await client.close()
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 Using SpotAsyncClient as a context manager; This example demonstrates the use of the context manager, which ensures the client is automatically closed after the request is completed.
@@ -215,7 +216,8 @@ async def main():
         response = await client.request("POST", "/0/private/Balance")
         print(response)
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 <a name="spotws"></a>
@@ -272,44 +274,40 @@ class Client(SpotWSClient):
         # You can also un-/subscribe here using self.subscribe/self.unsubscribe.
 
 async def main():
+    try:
+        # Public/unauthenticated websocket client
+        client = Client()  # only use this one if you don't need private feeds
+        await client.start()
+        await client.subscribe(
+            params={"channel": "ticker", "symbol": ["BTC/USD", "DOT/USD"]}
+        )
+        await client.subscribe(
+            params={"channel": "book", "depth": 25, "symbol": ["BTC/USD"]}
+        )
+        # wait because unsubscribing is faster than unsubscribing … (just for that example)
+        await asyncio.sleep(3)
+        # print(client.active_public_subscriptions) # to list active subscriptions
+        await client.unsubscribe(
+            params={"channel": "ticker", "symbol": ["BTC/USD", "DOT/USD"]}
+        )
+        # …
 
-    # Public/unauthenticated websocket client
-    client = Client()  # only use this one if you don't need private feeds
-    await client.start()
-    await client.subscribe(
-        params={"channel": "ticker", "symbol": ["BTC/USD", "DOT/USD"]}
-    )
-    await client.subscribe(
-        params={"channel": "book", "depth": 25, "symbol": ["BTC/USD"]}
-    )
-    # wait because unsubscribing is faster than unsubscribing … (just for that example)
-    await asyncio.sleep(3)
-    # print(client.active_public_subscriptions) # to list active subscriptions
-    await client.unsubscribe(
-        params={"channel": "ticker", "symbol": ["BTC/USD", "DOT/USD"]}
-    )
-    # …
+        # AS default, the authenticated client starts two websocket connections,
+        # one for authenticated and one for public messages. If there is no need
+        # for a public connection, it can be disabled using the ``no_public``
+        # parameter.
+        client_auth = Client(key="api-key", secret="secret-key", no_public=True)
+        await client_auth.start()
+        await client_auth.subscribe(params={"channel": "balances"})
 
-    # AS default, the authenticated client starts two websocket connections,
-    # one for authenticated and one for public messages. If there is no need
-    # for a public connection, it can be disabled using the ``no_public``
-    # parameter.
-    client_auth = Client(key="api-key", secret="secret-key", no_public=True)
-    await client_auth.start()
-    await client_auth.subscribe(params={"channel": "balances"})
-
-    while not client.exception_occur and not client_auth.exception_occur:
-        await asyncio.sleep(6)
-
+        while not client.exception_occur and not client_auth.exception_occur:
+            await asyncio.sleep(6)
+    finally:
+        await client.close()
+        await client_auth.close()
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        pass
-        # The websocket client will send {'event': 'asyncio.CancelledError'}
-        # via on_message so you can handle the behavior/next actions
-        # individually within your strategy.
+    asyncio.run(main())
 ```
 
 <a name="futuresusage"></a>
@@ -352,9 +350,10 @@ async def main():
         response = await client.request("GET", "/derivatives/api/v3/accounts")
         print(response)
     finally:
-        await client.async_close()
+        await client.close()
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 Using FuturesAsyncClient as context manager; This example demonstrates the use
@@ -370,7 +369,8 @@ async def main():
         response = await client.request("GET", "/derivatives/api/v3/accounts")
         print(response)
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 <a name="futuresws"></a>
@@ -395,44 +395,44 @@ class Client(FuturesWSClient):
         print(event)
 
 async def main():
-    # Public/unauthenticated websocket connection
-    client = Client()
-    await client.start()
+    try:
+        # Public/unauthenticated websocket connection
+        client = Client()
+        await client.start()
 
-    products = ["PI_XBTUSD", "PF_ETHUSD"]
+        products = ["PI_XBTUSD", "PF_ETHUSD"]
 
-    # subscribe to a public websocket feed
-    await client.subscribe(feed="ticker", products=products)
-    # await client.subscribe(feed="book", products=products)
-    # …
+        # subscribe to a public websocket feed
+        await client.subscribe(feed="ticker", products=products)
+        # await client.subscribe(feed="book", products=products)
+        # …
 
-    # unsubscribe from a public websocket feed
-    # await client.unsubscribe(feed="ticker", products=products)
+        # unsubscribe from a public websocket feed
+        # await client.unsubscribe(feed="ticker", products=products)
 
-    # Private/authenticated websocket connection (+public)
-    client_auth = Client(key="key-key", secret="secret-key")
-    await client_auth.start()
+        # Private/authenticated websocket connection (+public)
+        client_auth = Client(key="key-key", secret="secret-key")
+        await client_auth.start()
 
-    # print(client_auth.get_available_private_subscription_feeds())
+        # print(client_auth.get_available_private_subscription_feeds())
 
-    # subscribe to a private/authenticated websocket feed
-    await client_auth.subscribe(feed="fills")
-    await client_auth.subscribe(feed="open_positions")
-    await client_auth.subscribe(feed="open_orders")
-    # …
+        # subscribe to a private/authenticated websocket feed
+        await client_auth.subscribe(feed="fills")
+        await client_auth.subscribe(feed="open_positions")
+        await client_auth.subscribe(feed="open_orders")
+        # …
 
-    # unsubscribe from a private/authenticated websocket feed
-    await client_auth.unsubscribe(feed="fills")
+        # unsubscribe from a private/authenticated websocket feed
+        await client_auth.unsubscribe(feed="fills")
 
-    while not client.exception_occur and not client_auth.exception_occur:
-        await asyncio.sleep(6)
+        while not client.exception_occur and not client_auth.exception_occur:
+            await asyncio.sleep(6)
+    finally:
+        await client.close()
+        await client_auth.close()
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        # do some exception handling …
-        pass
+    asyncio.run(main())
 ```
 
 ---

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -60,12 +60,12 @@ Features
 
 General:
 
-- command-line interface
-- access both public and private, REST and websocket endpoints
-- responsive error handling and custom exceptions
-- extensive examples
-- tested using the `pytest <https://docs.pytest.org/en/7.3.x/>`_ framework
-- releases are permanently archived at `Zenodo <https://zenodo.org/badge/latestdoi/510751854>`_
+- Command-line interface
+- Access both public and private, REST and websocket endpoints
+- Responsive error handling and custom exceptions
+- Extensive examples
+- Tested using the `pytest <https://docs.pytest.org/en/7.3.x/>`_ framework
+- Releases are permanently archived at `Zenodo <https://zenodo.org/badge/latestdoi/510751854>`_
 
 Available Clients:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# python-kraken-sdk usage examples
+
+This directory contains several examples demonstrating how to use the
+`python-kraken-sdk`. These examples cover various functionalities such as spot
+trading, futures trading, and market data retrieval using both REST and
+WebSocket APIs.
+
+Ideal examples of successful running trading algorithms based on the
+python-kraken-sdk are listed below:
+
+- https://github.com/btschwertfeger/kraken-infinity-grid
+- https://github.com/btschwertfeger/kraken-rebalance-bot
+
+For more detailed and up-to-date usage, refer to the unit tests provided in the
+main package.

--- a/examples/futures_ws_examples.py
+++ b/examples/futures_ws_examples.py
@@ -101,8 +101,6 @@ async def main() -> None:
 
         while not client.exception_occur:  # and not client_auth.exception_occur:
             await asyncio.sleep(6)
-    except Exception:
-        pass
     finally:
         # Close the sessions properly.
         for _client in clients:

--- a/examples/futures_ws_examples.py
+++ b/examples/futures_ws_examples.py
@@ -17,7 +17,6 @@ import logging
 import logging.config
 import os
 import time
-from contextlib import suppress
 
 from kraken.futures import FuturesWSClient
 
@@ -29,6 +28,8 @@ logging.basicConfig(
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 LOG: logging.Logger = logging.getLogger(__name__)
+
+clients = []
 
 
 # Custom client
@@ -48,60 +49,68 @@ async def main() -> None:
     key = os.getenv("FUTURES_API_KEY")
     secret = os.getenv("FUTURES_SECRET_KEY")
 
-    # _____Public_Websocket_Feeds___________________
-    client = Client()
-    await client.start()
-    # print(client.get_available_public_subscription_feeds())
+    try:
+        # _____Public_Websocket_Feeds___________________
+        client = Client()
+        clients.append(client)
+        await client.start()
+        # print(client.get_available_public_subscription_feeds())
 
-    products = ["PI_XBTUSD", "PF_SOLUSD"]
-    # subscribe to a public websocket feed
-    await client.subscribe(feed="ticker", products=products)
-    await client.subscribe(feed="book", products=products)
-    # await client.subscribe(feed='trade', products=products)
-    # await client.subscribe(feed='ticker_lite', products=products)
-    # await client.subscribe(feed='heartbeat')
-    # time.sleep(2)
+        products = ["PI_XBTUSD", "PF_SOLUSD"]
+        # subscribe to a public websocket feed
+        await client.subscribe(feed="ticker", products=products)
+        await client.subscribe(feed="book", products=products)
+        # await client.subscribe(feed='trade', products=products)
+        # await client.subscribe(feed='ticker_lite', products=products)
+        # await client.subscribe(feed='heartbeat')
+        # time.sleep(2)
 
-    # unsubscribe from a websocket feed
-    time.sleep(2)  # in case subscribe is not done yet
-    # await client.unsubscribe(feed='ticker', products=['PI_XBTUSD'])
-    await client.unsubscribe(feed="ticker", products=["PF_XBTUSD"])
-    await client.unsubscribe(feed="book", products=products)
-    # ...
-
-    # _____Private_Websocket_Feeds_________________
-    if key and secret:
-        client_auth = Client(key=key, secret=secret)
-        await client_auth.start()
-        # print(client_auth.get_available_private_subscription_feeds())
-
-        # subscribe to a private/authenticated websocket feed
-        await client_auth.subscribe(feed="fills")
-        await client_auth.subscribe(feed="open_positions")
-        # await client_auth.subscribe(feed='open_orders')
-        # await client_auth.subscribe(feed='open_orders_verbose')
-        # await client_auth.subscribe(feed='deposits_withdrawals')
-        # await client_auth.subscribe(feed='account_balances_and_margins')
-        # await client_auth.subscribe(feed='balances')
-        # await client_auth.subscribe(feed='account_log')
-        # await client_auth.subscribe(feed='notifications_auth')
-
-        # authenticated clients can also subscribe to public feeds
-        # await client_auth.subscribe(feed='ticker', products=['PI_XBTUSD', 'PF_ETHUSD'])
-
-        # time.sleep(1)
-        # unsubscribe from a private/authenticated websocket feed
-        await client_auth.unsubscribe(feed="fills")
-        await client_auth.unsubscribe(feed="open_positions")
+        # unsubscribe from a websocket feed
+        time.sleep(2)  # in case subscribe is not done yet
+        # await client.unsubscribe(feed='ticker', products=['PI_XBTUSD'])
+        await client.unsubscribe(feed="ticker", products=["PF_XBTUSD"])
+        await client.unsubscribe(feed="book", products=products)
         # ...
 
-    while not client.exception_occur:  # and not client_auth.exception_occur:
-        await asyncio.sleep(6)
+        # _____Private_Websocket_Feeds_________________
+        if key and secret:
+            client_auth = Client(key=key, secret=secret)
+            clients.append(client_auth)
+            await client_auth.start()
+            # print(client_auth.get_available_private_subscription_feeds())
+
+            # subscribe to a private/authenticated websocket feed
+            await client_auth.subscribe(feed="fills")
+            await client_auth.subscribe(feed="open_positions")
+            # await client_auth.subscribe(feed='open_orders')
+            # await client_auth.subscribe(feed='open_orders_verbose')
+            # await client_auth.subscribe(feed='deposits_withdrawals')
+            # await client_auth.subscribe(feed='account_balances_and_margins')
+            # await client_auth.subscribe(feed='balances')
+            # await client_auth.subscribe(feed='account_log')
+            # await client_auth.subscribe(feed='notifications_auth')
+
+            # authenticated clients can also subscribe to public feeds
+            # await client_auth.subscribe(feed='ticker', products=['PI_XBTUSD', 'PF_ETHUSD'])
+
+            # time.sleep(1)
+            # unsubscribe from a private/authenticated websocket feed
+            await client_auth.unsubscribe(feed="fills")
+            await client_auth.unsubscribe(feed="open_positions")
+            # ...
+
+        while not client.exception_occur:  # and not client_auth.exception_occur:
+            await asyncio.sleep(6)
+    except Exception:
+        pass
+    finally:
+        # Close the sessions properly.
+        for _client in clients:
+            await _client.close()
 
 
 if __name__ == "__main__":
-    with suppress(KeyboardInterrupt):
-        asyncio.run(main())
+    asyncio.run(main())
     # the websocket client will send {'event': 'asyncio.CancelledError'} via on_message
     # so you can handle the behavior/next actions individually within you strategy
 

--- a/examples/spot_examples.py
+++ b/examples/spot_examples.py
@@ -59,7 +59,7 @@ def user_examples() -> None:
     response = user.request_export_report(
         report="ledgers",
         description="myLedgers1",
-        format="CSV",
+        format_="CSV",
     )  # report='trades'
     print(user.get_export_report_status(report="ledgers"))
 

--- a/examples/spot_ws_examples.py
+++ b/examples/spot_ws_examples.py
@@ -114,8 +114,6 @@ async def main() -> None:
 
         while not client.exception_occur:  # and not client_auth.exception_occur:
             await asyncio.sleep(6)
-    except Exception:
-        pass
     finally:
         # Stop the sessions properly.
         for _client in clients:

--- a/src/kraken/base_api/__init__.py
+++ b/src/kraken/base_api/__init__.py
@@ -27,7 +27,8 @@ from kraken.exceptions import _get_exception
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine
     from typing import Final
-import warnings
+
+from kraken.utils.utils import deprecated
 
 Self = TypeVar("Self")
 
@@ -665,21 +666,23 @@ class SpotAsyncClient(SpotClient):
 
         raise Exception(f"{response.status} - {response.text}")
 
+    async def close(self: SpotAsyncClient) -> None:
+        """Closes the aiohttp session"""
+        await self.__session.close()
+
+    @deprecated(
+        "The 'async_close' function is deprecated and will be replaced by"
+        " 'close' in a future release.",
+    )
     async def async_close(self: SpotAsyncClient) -> None:
         """Closes the aiohttp session"""
-        warnings.warn(
-            "The 'async_close' function is deprecated and will be replaced by"
-            " 'close' in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         await self.__session.close()
 
     async def __aenter__(self: Self) -> Self:
         return self
 
     async def __aexit__(self: SpotAsyncClient, *args: object) -> None:
-        await self.async_close()
+        await self.close()
 
 
 class NFTClient(SpotClient):
@@ -1152,21 +1155,23 @@ class FuturesAsyncClient(FuturesClient):
 
         raise Exception(f"{response.status} - {response.text}")
 
+    async def close(self: FuturesAsyncClient) -> None:
+        """Closes the aiohttp session"""
+        await self.__session.close()
+
+    @deprecated(
+        "The 'async_close' function is deprecated and will be replaced by"
+        " 'close' in a future release.",
+    )
     async def async_close(self: FuturesAsyncClient) -> None:
         """Closes the aiohttp session"""
-        warnings.warn(
-            "The 'async_close' function is deprecated and will be replaced by"
-            " 'close' in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         await self.__session.close()
 
     async def __aenter__(self: Self) -> Self:
         return self
 
     async def __aexit__(self: FuturesAsyncClient, *args: object) -> None:
-        return await self.async_close()
+        return await self.close()
 
 
 __all__ = [

--- a/src/kraken/futures/ws_client.py
+++ b/src/kraken/futures/ws_client.py
@@ -24,7 +24,7 @@ from kraken.futures.websocket import ConnectFuturesWebsocket
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
-import warnings
+from kraken.utils.utils import deprecated
 
 Self = TypeVar("Self")
 
@@ -156,16 +156,21 @@ class FuturesWSClient(FuturesAsyncClient):
         else:
             raise TimeoutError("Could not connect to the Kraken API!")
 
-    async def stop(self: FuturesWSClient) -> None:
+    async def close(self: FuturesWSClient) -> None:
         """Method to stop the websocket connection."""
-        warnings.warn(
-            "The 'stop' function is deprecated and will be replaced by"
-            " 'close' in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._conn:
             await self._conn.stop()
+        await super().close()
+
+    @deprecated(
+        "The 'stop' function is deprecated and will be replaced by"
+        " 'close' in a future release.",
+    )
+    async def stop(self: FuturesWSClient) -> None:
+        """Method to stop the websocket connection."""
+        if self._conn:
+            await self._conn.stop()
+        await super().close()
 
     @property
     def key(self: FuturesWSClient) -> str:
@@ -452,7 +457,7 @@ class FuturesWSClient(FuturesAsyncClient):
     ) -> None:
         """Exit if used as context manager"""
         await super().__aexit__()
-        await self.stop()
+        await self.close()
 
 
 __all__ = ["FuturesWSClient"]

--- a/src/kraken/utils/utils.py
+++ b/src/kraken/utils/utils.py
@@ -17,24 +17,28 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def deprecated(func: Callable) -> Callable:
+def deprecated(message: str) -> Callable:
     """
-    Function used as decorator to mark decorated functions as deprecated.
+    Function used as decorator to mark decorated functions as deprecated with a
+    custom message.
     """
 
-    @wraps(func)
-    def wrapper(
-        *args: Any | None,
-        **kwargs: Any | None,
-    ) -> Any | None:  # noqa: ANN401
-        warnings.warn(
-            f"Call to deprecated function {func.__name__}.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return func(*args, **kwargs)
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(
+            *args: Any | None,
+            **kwargs: Any | None,
+        ) -> Any | None:  # noqa: ANN401
+            warnings.warn(
+                f"{message}",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
 
-    return wrapper
+        return wrapper
+
+    return decorator
 
 
 __all__ = ["deprecated"]

--- a/tests/futures/test_futures_base_api.py
+++ b/tests/futures/test_futures_base_api.py
@@ -120,7 +120,7 @@ def test_futures_rest_async_client_post(
                 dict,
             )
         finally:
-            await client.async_close()
+            await client.close()
 
     run(check())
 

--- a/tests/futures/test_futures_websocket.py
+++ b/tests/futures/test_futures_websocket.py
@@ -36,7 +36,7 @@ def test_create_public_client(caplog: pytest.LogCaptureFixture) -> None:
         await client.start()
         await async_sleep(4)
         assert not client.is_auth
-        await client.stop()
+        await client.close()
         await async_sleep(2)
 
     asyncio.run(instantiate_client())

--- a/tests/spot/test_spot_base_api.py
+++ b/tests/spot/test_spot_base_api.py
@@ -100,7 +100,7 @@ def test_spot_rest_async_client_get() -> None:
                 ),
             )
         finally:
-            await client.async_close()
+            await client.close()
 
     run(check())
 
@@ -227,7 +227,7 @@ def test_spot_rest_async_client_post_report(
                         )
                     sleep(2)
         finally:
-            await client.async_close()
+            await client.close()
 
     run(check())
 

--- a/tests/spot/test_spot_websocket.py
+++ b/tests/spot/test_spot_websocket.py
@@ -48,7 +48,7 @@ def test_create_public_client(caplog: pytest.LogCaptureFixture) -> None:
         client = SpotWebsocketClientTestWrapper()
         await client.start()
         await async_sleep(5)
-        await client.stop()
+        await client.close()
 
     asyncio_run(create_client())
 


### PR DESCRIPTION
# Summary

The SDK now provides the mentioned `close` function, which replaces the `stop` and `async_close` functions for closing sessions. For compatibility reasons, the drop of the deprecated functions will be done in a future release.

Tested the change using the [kraken-infinity-grid](https://github.com/btschwertfeger/kraken-infinity-grid).

Closes #357 