### PR TITLE
Resolve "Mark Futures Fee Schedules endpoints as deprecated"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "orjson",
   "aiohttp",
 ]
-keywords = ["crypto", "trading", "kraken", "exchange", "api", "sdk", "kraken crypto asset exchange", "automation",]
+keywords = ["crypto", "trading", "kraken", "exchange", "api", "sdk", "automation"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: AsyncIO",

--- a/src/kraken/futures/market.py
+++ b/src/kraken/futures/market.py
@@ -25,6 +25,7 @@ from functools import lru_cache
 from typing import Self
 
 from kraken.base_api import FuturesClient, defined, ensure_string
+from kraken.utils.utils import deprecated
 
 
 class Market(FuturesClient):
@@ -262,6 +263,13 @@ class Market(FuturesClient):
             extra_params=extra_params,
         )
 
+    @deprecated(
+        "The 'get_fee_schedules' function is deprecated. As of the Kraken"
+        " changelog entry dated 22 June 2026, the Futures Fee Schedules"
+        " endpoints are deprecated since fee calculation moved to a centralized"
+        " Kraken fee service. Determine applicable fee rates via the Spot"
+        " 'GetTradeVolume' endpoint instead.",
+    )
     @ensure_string("extra_params")
     @lru_cache
     def get_fee_schedules(
@@ -271,6 +279,13 @@ class Market(FuturesClient):
     ) -> dict:
         """
         Retrieve information about the current fees
+
+        .. deprecated::
+            As of the Kraken changelog entry dated 22 June 2026, the Futures Fee
+            Schedules endpoints are deprecated since fee calculation moved to a
+            centralized Kraken fee service. Determine applicable fee rates via
+            the Spot :func:`kraken.spot.User.get_trade_volume`
+            (``GetTradeVolume``) endpoint instead.
 
         - https://docs.kraken.com/api/docs/futures-api/trading/get-fee-schedules-v-3
 
@@ -313,6 +328,13 @@ class Market(FuturesClient):
             extra_params=extra_params,
         )
 
+    @deprecated(
+        "The 'get_fee_schedules_vol' function is deprecated. As of the Kraken"
+        " changelog entry dated 22 June 2026, the Futures Fee Schedules"
+        " endpoints are deprecated since fee calculation moved to a centralized"
+        " Kraken fee service. Determine applicable fee rates via the Spot"
+        " 'GetTradeVolume' endpoint instead.",
+    )
     def get_fee_schedules_vol(
         self: Market,
         *,
@@ -320,6 +342,13 @@ class Market(FuturesClient):
     ) -> dict:
         """
         Get the personal volumes per fee schedule
+
+        .. deprecated::
+            As of the Kraken changelog entry dated 22 June 2026, the Futures Fee
+            Schedules endpoints are deprecated since fee calculation moved to a
+            centralized Kraken fee service. Determine applicable fee rates via
+            the Spot :func:`kraken.spot.User.get_trade_volume`
+            (``GetTradeVolume``) endpoint instead.
 
         Requires the ``General API - Full Access`` permission in the API key
         settings.

--- a/tests/futures/test_futures_market.py
+++ b/tests/futures/test_futures_market.py
@@ -106,18 +106,24 @@ class TestFuturesMarket:
 
     def test_get_fee_schedules(self: Self, futures_market: Market) -> None:
         """
-        Checks the ``get_fee_schedules`` endpoint.
+        Checks the ``get_fee_schedules`` endpoint and that it raises a
+        deprecation warning.
         """
-        self._assert_successful_response(futures_market.get_fee_schedules())
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            self._assert_successful_response(futures_market.get_fee_schedules())
 
     @pytest.mark.futures
     @pytest.mark.futures_auth
     @pytest.mark.futures_market
     def test_get_fee_schedules_vol(self: Self, futures_auth_market: Market) -> None:
         """
-        Checks the ``get_fee_schedules_vol`` endpoint.
+        Checks the ``get_fee_schedules_vol`` endpoint and that it raises a
+        deprecation warning.
         """
-        self._assert_successful_response(futures_auth_market.get_fee_schedules_vol())
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            self._assert_successful_response(
+                futures_auth_market.get_fee_schedules_vol(),
+            )
 
     def test_get_orderbook(self: Self, futures_market: Market) -> None:
         """


### PR DESCRIPTION
Mark the Futures Fee Schedules endpoints (`Market.get_fee_schedules`, `Market.get_fee_schedules_vol`) as deprecated and point users to the Spot `GetTradeVolume` endpoint.

Closes #430