### PR TITLE
Resolve "Running GitHub Actions on contributions is cumbersome"

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -121,7 +121,9 @@ jobs:
   ##
   ##  (private endpoints)
   Test-Spot-Private:
-    if: success() && github.actor == 'btschwertfeger'
+    if: |
+      success()
+      && github.actor == 'btschwertfeger'
     needs: [Build]
     uses: ./.github/workflows/_test_spot_private.yaml
     strategy:
@@ -153,7 +155,9 @@ jobs:
   ##
   ##  (private endpoints)
   Test-Futures-Private:
-    if: success() && github.actor == 'btschwertfeger'
+    if: |
+      success()
+      && github.actor == 'btschwertfeger'
     needs: [Build]
     uses: ./.github/workflows/_test_futures_private.yaml
     strategy:
@@ -173,8 +177,8 @@ jobs:
   CodeCov:
     if: |
       success()
-      && github.actor == 'btschwertfeger'
       && github.event_name != 'schedule'
+      && github.actor == 'btschwertfeger'
     needs:
       - Build
       # Wait for private tests to avoid nonce errors and rate limiting
@@ -192,7 +196,9 @@ jobs:
   ##
   UploadTestPyPI:
     if: |
-      (success() && github.ref == 'refs/heads/master')
+      success()
+      && github.ref == 'refs/heads/master'
+      && github.actor == 'btschwertfeger'
       && (github.event_name == 'push' || github.event_name == 'release')
     needs:
       - Build


### PR DESCRIPTION
To encounter always failing tests on contributions due to missing access to repository secrets, jobs that require those are disabled for PRs of non-owners. This way the workflow execution looks sane, while the reviewer needs to run the sensitive tests by themselves before proposed changes can be approved and merged.

The issue was already partly addressed in https://github.com/btschwertfeger/python-kraken-sdk/pull/394. 

Closes #375 