### PR TITLE
Resolve "Allow usage of other Kraken instances via CLI"

### DIFF
--- a/.github/workflows/_codecov.yaml
+++ b/.github/workflows/_codecov.yaml
@@ -91,7 +91,8 @@ jobs:
           FUTURES_SECRET_KEY: ${{ secrets.FUTURES_SECRET_KEY }}
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
-        run: pytest -vv --cov=kraken --cov-report=xml:coverage.xml --cov-report=term tests
+        run: |
+          pytest -vv --cov=kraken --cov-report=xml:coverage.xml --cov-report=term tests
 
       - name: Export coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_codecov.yaml
+++ b/.github/workflows/_codecov.yaml
@@ -91,8 +91,7 @@ jobs:
           FUTURES_SECRET_KEY: ${{ secrets.FUTURES_SECRET_KEY }}
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
-        run: |
-          pytest -vv --cov=kraken --cov-report=xml:coverage.xml --cov-report=term tests
+        run: pytest -vv -x --cov=kraken --cov-report=xml:coverage.xml --cov-report=term tests
 
       - name: Export coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_test_futures_private.yaml
+++ b/.github/workflows/_test_futures_private.yaml
@@ -98,7 +98,7 @@ jobs:
           FUTURES_SECRET_KEY: ${{ secrets.FUTURES_SECRET_KEY }}
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
-        run: pytest -vv -m "futures and futures_auth and not futures_websocket" tests
+        run: pytest -vv -x -m "futures and futures_auth and not futures_websocket" tests
 
       - name: Testing Futures websocket client
         env:
@@ -106,4 +106,4 @@ jobs:
           FUTURES_SECRET_KEY: ${{ secrets.FUTURES_SECRET_KEY }}
           FUTURES_SANDBOX_KEY: ${{ secrets.FUTURES_SANDBOX_KEY }}
           FUTURES_SANDBOX_SECRET: ${{ secrets.FUTURES_SANDBOX_SECRET }}
-        run: pytest -vv -m "futures and futures_auth and futures_websocket" tests
+        run: pytest -vv -x -m "futures and futures_auth and futures_websocket" tests

--- a/.github/workflows/_test_futures_public.yaml
+++ b/.github/workflows/_test_futures_public.yaml
@@ -79,7 +79,7 @@ jobs:
           uv pip install $wheel -r requirements-dev.txt
 
       - name: Testing Futures REST endpoints
-        run: pytest -vv -m "futures and not futures_auth and not futures_websocket" tests
+        run: pytest -vv -x -m "futures and not futures_auth and not futures_websocket" tests
 
       - name: Testing Futures websocket endpoints
-        run: pytest -vv -m "futures and not futures_auth and futures_websocket" tests
+        run: pytest -vv -x -m "futures and not futures_auth and futures_websocket" tests

--- a/.github/workflows/_test_futures_public.yaml
+++ b/.github/workflows/_test_futures_public.yaml
@@ -79,7 +79,7 @@ jobs:
           uv pip install $wheel -r requirements-dev.txt
 
       - name: Testing Futures REST endpoints
-        run: pytest -vv -x -m "futures and not futures_auth and not futures_websocket" tests
+        run: pytest -vv -x -n auto -m "futures and not futures_auth and not futures_websocket" tests
 
       - name: Testing Futures websocket endpoints
-        run: pytest -vv -x -m "futures and not futures_auth and futures_websocket" tests
+        run: pytest -vv -x -n auto -m "futures and not futures_auth and futures_websocket" tests

--- a/.github/workflows/_test_spot_private.yaml
+++ b/.github/workflows/_test_spot_private.yaml
@@ -100,10 +100,10 @@ jobs:
           SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
           XSTOCKS_API_KEY: ${{ secrets.XSTOCKS_API_KEY }}
           XSTOCKS_SECRET_KEY: ${{ secrets.XSTOCKS_SECRET_KEY }}
