### PR TITLE
Resolve "`spot.Trade.truncate` not working for xStocks"

### DIFF
--- a/src/kraken/spot/market.py
+++ b/src/kraken/spot/market.py
@@ -152,6 +152,7 @@ class Market(SpotClient):
         self: Market,
         pair: str | list[str] | None = None,
         info: str | None = None,
+        aclass_base: str | None = None,
         *,
         extra_params: dict | None = None,
     ) -> dict:
@@ -221,6 +222,8 @@ class Market(SpotClient):
             params["pair"] = pair
         if defined(info):
             params["info"] = info
+        if defined(aclass_base):
+            params["aclass_base"] = aclass_base
         return self.request(  # type: ignore[return-value]
             method="GET",
             uri="/0/public/AssetPairs",

--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -342,8 +342,8 @@ class Trade(SpotClient):
                     amount=volume,
                     amount_type="volume",
                     pair=pair,
-                    aclass_base=(
-                        extra_params.get("aclass_base") if extra_params else "currency"
+                    asset_class=(
+                        extra_params.get("asset_class") if extra_params else "currency"
                     ),
                 )
             ),
@@ -777,7 +777,7 @@ class Trade(SpotClient):
         amount: Decimal | float | str,
         amount_type: str,
         pair: str,
-        aclass_base: str = "currency",
+        asset_class: str = "currency",
     ) -> str:
         """
         Kraken only allows volume and price amounts to be specified with a
@@ -796,10 +796,10 @@ class Trade(SpotClient):
         :type amount_type: str
         :param pair: The currency pair the amount is in reference to.
         :type pair: str
-        :param aclass_base: The asset class of the base currency. Default is
+        :param asset_class: The asset class of the base currency. Default is
             ``"currency"``. If the traded asset is a tokenized asset, set this
             to ``"tokenized_asset"``.
-        :type aclass_base: str, optional
+        :type asset_class: str, optional
         :raises ValueError: If the ``amount_type`` is ``price`` and the price is
             less than the costmin.
         :raises ValueError: If the ``amount_type`` is ``volume`` and the volume
@@ -845,7 +845,7 @@ class Trade(SpotClient):
 
         pair_data: dict = self.__market.get_asset_pairs(
             pair=pair,
-            aclass_base=aclass_base,
+            aclass_base=asset_class,
         )
         data: dict = pair_data[next(iter(pair_data))]
 

--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -109,7 +109,7 @@ class Trade(SpotClient):
         settings.
 
         If the traded asset is a tokenized asset, `extra_params` must contain
-        the key `"aclass_base"` with value `"tokenized_asset"`.
+        the key `"asset_class"` with value `"tokenized_asset"`.
 
         - https://docs.kraken.com/api/docs/rest-api/add-order
 
@@ -343,7 +343,9 @@ class Trade(SpotClient):
                     amount_type="volume",
                     pair=pair,
                     asset_class=(
-                        extra_params.get("asset_class") if extra_params else "currency"
+                        extra_params.get("asset_class", "currency")
+                        if extra_params
+                        else "currency"
                     ),
                 )
             ),

--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -108,6 +108,9 @@ class Trade(SpotClient):
         Requires the ``Create and modify orders`` permission in the API key
         settings.
 
+        If the traded asset is a tokenized asset, `extra_params` must contain
+        the key `"aclass_base"` with value `"tokenized_asset"`.
+
         - https://docs.kraken.com/api/docs/rest-api/add-order
 
         :param ordertype: The kind of the order, one of: ``market``, ``limit``,
@@ -335,7 +338,14 @@ class Trade(SpotClient):
             "volume": (
                 volume
                 if not truncate
-                else self.truncate(amount=volume, amount_type="volume", pair=pair)
+                else self.truncate(
+                    amount=volume,
+                    amount_type="volume",
+                    pair=pair,
+                    aclass_base=(
+                        extra_params.get("aclass_base") if extra_params else "currency"
+                    ),
+                )
             ),
             "stptype": stptype,
             "starttm": starttm,
@@ -767,26 +777,33 @@ class Trade(SpotClient):
         amount: Decimal | float | str,
         amount_type: str,
         pair: str,
+        aclass_base: str = "currency",
     ) -> str:
         """
-        Kraken only allows volume and price amounts to be specified with a specific number of
-        decimal places, and these vary depending on the currency pair used.
+        Kraken only allows volume and price amounts to be specified with a
+        specific number of decimal places, and these vary depending on the
+        currency pair used.
 
