### PR TITLE
`kraken.spot.trade.create_order`: `stp_type` should be  `stptype`

### DIFF
--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -328,7 +328,7 @@ class Trade(SpotClient):
                 if not truncate
                 else self.truncate(amount=volume, amount_type="volume", pair=pair)
             ),
-            "stp_type": stptype,
+            "stptype": stptype,
             "starttm": starttm,
             "validate": validate,
             "reduce_only": reduce_only,
@@ -347,6 +347,8 @@ class Trade(SpotClient):
             params["trigger"] = trigger
         if defined(timeinforce):
             params["timeinforce"] = timeinforce
+            if timeinforce == 'IOC':
+                params.pop("starttm", None)
         if defined(expiretm):
             params["expiretm"] = str(expiretm)
         if defined(price):

--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -347,10 +347,6 @@ class Trade(SpotClient):
             params["trigger"] = trigger
         if defined(timeinforce):
             params["timeinforce"] = timeinforce
-            ## notice: At least as of 2025.04.11, 'starttm' needs to be removed for IOC orders.
-            ## However, due to historical complexity, the maintainer decided not to change it, so this note is left as a reminder
-            # if timeinforce == 'IOC':
-            #     params.pop("starttm", None)
         if defined(expiretm):
             params["expiretm"] = str(expiretm)
         if defined(price):

--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -347,8 +347,10 @@ class Trade(SpotClient):
             params["trigger"] = trigger
         if defined(timeinforce):
             params["timeinforce"] = timeinforce
-            if timeinforce == 'IOC':
-                params.pop("starttm", None)
+            ## notice: At least as of 2025.04.11, 'starttm' needs to be removed for IOC orders.
+            ## However, due to historical complexity, the maintainer decided not to change it, so this note is left as a reminder
+            # if timeinforce == 'IOC':
+            #     params.pop("starttm", None)
         if defined(expiretm):
             params["expiretm"] = str(expiretm)
         if defined(price):


### PR DESCRIPTION
Fix the `stp_type` parameter, which must be `stptype`. 

Closes #374 