### PR TITLE
Resolve "Document FOK as a valid timeinforce value in Trade.create_order"

### DIFF
--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -153,7 +153,8 @@ class Trade(SpotClient):
             information)
         :type oflags: str | list[str], optional
         :param timeinforce: how long the order remains in the orderbook, one of:
-            ``GTC``, ``IOC``, ``GTD`` (see the referenced Kraken documentation
+            ``GTC``, ``IOC``, ``GTD``, ``FOK`` (see the referenced Kraken
+            documentation
             for more information)
         :type timeinforce: str, optional
         :param displayvol: Define how much of the volume is visible in the


### PR DESCRIPTION
Add ``FOK`` (fill-or-kill) to the documented ``timeinforce`` values in the `Trade.create_order` docstring, following the Kraken changelog entry (12 May 2026) that added it as a valid option for the Spot `AddOrder`/`AddOrderBatch` endpoints. The value already worked functionally; only the docstring was stale.

Closes #431