### PR TITLE
Fix issue with batchorder endpoint (derivatvies)

### DIFF
--- a/src/kraken/futures/trade.py
+++ b/src/kraken/futures/trade.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 from typing import TypeVar
+from urllib.parse import encode
 
 from kraken.base_api import FuturesClient, defined
 
@@ -237,7 +238,7 @@ class Trade(FuturesClient):
         return self.request(  # type: ignore[return-value]
             method="POST",
             uri="/derivatives/api/v3/batchorder",
-            post_params=params,
+            post_params=encode(params),
             auth=True,
             extra_params=extra_params,
         )


### PR DESCRIPTION
- Fix an issue where orders are sent to the API endpoint (derivatives/api/v3/batchorder) but are not executed. It seems, according to kraken support, that the payload needs to be encoded (URL-encoding).

# Summary

A short summary into the pull request including the reason for that change.

## Changes / Features

What has being changed - provide code snippets, examples, screenshots, lists -
any kind of information hat helps to understand the update.

**Make sure to address all topics of the [self-review
checklist](https://github.com/btschwertfeger/python-kraken-sdk/blob/master/.github/self-review.md).**

Closes: Don't forget to link an existing issue for your change. If there is no
open issue for your change - create one to make it more likely that his update
will be accepted:
https://github.com/btschwertfeger/python-kraken-sdk/issues/368
[python-kraken-sdk/issues/choose](https://github.com/btschwertfeger/python-kraken-sdk/issues/new/choose).