-        This function converts an amount of a specific type and pair to a string that uses
-        the correct number of decimal places.
+        This function converts an amount of a specific type and pair to a string
+        that uses the correct number of decimal places.
 
         This function uses caching. Run ``truncate.clear_cache()`` to clear.
 
         :param amount: The floating point number to represent
         :type amount: Decimal | float | str
-        :param amount_type: What the amount represents. Either ``"price"`` or ``"volume"``
+        :param amount_type: What the amount represents. Either ``"price"`` or
+            ``"volume"``
         :type amount_type: str
         :param pair: The currency pair the amount is in reference to.
         :type pair: str
-        :raises ValueError: If the ``amount_type`` is ``price`` and the price is less
-            than the costmin.
-        :raises ValueError: If the ``amount_type`` is ``volume`` and the volume is
-            less than the ordermin.
+        :param aclass_base: The asset class of the base currency. Default is
+            ``"currency"``. If the traded asset is a tokenized asset, set this
+            to ``"tokenized_asset"``.
+        :type aclass_base: str, optional
+        :raises ValueError: If the ``amount_type`` is ``price`` and the price is
+            less than the costmin.
+        :raises ValueError: If the ``amount_type`` is ``volume`` and the volume
+            is less than the ordermin.
         :raises ValueError: If no valid ``amount_type`` was passed.
         :return: A string representation of the amount.
         :rtype: str
@@ -826,7 +843,10 @@ class Trade(SpotClient):
         if amount_type not in {"price", "volume"}:
             raise ValueError("Amount type must be 'volume' or 'price'!")
 
-        pair_data: dict = self.__market.get_asset_pairs(pair=pair)
+        pair_data: dict = self.__market.get_asset_pairs(
+            pair=pair,
+            aclass_base=aclass_base,
+        )
         data: dict = pair_data[next(iter(pair_data))]
 
         pair_decimals: int = int(data["pair_decimals"])

--- a/tests/spot/test_spot_trade.py
+++ b/tests/spot/test_spot_trade.py
@@ -18,7 +18,6 @@ from kraken.spot import Trade
 
 
 @pytest.mark.spot
-@pytest.mark.spot_auth
 @pytest.mark.spot_trade
 class TestSpotTrade:
     """Test class for Spot Trade client functionality."""
@@ -29,6 +28,7 @@ class TestSpotTrade:
     TEST_TXID = "OHYO67-6LP66-HMQ437"
     TEST_USERREF = "12345678"
 
+    @pytest.mark.spot_auth
     def test_create_order(self: Self, spot_auth_trade: Trade) -> None:
         """
         This test checks the ``create_order`` function by performing calls to
@@ -37,55 +37,52 @@ class TestSpotTrade:
         not have trade permission.
         """
         with pytest.raises(KrakenPermissionDeniedError):