-        run: pytest -vv -m "spot and spot_auth and not spot_websocket" tests
+        run: pytest -vv -x -m "spot and spot_auth and not spot_websocket" tests
 
       - name: Testing Spot websocket client
         env:
           SPOT_API_KEY: ${{ secrets.SPOT_API_KEY }}
           SPOT_SECRET_KEY: ${{ secrets.SPOT_SECRET_KEY }}
-        run: pytest -vv -m "spot and spot_auth and spot_websocket" tests
+        run: pytest -vv -x -m "spot and spot_auth and spot_websocket" tests

--- a/.github/workflows/_test_spot_public.yaml
+++ b/.github/workflows/_test_spot_public.yaml
@@ -80,7 +80,7 @@ jobs:
           uv pip install $wheel -r requirements-dev.txt
 
       - name: Testing Spot REST endpoints
-        run: pytest -vv -m "spot and not spot_auth and not spot_websocket" tests
+        run: pytest -vv -x -m "spot and not spot_auth and not spot_websocket" tests
 
       - name: Testing Spot websocket endpoints
-        run: pytest -vv -m "spot and not spot_auth and spot_websocket" tests
+        run: pytest -vv -x -m "spot and not spot_auth and spot_websocket" tests

--- a/.github/workflows/_test_spot_public.yaml
+++ b/.github/workflows/_test_spot_public.yaml
@@ -80,7 +80,7 @@ jobs:
           uv pip install $wheel -r requirements-dev.txt
 
       - name: Testing Spot REST endpoints
-        run: pytest -vv -x -m "spot and not spot_auth and not spot_websocket" tests
+        run: pytest -vv -x -n auto -m "spot and not spot_auth and not spot_websocket" tests
 
       - name: Testing Spot websocket endpoints
-        run: pytest -vv -x -m "spot and not spot_auth and spot_websocket" tests
+        run: pytest -vv -x -n auto -m "spot and not spot_auth and spot_websocket" tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,16 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.3
     hooks:
-      - id: ruff
+      - id: ruff-check
         args:
           - --preview
           - --fix
           - --exit-non-zero-on-fix
+      # Formatter disabled since it does not work together with COM812
+      # - id: ruff-format
+      #   args:
+      #     - --preview
+      #     - --exit-non-zero-on-fix
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.18.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.13.3
     hooks:
       - id: ruff
         args:
@@ -15,7 +15,7 @@ repos:
           - --fix
           - --exit-non-zero-on-fix
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.1
+    rev: v1.18.2
     hooks:
       - id: mypy
         name: mypy
@@ -67,7 +67,7 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
   - repo: https://github.com/rbubley/mirrors-prettier
