### PR TITLE
Pin dependencies to fix doc building

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,11 +3,11 @@ asyncio>=3.4
 click~=8.1
 cloup~=3.0
 ipython
+nbsphinx
 orjson
 requests~=2.32
 setuptools_scm
 sphinx<8.2.0 # doesn't work with nbsphinx
-sphinx
 sphinx-click
 sphinx-rtd-theme
 websockets>=14.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,12 +1,12 @@
 aiohttp
 asyncio>=3.4
-click
-cloup
+click~=8.1
+cloup~=3.0
 ipython
-nbsphinx
 orjson
-requests
+requests~=2.32
 setuptools_scm
+sphinx<8.2.0 # doesn't work with nbsphinx
 sphinx
 sphinx-click
 sphinx-rtd-theme

--- a/tests/nft/test_nft_market.py
+++ b/tests/nft/test_nft_market.py
@@ -16,6 +16,8 @@ import pytest
 if TYPE_CHECKING:
     from kraken.nft import Market
 
+pytestmark = [pytest.mark.skip(reason="NFT Market API is not available.")]
+
 
 @pytest.mark.nft
 @pytest.mark.nft_market

--- a/tests/nft/test_nft_trade.py
+++ b/tests/nft/test_nft_trade.py
@@ -24,6 +24,8 @@ from kraken.exceptions import (
     KrakenNFTNotAvailableError,
 )
 
+pytestmark = [pytest.mark.skip(reason="NFT Market API is not available.")]
+
 
 @pytest.mark.nft
 @pytest.mark.nft_auth


### PR DESCRIPTION
The latest version of sphinx is not compatible with nbsphinx, so lets pin the dependencies. 

Skipping the NFT tests as the marketplace was closed.