-            assert isinstance(
-                spot_auth_trade.create_order(
-                    ordertype="limit",
-                    side="buy",
-                    volume=1.001,
-                    oflags=["post"],
-                    pair=self.TEST_PAIR_BTCEUR,
-                    price=1.001,  # this also checks the truncate option
-                    timeinforce="GTC",
-                    truncate=True,
-                    validate=True,  # important to just test this endpoint without risking money
-                ),
-                dict,
+            spot_auth_trade.create_order(
+                ordertype="limit",
+                side="buy",
+                volume=1.001,
+                oflags=["post"],
+                pair=self.TEST_PAIR_BTCEUR,
+                price=1.001,  # this also checks the truncate option
+                timeinforce="GTC",
+                truncate=True,
+                validate=True,  # important to just test this endpoint without risking money
             )
 
-        with pytest.raises(KrakenPermissionDeniedError):
-            assert isinstance(
-                spot_auth_trade.create_order(
-                    ordertype="limit",
-                    side="buy",
-                    volume=10000000,
-                    oflags=["post"],
-                    pair=self.TEST_PAIR_BTCEUR,
-                    price=100,
-                    expiretm="0",
-                    displayvol=1000,
-                    validate=True,  # important to just test this endpoint without risking money
-                ),
-                dict,
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
+            spot_auth_trade.create_order(
+                ordertype="limit",
+                side="buy",
+                volume=10000000,
+                oflags=["post"],
+                pair=self.TEST_PAIR_BTCEUR,
+                price=100,
+                expiretm="0",
+                displayvol=1000,
+                validate=True,  # important to just test this endpoint without risking money
             )
 
-        with pytest.raises(KrakenPermissionDeniedError):
-            assert isinstance(
-                spot_auth_trade.create_order(
-                    ordertype="stop-loss",
-                    side="sell",
-                    volume="1000",
-                    trigger="last",
-                    pair=self.TEST_PAIR_XBTUSD,
-                    price="100",
-                    leverage="2",
-                    reduce_only=True,
-                    userref="12345",
-                    close_ordertype="limit",
-                    close_price="123",
-                    close_price2="92",
-                    validate=True,
-                ),
-                dict,
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
+            spot_auth_trade.create_order(
+                ordertype="stop-loss",
+                side="sell",
+                volume="1000",
+                trigger="last",
+                pair=self.TEST_PAIR_XBTUSD,
+                price="100",
+                leverage="2",
+                reduce_only=True,
+                userref="12345",
+                close_ordertype="limit",
+                close_price="123",
+                close_price2="92",
+                validate=True,  # important to just test this endpoint without risking money
             )
 
         deadline = (datetime.now(UTC) + timedelta(seconds=20)).isoformat()
@@ -107,6 +104,7 @@ class TestSpotTrade:
                 deadline=deadline,
             )
 
+    @pytest.mark.spot_auth
     def test_failing_create_order(self: Self, spot_auth_trade: Trade) -> None:
         """
         Test that checks if the ``create_order`` function raises a ValueError
@@ -128,13 +126,17 @@ class TestSpotTrade:
                 validate=True,
             )
 
+    @pytest.mark.spot_auth
     def test_create_order_batch(self: Self, spot_auth_trade: Trade) -> None:
         """
         Checks the ``create_order_batch`` function by executing
         a batch order in validate mode. (Permission denied,
         since the CI does not have trade permissions)
         """
-        with pytest.raises(KrakenPermissionDeniedError):
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
             spot_auth_trade.create_order_batch(
                 orders=[
                     {
@@ -164,6 +166,7 @@ class TestSpotTrade:
                 validate=True,  # important
             )
 
+    @pytest.mark.spot_auth
     def test_edit_order(self: Self, spot_auth_trade: Trade) -> None:
         """
         Test the ``edit_order`` function by editing an order.
@@ -171,7 +174,10 @@ class TestSpotTrade:
         KrakenPermissionDeniedError: since CI does not have trade permissions. If
         the request would be malformed, another exception could be observed.
         """
-        with pytest.raises(KrakenPermissionDeniedError):
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
             spot_auth_trade.edit_order(
                 txid=self.TEST_TXID,
                 userref=self.TEST_USERREF,
@@ -182,9 +188,10 @@ class TestSpotTrade:
                 cancel_response=False,
                 truncate=True,
                 oflags=["post"],
-                validate=True,
+                validate=True,  # important
             )
 
+    @pytest.mark.spot_auth
     def test_amend_order(self: Self, spot_auth_trade: Trade) -> None:
         """
         Test the ``amend_order`` function by editing an order.
@@ -192,7 +199,10 @@ class TestSpotTrade:
         KrakenPermissionDeniedError: since CI does not have trade permissions. If
         the request would be malformed, another exception could be observed.
         """
-        with pytest.raises(KrakenPermissionDeniedError):
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
             spot_auth_trade.amend_order(
                 extra_params={
                     "txid": "OVM3PT-56ACO-53SM2T",
@@ -200,6 +210,7 @@ class TestSpotTrade:
                 },
             )
 
+    @pytest.mark.spot_auth
     def test_cancel_order(self: Self, spot_auth_trade: Trade) -> None:
         """
         Checks the ``cancel_order`` function by canceling an order.
@@ -207,9 +218,13 @@ class TestSpotTrade:
         A KrakenPermissionDeniedError is expected since CI keys are
         not allowed to trade/cancel/withdraw/stake.
         """
-        with pytest.raises(KrakenPermissionDeniedError):
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
             spot_auth_trade.cancel_order(txid="OB6JJR-7NZ5P-N5SKCB")
 
+    @pytest.mark.spot_auth
     @pytest.mark.skip(reason="Test do not have trade/cancel permission")
     def test_cancel_all_orders(self: Self, spot_auth_trade: Trade) -> None:
         """
@@ -217,9 +232,13 @@ class TestSpotTrade:
         A KrakenPermissionDeniedError will be raised since the CI API keys
         do not have cancel permission.
         """
-        with pytest.raises(KrakenPermissionDeniedError):
-            assert isinstance(spot_auth_trade.cancel_all_orders(), dict)
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
+            spot_auth_trade.cancel_all_orders()
 
+    @pytest.mark.spot_auth
     @pytest.mark.skip(reason="Test do not have trade/cancel permission")
     def test_cancel_all_orders_after_x(self: Self, spot_auth_trade: Trade) -> None:
         """
@@ -229,33 +248,32 @@ class TestSpotTrade:
         THe KrakenPermissionDeniedError will be caught since the CI API keys are not
         allowed to cancel orders.
         """
-        with pytest.raises(KrakenPermissionDeniedError):
-            assert isinstance(
-                spot_auth_trade.cancel_all_orders_after_x(timeout=0),
-                dict,
-            )
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
+            spot_auth_trade.cancel_all_orders_after_x(timeout=0)
 
+    @pytest.mark.spot_auth
     def test_cancel_order_batch(self: Self, spot_auth_trade: Trade) -> None:
         """
         Tests the ``cancel_order_batch`` function by cancelling dummy orders that
         do not exist anymore. Error will be raised since the CI do not have trade
         permissions.
         """
-        with pytest.raises(KrakenPermissionDeniedError):
-            assert isinstance(
-                spot_auth_trade.cancel_order_batch(
-                    orders=[
-                        "O2JLFP-VYFIW-35ZAAE",
-                        "O523KJ-DO4M2-KAT243",
-                        "OCDIAL-YC66C-DOF7HS",
-                        "OVFPZ2-DA2GV-VBFVVI",
-                    ],
-                ),
-                dict,
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
+            spot_auth_trade.cancel_order_batch(
+                orders=[
+                    "O2JLFP-VYFIW-35ZAAE",
+                    "O523KJ-DO4M2-KAT243",
+                    "OCDIAL-YC66C-DOF7HS",
+                    "OVFPZ2-DA2GV-VBFVVI",
+                ],
             )
 
-    @pytest.mark.spot
-    @pytest.mark.spot_trade
     def test_truncate_price(self: Self, spot_trade: Trade) -> None:
         """
         Checks if the truncate function returns the expected results by checking
@@ -288,8 +306,6 @@ class TestSpotTrade:
             )
         sleep(3)
 
-    @pytest.mark.spot
-    @pytest.mark.spot_trade
     def test_truncate_volume(self: Self, spot_trade: Trade) -> None:
         """
         Checks if the truncate function returns the expected results by checking
@@ -322,8 +338,6 @@ class TestSpotTrade:
             )
         sleep(3)
 
-    @pytest.mark.spot
-    @pytest.mark.spot_trade
     def test_truncate_fail_price_costmin(self: Self, spot_trade: Trade) -> None:
         """
         Checks if the truncate function fails if the price is less than the costmin.
@@ -334,8 +348,6 @@ class TestSpotTrade:
         with pytest.raises(ValueError, match=r"Price is less than the costmin: 0.5!"):
             spot_trade.truncate(amount=0.001, amount_type="price", pair="XBTUSD")
 
-    @pytest.mark.spot
-    @pytest.mark.spot_trade
     def test_truncate_fail_volume_ordermin(self: Self, spot_trade: Trade) -> None:
         """
         Checks if the truncate function fails if the volume is less than the
@@ -350,8 +362,6 @@ class TestSpotTrade:
         ):
             spot_trade.truncate(amount=0.0000001, amount_type="volume", pair="XBTUSD")
 
-    @pytest.mark.spot
-    @pytest.mark.spot_trade
     def test_truncate_fail_invalid_amount_type(self: Self, spot_trade: Trade) -> None:
         """
         Checks if the truncate function fails when no valid ``amount_type`` was
@@ -362,3 +372,28 @@ class TestSpotTrade:
             match=r"Amount type must be 'volume' or 'price'!",
         ):
             spot_trade.truncate(amount=1, amount_type="invalid", pair="XBTUSD")