@@ -75,7 +75,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/PyCQA/isort # TODO: remove as soon as ruff is stable
-    rev: 6.0.1
+    rev: 6.1.0
     hooks:
       - id: isort
         args:

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ dev: check-uv
 .PHONY: test
 test:
 	@rm .cache/tests/*.log || true
+	./tests/cli/basic.sh
 	$(PYTEST) $(PYTEST_OPTS) $(TEST_DIR)
 
 .PHONY: tests
@@ -81,6 +82,7 @@ wip:
 .PHONY: coverage
 coverage:
 	@rm .cache/tests/*.log || true
+	./tests/cli/basic.sh
 	$(PYTEST) $(PYTEST_COV_OPTS) $(TEST_DIR)
 
 ## doctest	Run the documentation related tests

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ UV ?= uv
 PYTHON := python
 PYTEST := $(UV) run pytest
 PYTEST_OPTS := -vv --junit-xml=pytest.xml
-PYTEST_COV_OPTS := $(PYTEST_OPTS) --cov=kraken --cov-report=xml:coverage.xml --cov-report=term-missing
+PYTEST_COV_OPTS := $(PYTEST_OPTS) --cov=kraken --cov-report=xml:coverage.xml --cov-report=term-missing --cov-report=html
 TEST_DIR := tests
 
 ## ======= M A K E F I L E - T A R G E T S =====================================
@@ -92,11 +92,11 @@ doctest:
 	cd docs && make doctest
 
 ## ======= M I S C E L A N I O U S =============================================
-## pre-commit	Run the pre-commit targets
+## prek	Run the pre-commit targets
 ##
-.PHONY: pre-commit
-pre-commit:
-	@pre-commit run -a
+.PHONY: prek
+prek:
+	@prek run -a
 
 ## ruff           Run ruff without fix
 ##

--- a/examples/futures_trading_bot_template.py
+++ b/examples/futures_trading_bot_template.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import logging.config
 import os
 import sys
 import traceback

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-cov
 pytest-mock
 pytest-retry
 pytest-timeout
+pytest-xdist

--- a/src/kraken/cli.py
+++ b/src/kraken/cli.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import sys
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from click import echo
 from cloup import (
@@ -52,7 +53,7 @@ def _print_version(
     param: Any,  # noqa: ANN401, ARG001
     value: Any,  # noqa: ANN401
 ) -> None:
-    """Prints the version of the package"""
+    """Prints the version of the package."""
     if not value or ctx.resilient_parsing:
         return
     from importlib.metadata import version  # noqa: PLC0415
@@ -62,8 +63,7 @@ def _print_version(
 
 
 def _get_base_url(url: str) -> str:
-    """Extracts the base URL from a full URL"""
-    from urllib.parse import urlparse  # noqa: PLC0415
+    """Extracts the base URL from a full URL."""
 
     parsed_url = urlparse(url)
     if parsed_url.scheme and parsed_url.netloc:
@@ -72,16 +72,16 @@ def _get_base_url(url: str) -> str:
 
 
 def _get_uri_path(url: str) -> str:
-    """Extracts the URI path from a full URL or returns the URL if it's already a path"""
-    from urllib.parse import urlparse  # noqa: PLC0415
+    """
+    Extracts the URI path from a full URL or returns the URL if it's already a
+    path.
+    """
 
     parsed_url = urlparse(url)
     if parsed_url.scheme and parsed_url.netloc:
         path = parsed_url.path
         if parsed_url.query:
             path += f"?{parsed_url.query}"
-        if parsed_url.fragment:
-            path += f"#{parsed_url.fragment}"
         return path
     return url
 
@@ -188,9 +188,9 @@ def spot(ctx: Context, url: str, **kwargs: dict) -> None:  # noqa: ARG001
             )
         )
     except JSONDecodeError as exc:
-        LOG.error(f"Could not parse the passed data. {exc}")  # noqa: G004
+        LOG.error("Could not parse the passed data. %s", exc)
     except Exception as exc:  # noqa: BLE001
-        LOG.error(f"Exception occurred: {exc}")  # noqa: G004
+        LOG.error("Exception occurred: %s", exc)
         sys.exit(1)
     else:
         echo(response)
@@ -266,9 +266,9 @@ def futures(ctx: Context, url: str, **kwargs: dict) -> None:  # noqa: ARG001
             )
         )
     except JSONDecodeError as exc:
-        LOG.error(f"Could not parse the passed data. {exc}")  # noqa: G004
+        LOG.error("Could not parse the passed data. %s", exc)
     except Exception as exc:  # noqa: BLE001
-        LOG.error(f"Exception occurred: {exc}")  # noqa: G004
+        LOG.error("Exception occurred: %s", exc)
         sys.exit(1)
     else:
         echo(response)

--- a/src/kraken/cli.py
+++ b/src/kraken/cli.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import logging
 import sys
-from re import sub as re_sub
 from typing import TYPE_CHECKING, Any
 
 from click import echo
@@ -48,7 +47,11 @@ if TYPE_CHECKING:
 LOG: logging.Logger = logging.getLogger(__name__)
 
 
-def print_version(ctx: Context, param: Any, value: Any) -> None:  # noqa: ANN401, ARG001
+def _print_version(
+    ctx: Context,
+    param: Any,  # noqa: ANN401, ARG001
+    value: Any,  # noqa: ANN401
+) -> None:
     """Prints the version of the package"""
     if not value or ctx.resilient_parsing:
         return
@@ -56,6 +59,31 @@ def print_version(ctx: Context, param: Any, value: Any) -> None:  # noqa: ANN401
 
     echo(version("python-kraken-sdk"))
     ctx.exit()
+
+
+def _get_base_url(url: str) -> str:
+    """Extracts the base URL from a full URL"""
+    from urllib.parse import urlparse  # noqa: PLC0415
+
+    parsed_url = urlparse(url)
+    if parsed_url.scheme and parsed_url.netloc:
+        return f"{parsed_url.scheme}://{parsed_url.netloc}"
+    return ""
+
+
+def _get_uri_path(url: str) -> str:
+    """Extracts the URI path from a full URL or returns the URL if it's already a path"""
+    from urllib.parse import urlparse  # noqa: PLC0415
+
+    parsed_url = urlparse(url)
+    if parsed_url.scheme and parsed_url.netloc:
+        path = parsed_url.path
+        if parsed_url.query:
+            path += f"?{parsed_url.query}"
+        if parsed_url.fragment:
+            path += f"#{parsed_url.fragment}"
+        return path
+    return url
 
 
 @group(
@@ -76,7 +104,7 @@ def print_version(ctx: Context, param: Any, value: Any) -> None:  # noqa: ANN401
 @option(
     "--version",
     is_flag=True,
-    callback=print_version,
+    callback=_print_version,
     expose_value=False,
     is_eager=True,
 )
@@ -142,17 +170,18 @@ def spot(ctx: Context, url: str, **kwargs: dict) -> None:  # noqa: ARG001
     """Access the Kraken Spot REST API"""
     from kraken.base_api import SpotClient  # noqa: PLC0415
 
-    LOG.debug("Initialize the Kraken client")
     client = SpotClient(
         key=kwargs["api_key"],  # type: ignore[arg-type]
         secret=kwargs["secret_key"],  # type: ignore[arg-type]
+        url=_get_base_url(url),
     )
 
+    uri = _get_uri_path(url)
     try:
         response = (
             client.request(  # pylint: disable=protected-access,no-value-for-parameter
                 method=kwargs["x"],  # type: ignore[arg-type]
-                uri=(uri := re_sub(r"https://.*.com", "", url)),
+                uri=uri,
                 params=orloads(kwargs.get("data") or "{}"),
                 timeout=kwargs["timeout"],  # type: ignore[arg-type]
                 auth="private" in uri.lower(),
@@ -218,17 +247,18 @@ def futures(ctx: Context, url: str, **kwargs: dict) -> None:  # noqa: ARG001
     """Access the Kraken Futures REST API"""
     from kraken.base_api import FuturesClient  # noqa: PLC0415
 
-    LOG.debug("Initialize the Kraken client")
     client = FuturesClient(
         key=kwargs["api_key"],  # type: ignore[arg-type]
         secret=kwargs["secret_key"],  # type: ignore[arg-type]
+        url=_get_base_url(url),
     )
 
+    uri = _get_uri_path(url)
     try:
         response = (
             client.request(  # pylint: disable=protected-access,no-value-for-parameter
                 method=kwargs["x"],  # type: ignore[arg-type]
-                uri=(uri := re_sub(r"https://.*.com", "", url)),
+                uri=uri,
                 post_params=orloads(kwargs.get("data") or "{}"),
                 query_params=orloads(kwargs.get("query") or "{}"),
                 timeout=kwargs["timeout"],  # type: ignore[arg-type]

--- a/tests/cli/basic.sh
+++ b/tests/cli/basic.sh
@@ -1,13 +1,36 @@
 #!/bin/bash
+# -*- mode: python; coding: utf-8 -*-
+#
+# Copyright (C) 2024 Benjamin Thomas Schwertfeger
+# All rights reserved.
+# https://github.com/btschwertfeger
+#
+# Test basic CLI functionality
 
-kraken spot https://api.kraken.com/0/public/Time
-kraken spot /0/public/Time
+set -e
 
-kraken spot -X POST https://api.kraken.com/0/private/Balance
-kraken spot -X POST https://api.kraken.com/0/private/TradeBalance -d '{"asset": "DOT"}'
+run_test() {
+    local description="$1"
+    shift
+    if "$@" > /dev/null 2>&1; then
+        echo "${description}:: SUCCESS"
+    else
+        echo "${description}:: FAILED"
+        return 1
+    fi
+}
 
-kraken futures https://futures.kraken.com/api/charts/v1/spot/PI_XBTUSD/1d
-kraken futures /api/charts/v1/spot/PI_XBTUSD/1d
+run_test "spot_public_full_url" kraken spot https://api.kraken.com/0/public/Time
+run_test "spot_public_path_only" kraken spot /0/public/Time
 
-kraken futures https://futures.kraken.com/derivatives/api/v3/openpositions
-# kraken futures -X POST https://futures.kraken.com/derivatives/api/v3/editorder -d '{"cliOrdID": "12345", "limitPrice": 10}'
+run_test "spot_private_balance_full_url" kraken spot -X POST https://api.kraken.com/0/private/Balance
+run_test "spot_private_balance_path_only" kraken spot -X POST /0/private/Balance
+
+run_test "spot_private_trade_balance_with_data_full_url" kraken spot -X POST https://api.kraken.com/0/private/TradeBalance -d '{"asset": "DOT"}'
+run_test "spot_private_trade_balance_with_data_path_only" kraken spot -X POST /0/private/TradeBalance -d '{"asset": "DOT"}'
+
+run_test "futures_public_charts_full_url" kraken futures https://futures.kraken.com/api/charts/v1/spot/PI_XBTUSD/1d
+run_test "futures_public_charts_path_only" kraken futures /api/charts/v1/spot/PI_XBTUSD/1d
+
+run_test "futures_private_openpositions" kraken futures https://futures.kraken.com/derivatives/api/v3/openpositions
+# run_test "futures_private_editorder" kraken futures -X POST https://futures.kraken.com/derivatives/api/v3/editorder -d '{"cliOrdID": "12345", "limitPrice": 10}'

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -23,29 +23,45 @@ def cli_runner() -> CliRunner:
 
 
 @pytest.fixture
-def with_cli_env_vars() -> Generator:
+def with_spot_secrets() -> Generator:
     """Setup some environment variables for th CLI tests"""
 
     if not all(
         (
             spot_api_key := os.getenv("SPOT_API_KEY"),
             spot_secret_key := os.getenv("SPOT_SECRET_KEY"),
-            futures_api_key := os.getenv("FUTURES_API_KEY"),
-            futures_secret_key := os.getenv("FUTURES_SECRET_KEY"),
         ),
     ):
         pytest.fail("No API keys provided for CLI tests!")
 
     os.environ["KRAKEN_SPOT_API_KEY"] = spot_api_key
     os.environ["KRAKEN_SPOT_SECRET_KEY"] = spot_secret_key
+
+    yield
+
+    for var in ("KRAKEN_SPOT_API_KEY", "KRAKEN_SPOT_SECRET_KEY"):
+        if os.getenv(var):
+            del os.environ[var]
+
+
+@pytest.fixture
+def with_futures_secrets() -> Generator:
+    """Setup some environment variables for the CLI tests"""
+
+    if not all(
+        (
+            futures_api_key := os.getenv("FUTURES_API_KEY"),
+            futures_secret_key := os.getenv("FUTURES_SECRET_KEY"),
+        ),
+    ):
+        pytest.fail("No API keys provided for CLI tests!")
+
     os.environ["KRAKEN_FUTURES_API_KEY"] = futures_api_key
     os.environ["KRAKEN_FUTURES_SECRET_KEY"] = futures_secret_key
 
     yield
 
     for var in (
-        "KRAKEN_SPOT_API_KEY",
-        "KRAKEN_SPOT_SECRET_KEY",
         "KRAKEN_FUTURES_API_KEY",
         "KRAKEN_FUTURES_SECRET_KEY",
     ):

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import os
+from typing import Generator
 
 import pytest
 from click.testing import CliRunner
@@ -22,12 +23,23 @@ def cli_runner() -> CliRunner:
 
 
 @pytest.fixture
-def _with_cli_env_vars() -> None:
+def with_cli_env_vars() -> Generator:
     """Setup some environment variables for th CLI tests"""
-    os.environ["KRAKEN_SPOT_API_KEY"] = os.getenv("SPOT_API_KEY", "")
-    os.environ["KRAKEN_SPOT_SECRET_KEY"] = os.getenv("SPOT_SECRET_KEY", "")
-    os.environ["KRAKEN_FUTURES_API_KEY"] = os.getenv("FUTURES_API_KEY", "")
-    os.environ["KRAKEN_FUTURES_SECRET_KEY"] = os.getenv("FUTURES_SECRET_KEY", "")
+
+    if not all(
+        (
+            spot_api_key := os.getenv("SPOT_API_KEY"),
+            spot_secret_key := os.getenv("SPOT_SECRET_KEY"),
+            futures_api_key := os.getenv("FUTURES_API_KEY"),
+            futures_secret_key := os.getenv("FUTURES_SECRET_KEY"),
+        ),
+    ):
+        pytest.fail("No API keys provided for CLI tests!")
+
+    os.environ["KRAKEN_SPOT_API_KEY"] = spot_api_key
+    os.environ["KRAKEN_SPOT_SECRET_KEY"] = spot_secret_key
+    os.environ["KRAKEN_FUTURES_API_KEY"] = futures_api_key
+    os.environ["KRAKEN_FUTURES_SECRET_KEY"] = futures_secret_key
 
     yield
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -67,7 +67,7 @@ def test_cli_spot_public(cli_runner: CliRunner, args: list[str]) -> None:
     assert result.exit_code == 0
 
 
-@pytest.mark.usefixtures("with_cli_env_vars")
+@pytest.mark.usefixtures("with_spot_secrets")
 @pytest.mark.spot
 @pytest.mark.spot_auth
 @pytest.mark.parametrize(
@@ -122,7 +122,7 @@ def test_cli_futures_public(cli_runner: CliRunner, args: list[str]) -> None:
     assert result.exit_code == 0
 
 
-@pytest.mark.usefixtures("with_cli_env_vars")
+@pytest.mark.usefixtures("with_futures_secrets")
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.parametrize(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -67,7 +67,7 @@ def test_cli_spot_public(cli_runner: CliRunner, args: list[str]) -> None:
     assert result.exit_code == 0
 
 
-@pytest.mark.usefixtures("_with_cli_env_vars")
+@pytest.mark.usefixtures("with_cli_env_vars")
 @pytest.mark.spot
 @pytest.mark.spot_auth
 @pytest.mark.parametrize(
@@ -122,7 +122,7 @@ def test_cli_futures_public(cli_runner: CliRunner, args: list[str]) -> None:
     assert result.exit_code == 0
 
 
-@pytest.mark.usefixtures("_with_cli_env_vars")
+@pytest.mark.usefixtures("with_cli_env_vars")
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.parametrize(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -4,7 +4,6 @@
 # All rights reserved.
 # https://github.com/btschwertfeger
 #
-
 """Module implementing unit tests for the command-line interface"""
 
 from __future__ import annotations
@@ -75,3 +74,152 @@ def test_cli_futures_private(
         ["futures", "https://futures.kraken.com/derivatives/api/v3/openpositions"],
     )
     assert result.exit_code == 0, result.exception
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        pytest.param(
+            "https://api.kraken.com/0/public/Time",
+            "https://api.kraken.com",
+            id="standard_spot_url",
+        ),
+        pytest.param(
+            "https://api.vip.uat.lobster.kraken.com/0/private/BalanceEx",
+            "https://api.vip.uat.lobster.kraken.com",
+            id="custom_kraken_instance",
+        ),
+        pytest.param(
+            "http://localhost:8080/api/v1/endpoint",
+            "http://localhost:8080",
+            id="http_localhost",
+        ),
+        pytest.param(
+            "https://futures.kraken.com/derivatives/api/v3/openpositions",
+            "https://futures.kraken.com",
+            id="futures_url",
+        ),
+        pytest.param(
+            "https://demo-futures.kraken.com/api/v3/accounts",
+            "https://demo-futures.kraken.com",
+            id="demo_sandbox_url",
+        ),
+        pytest.param(
+            "/0/public/Time",
+            "",
+            id="path_only_no_scheme",
+        ),
+        pytest.param(
+            "api/v1/endpoint",
+            "",
+            id="relative_path",
+        ),
+        pytest.param(
+            "",
+            "",
+            id="empty_string",
+        ),
+        pytest.param(
+            "https://api.kraken.com:443/0/public/Time",
+            "https://api.kraken.com:443",
+            id="url_with_port",
+        ),
+        pytest.param(
+            "https://api.kraken.com/0/public/Assets?asset=XBT,ETH",
+            "https://api.kraken.com",
+            id="url_with_query_params",
+        ),
+    ],
+)
+def test_get_base_url(url: str, expected: str) -> None:
+    """Test the get_base_url function extracts base URLs correctly"""
+    from kraken.cli import _get_base_url  # noqa: PLC2701,PLC0415
+
+    assert _get_base_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        pytest.param(
+            "https://api.kraken.com/0/public/Time",
+            "/0/public/Time",
+            id="standard_spot_url",
+        ),
+        pytest.param(
+            "https://api.vip.uat.lobster.kraken.com/0/private/BalanceEx",
+            "/0/private/BalanceEx",
+            id="custom_kraken_instance",
+        ),
+        pytest.param(
+            "http://localhost:8080/0/private/Balance",
+            "/0/private/Balance",
+            id="http_localhost",
+        ),
+        pytest.param(
+            "https://futures.kraken.com/derivatives/api/v3/openpositions",
+            "/derivatives/api/v3/openpositions",
+            id="futures_url",
+        ),
+        pytest.param(
+            "https://demo-futures.kraken.com/api/v3/accounts",
+            "/api/v3/accounts",
+            id="demo_sandbox_url",
+        ),
+        pytest.param(
+            "/0/public/Time",
+            "/0/public/Time",
+            id="path_only_no_scheme",
+        ),
+        pytest.param(
+            "api/v1/endpoint",
+            "api/v1/endpoint",
+            id="relative_path",
+        ),
+        pytest.param(
+            "",
+            "",
+            id="empty_string",
+        ),
+        pytest.param(
+            "https://api.kraken.com:443/0/public/Time",
+            "/0/public/Time",
+            id="url_with_port",
+        ),
+        pytest.param(
+            "https://api.kraken.com/0/public/Assets?asset=XBT,ETH",
+            "/0/public/Assets?asset=XBT,ETH",
+            id="url_with_query_params",
+        ),
+        pytest.param(
+            "https://api.kraken.com/0/public/OHLC?pair=XBTUSD&interval=1440",
+            "/0/public/OHLC?pair=XBTUSD&interval=1440",
+            id="url_with_multiple_query_params",
+        ),
+        pytest.param(
+            "https://api.kraken.com/0/public/Ticker#section",
+            "/0/public/Ticker#section",
+            id="url_with_fragment",
+        ),
+        pytest.param(
+            "https://api.kraken.com/0/public/Ticker?pair=XBTUSD#section",
+            "/0/public/Ticker?pair=XBTUSD#section",
+            id="url_with_query_and_fragment",
+        ),
+        pytest.param(
+            "https://futures.kraken.com/api/charts/v1/spot/PI_XBTUSD/1d",
+            "/api/charts/v1/spot/PI_XBTUSD/1d",
+            id="futures_charts_url",
+        ),
+        pytest.param(
+            "/derivatives/api/v3/openpositions",
+            "/derivatives/api/v3/openpositions",
+            id="derivatives_path_only",
+        ),
+    ],
+)
+def test_get_uri_path(url: str, expected: str) -> None:
+    """Test the _get_uri_path function extracts URI paths correctly"""
+    from kraken.cli import _get_uri_path  # noqa: PLC2701,PLC0415
+
+    assert _get_uri_path(url) == expected


### PR DESCRIPTION
The URL passed to the CLI is now parsed correctly, allowing to communicate with other Kraken instances than the default one.

Closes #406 