+
+    def test_truncate_tokenized_asset(self: Self, spot_trade: Trade) -> None:
+        """
+        Checks if the truncate function returns the expected results by checking
+        different inputs for volume for a tokenized asset.
+
+        NOTE: This test may break in the future since the lot_decimals,
+              pair_decimals, ordermin and costmin attributes could change.
+        """
+        for volume, expected in (
+            (1, "1.00000000"),
+            (1.1, "1.10000000"),
+            (1.67, "1.67000000"),
+            (1.9328649837, "1.93286498"),
+        ):
+            assert (
+                spot_trade.truncate(
+                    amount=volume,
+                    amount_type="volume",
+                    pair="AAPLxUSD",
+                    aclass_base="tokenized_asset",
+                )
+                == expected
+            )
+        sleep(3)

--- a/tests/spot/test_spot_trade.py
+++ b/tests/spot/test_spot_trade.py
@@ -392,7 +392,7 @@ class TestSpotTrade:
                     amount=volume,
                     amount_type="volume",
                     pair="AAPLxUSD",
-                    aclass_base="tokenized_asset",
+                    asset_class="tokenized_asset",
                 )
                 == expected
             )


### PR DESCRIPTION
Adding a new optional parameter to the truncate function to allow the use for alternative asset classes like `"tokenized_asset"`

Closes #403 