### PR TITLE
Resolve "Add cl_ord_id to spot clients"

### DIFF
--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -545,8 +545,6 @@ class Trade(SpotClient):
         :param deadline: RFC3339 timestamp after which the matching engine
             rejects the request
         :type deadline: str, optional
-        :raises kraken.exceptions.KrakenInvalidArgumentsError: If neither
-            ``txid`` nor ``cl_ord_id`` is set
         :return: Success or failure
         :rtype: dict
 
@@ -697,7 +695,6 @@ class Trade(SpotClient):
             extra_params=extra_params,
         )
 
-    @ensure_string("cl_ord_id")
     def cancel_order(
         self: Trade,
         txid: str | int | None = None,
@@ -718,8 +715,6 @@ class Trade(SpotClient):
         :type txid: str | int, optional
         :param cl_ord_id: Client order id to cancel
         :type cl_ord_id: str, optional
-        :raises kraken.exceptions.KrakenInvalidArgumentsError: If neither
-            ``txid`` nor ``cl_ord_id`` is set
         :return: Success or failure - Number of closed orders
         :rtype: dict
 

--- a/src/kraken/spot/trade.py
+++ b/src/kraken/spot/trade.py
@@ -75,7 +75,7 @@ class Trade(SpotClient):
         return self
 
     @ensure_string("oflags")
-    def create_order(  # pylint: disable=too-many-branches,too-many-arguments # noqa: PLR0912,PLR0913,PLR0917,C901
+    def create_order(  # pylint: disable=too-many-branches,too-many-arguments # noqa: PLR0913, PLR0917
         self: Trade,
         ordertype: str,
         side: str,
@@ -96,6 +96,7 @@ class Trade(SpotClient):
         close_price2: str | float | None = None,
         deadline: str | None = None,
         userref: int | None = None,
+        cl_ord_id: str | None = None,
         *,
         truncate: bool = False,
         reduce_only: bool | None = False,
@@ -191,6 +192,8 @@ class Trade(SpotClient):
         :type validate: bool, optional
         :param userref: User reference id for example to group orders
         :type userref: int, optional
+        :param cl_ord_id: Client order id, mutually exclusive with ``userref``
+        :type cl_ord_id: str, optional
         :raises ValueError: If input is not correct
         :return: The transaction id
         :rtype: dict
@@ -367,10 +370,6 @@ class Trade(SpotClient):
             if ordertype not in trigger_ordertypes:
                 raise ValueError(f"Cannot use trigger on ordertype {ordertype}!")
             params["trigger"] = trigger
-        if defined(timeinforce):
-            params["timeinforce"] = timeinforce
-        if defined(expiretm):
-            params["expiretm"] = str(expiretm)
         if defined(price):
             params["price"] = (
                 price
@@ -387,22 +386,33 @@ class Trade(SpotClient):
             raise ValueError(
                 f"Ordertype {ordertype} dos not allow a second price (price2)!",
             )
-        if defined(leverage):
-            params["leverage"] = str(leverage)
-        if defined(oflags):
-            params["oflags"] = oflags
-        if defined(close_ordertype):
-            params["close[ordertype]"] = close_ordertype
-        if defined(close_price):
-            params["close[price]"] = str(close_price)
-        if defined(close_price2):
-            params["close[price2]"] = str(close_price2)
-        if defined(deadline):
-            params["deadline"] = deadline
-        if defined(userref):
-            params["userref"] = userref
-        if defined(displayvol):
-            params["displayvol"] = str(displayvol)
+        params.update(
+            {
+                key: value
+                for key, value in (
+                    ("timeinforce", timeinforce),
+                    ("oflags", oflags),
+                    ("close[ordertype]", close_ordertype),
+                    ("deadline", deadline),
+                    ("userref", userref),
+                    ("cl_ord_id", cl_ord_id),
+                )
+                if defined(value)
+            },
+        )
+        params.update(
+            {
+                key: str(value)
+                for key, value in (
+                    ("expiretm", expiretm),
+                    ("leverage", leverage),
+                    ("close[price]", close_price),
+                    ("close[price2]", close_price2),
+                    ("displayvol", displayvol),
+                )
+                if defined(value)
+            },
+        )
 
         return self.request(  # type: ignore[return-value]
             method="POST",
@@ -464,7 +474,7 @@ class Trade(SpotClient):
             ...             "price": 1000000,
             ...             "timeinforce": "GTC",
             ...             "type": "sell",
-            ...             "userref": 16861348843,
+            ...             "cl_ord_id": "my-client-order-id",
             ...             "volume": 2,
             ...         },
             ...     ],
@@ -492,18 +502,53 @@ class Trade(SpotClient):
             extra_params=extra_params,
         )
 
-    def amend_order(
+    def amend_order(  # pylint: disable=too-many-arguments # noqa: PLR0913, PLR0917
         self: Trade,
+        txid: str | None = None,
+        cl_ord_id: str | None = None,
+        order_qty: str | float | None = None,
+        display_qty: str | float | None = None,
+        limit_price: str | float | None = None,
+        trigger_price: str | float | None = None,
+        pair: str | None = None,
+        post_only: bool | None = None,  # noqa: FBT001
+        deadline: str | None = None,
         *,
         extra_params: dict | None = None,
     ) -> dict:
         """
-        Amend/modify an open order.
+        Amend/modify an open order. The order to amend is identified by either
+        ``txid`` or ``cl_ord_id``.
 
         Requires the ``Create and modify orders`` and ``Cancel & close orders``
         permissions in the API key settings.
 
         - https://docs.kraken.com/api/docs/rest-api/amend-order
+
+        :param txid: The txid of the order to amend
+        :type txid: str, optional
+        :param cl_ord_id: Client order id of the order to amend
+        :type cl_ord_id: str, optional
+        :param order_qty: Set a new order quantity
+        :type order_qty: str | float, optional
+        :param display_qty: Set a new display quantity (iceberg orders only)
+        :type display_qty: str | float, optional
+        :param limit_price: Set a new limit price
+        :type limit_price: str | float, optional
+        :param trigger_price: Set a new trigger price
+        :type trigger_price: str | float, optional
+        :param pair: Required on amends for non-crypto pairs, i.e. provide the
+            pair symbol for xstocks
+        :type pair: str, optional
+        :param post_only: Set the post-only flag (default: ``False``)
+        :type post_only: bool, optional
+        :param deadline: RFC3339 timestamp after which the matching engine
+            rejects the request
+        :type deadline: str, optional
+        :raises kraken.exceptions.KrakenInvalidArgumentsError: If neither
+            ``txid`` nor ``cl_ord_id`` is set
+        :return: Success or failure
+        :rtype: dict
 
         .. code-block:: python
             :linenos:
@@ -512,15 +557,37 @@ class Trade(SpotClient):
             >>> from kraken.spot import Trade
             >>> trade = Trade(key="api-key", secret="secret-key")
             >>> trade.amend_order(
-            ...     extra_params={
-            ...         "txid": "OVM3PT-56ACO-53SM2T",
-            ...         "limit_price": "105636.9",
-            ...     }
+            ...     txid="OVM3PT-56ACO-53SM2T",
+            ...     limit_price="105636.9",
             ... )
         """
+        params: dict = {
+            key: value
+            for key, value in (
+                ("txid", txid),
+                ("cl_ord_id", cl_ord_id),
+                ("pair", pair),
+                ("post_only", post_only),
+                ("deadline", deadline),
+            )
+            if defined(value)
+        }
+        params.update(
+            {
+                key: str(value)
+                for key, value in (
+                    ("order_qty", order_qty),
+                    ("display_qty", display_qty),
+                    ("limit_price", limit_price),
+                    ("trigger_price", trigger_price),
+                )
+                if defined(value)
+            },
+        )
         return self.request(  # type: ignore[return-value]
             "POST",
             uri="/0/private/AmendOrder",
+            params=params,
             extra_params=extra_params,
         )
 
@@ -630,24 +697,29 @@ class Trade(SpotClient):
             extra_params=extra_params,
         )
 
-    @ensure_string("txid")
+    @ensure_string("cl_ord_id")
     def cancel_order(
         self: Trade,
-        txid: str,
+        txid: str | int | None = None,
+        cl_ord_id: str | None = None,
         *,
         extra_params: dict | None = None,
     ) -> dict:
         """
-        Cancel a specific order by ``txid``. Instead of a transaction id
-        a user reference id can be passed.
+        Cancel a specific order by ``txid`` or ``cl_ord_id``. Instead of a
+        transaction id a user reference id can be passed as ``txid``.
 
         Requires the ``Cancel/close orders`` permission in
         the API key settings.
 
         - https://docs.kraken.com/api/docs/rest-api/cancel-order
 
-        :param txid: Transaction id or comma delimited list of user reference ids to cancel.
-        :type txid: str
+        :param txid: Transaction id or user reference id to cancel
+        :type txid: str | int, optional
+        :param cl_ord_id: Client order id to cancel
+        :type cl_ord_id: str, optional
+        :raises kraken.exceptions.KrakenInvalidArgumentsError: If neither
+            ``txid`` nor ``cl_ord_id`` is set
         :return: Success or failure - Number of closed orders
         :rtype: dict
 
@@ -660,10 +732,15 @@ class Trade(SpotClient):
             >>> trade.cancel_order(txid="OAUHYR-YCVK6-P22G6P")
             { 'count': 1 }
         """
+        params: dict = {}
+        if defined(txid):
+            params["txid"] = txid
+        if defined(cl_ord_id):
+            params["cl_ord_id"] = cl_ord_id
         return self.request(  # type: ignore[return-value]
             method="POST",
             uri="/0/private/CancelOrder",
-            params={"txid": txid},
+            params=params,
             extra_params=extra_params,
         )
 

--- a/src/kraken/spot/user.py
+++ b/src/kraken/spot/user.py
@@ -252,6 +252,7 @@ class User(SpotClient):
     def get_open_orders(
         self: User,
         userref: int | None = None,
+        cl_ord_id: str | None = None,
         *,
         trades: bool | None = False,
         extra_params: dict | None = None,
@@ -266,6 +267,8 @@ class User(SpotClient):
 
         :param userref: Filter the results by user reference id
         :type userref: int, optional
+        :param cl_ord_id: Filter the results by client order id
+        :type cl_ord_id: str, optional
         :param trades: Include trades related to position or not into the
             response (default: ``False``)
         :type trades: bool
@@ -316,6 +319,8 @@ class User(SpotClient):
         params: dict = {"trades": trades}
         if defined(userref):
             params["userref"] = userref
+        if defined(cl_ord_id):
+            params["cl_ord_id"] = cl_ord_id
         return self.request(  # type: ignore[return-value]
             method="POST",
             uri="/0/private/OpenOrders",
@@ -330,6 +335,7 @@ class User(SpotClient):
         end: int | None = None,
         ofs: int | None = None,
         closetime: str | None = "both",
+        cl_ord_id: str | None = None,
         *,
         trades: bool | None = False,
         extra_params: dict | None = None,
@@ -344,6 +350,8 @@ class User(SpotClient):
 
         :param userref: Filter the results by user reference id
         :type userref: int, optional
+        :param cl_ord_id: Filter the results by client order id
+        :type cl_ord_id: str, optional
         :param start: Unix timestamp to start the search from
         :type start: int, optional
         :param end: Unix timestamp to define the last result to include
@@ -404,6 +412,8 @@ class User(SpotClient):
         params: dict = {"trades": trades, "closetime": closetime}
         if defined(userref):
             params["userref"] = userref
+        if defined(cl_ord_id):
+            params["cl_ord_id"] = cl_ord_id
         if defined(start):
             params["start"] = start
         if defined(end):

--- a/src/kraken/spot/ws_client.py
+++ b/src/kraken/spot/ws_client.py
@@ -281,7 +281,7 @@ class SpotWSClient(SpotWSClientBase):
             ...                     "limit_price": 500.21,
             ...                     "order_qty": 2.12345,
             ...                     "order_type": "limit",
-            ...                     "order_userref": 212345679,
+            ...                     "cl_ord_id": "my-client-order-id",
             ...                     "side": "sell",
             ...                     "stp_type": "cancel_both",
             ...                 },
@@ -361,16 +361,16 @@ class SpotWSClient(SpotWSClientBase):
             ...     }
             ... )
 
-        **Editing orders** can be done as shown in the example below. See
-        https://docs.kraken.com/api/docs/websocket-v2/edit_order for more information.
+        **Amending orders** can be done as shown in the example below. See
+        https://docs.kraken.com/api/docs/websocket-v2/amend_order for more information.
 
         .. code-block:: python
             :linenos:
-            :caption: Spot Websocket: Cancel order(s)
+            :caption: Spot Websocket: Amend order
 
             >>> await client_auth.send_message(
             ...     message={
-            ...         "method": "edit_order",
+            ...         "method": "amend_order",
             ...         "params": {
             ...             "order_id": "ORDER-ID123-456789",
             ...             "order_qty": 2.5,

--- a/tests/spot/test_spot_trade.py
+++ b/tests/spot/test_spot_trade.py
@@ -102,6 +102,7 @@ class TestSpotTrade:
                 timeinforce="GTC",
                 leverage=4,
                 deadline=deadline,
+                cl_ord_id="my-client-order-id",
             )
 
     @pytest.mark.spot_auth
@@ -204,10 +205,17 @@ class TestSpotTrade:
             match=r"API key doesn't have permission to make this request.",
         ):
             spot_auth_trade.amend_order(
-                extra_params={
-                    "txid": "OVM3PT-56ACO-53SM2T",
-                    "limit_price": "105636.9",
-                },
+                txid="OVM3PT-56ACO-53SM2T",
+                limit_price="105636.9",
+            )
+
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
+            spot_auth_trade.amend_order(
+                cl_ord_id="my-client-order-id",
+                limit_price="105636.9",
             )
 
     @pytest.mark.spot_auth
@@ -223,6 +231,12 @@ class TestSpotTrade:
             match=r"API key doesn't have permission to make this request.",
         ):
             spot_auth_trade.cancel_order(txid="OB6JJR-7NZ5P-N5SKCB")
+
+        with pytest.raises(
+            KrakenPermissionDeniedError,
+            match=r"API key doesn't have permission to make this request.",
+        ):
+            spot_auth_trade.cancel_order(cl_ord_id="my-client-order-id")
 
     @pytest.mark.spot_auth
     @pytest.mark.skip(reason="Test do not have trade/cancel permission")

--- a/tests/spot/test_spot_user.py
+++ b/tests/spot/test_spot_user.py
@@ -95,6 +95,12 @@ class TestSpotUser:
         assert is_not_error(
             spot_auth_user.get_open_orders(trades=False, userref="1234567"),
         )
+        assert is_not_error(
+            spot_auth_user.get_open_orders(
+                trades=False,
+                cl_ord_id="my-client-order-id",
+            ),
+        )
 
     def test_get_closed_orders(self: Self, spot_auth_user: User) -> None:
         """
@@ -104,6 +110,12 @@ class TestSpotUser:
         assert is_not_error(spot_auth_user.get_closed_orders())
         assert is_not_error(
             spot_auth_user.get_closed_orders(trades=True, userref="1234"),
+        )
+        assert is_not_error(
+            spot_auth_user.get_closed_orders(
+                trades=True,
+                cl_ord_id="my-client-order-id",
+            ),
         )
         assert is_not_error(
             spot_auth_user.get_closed_orders(trades=True, start="1668431675.4778206"),


### PR DESCRIPTION
# Summary

Adds support for the client order id (`cl_ord_id`) to the Spot trading and user
endpoints that accept it, as introduced by Kraken alongside `userref`.

REST:
- `Trade.create_order`, `Trade.amend_order`, `Trade.cancel_order`
- `User.get_open_orders`, `User.get_closed_orders`

`amend_order` is also fleshed out with its full named parameter list (it was
previously an `extra_params`-only stub). `cancel_order` now exposes `txid` and
`cl_ord_id` as named parameters; the `ensure_string` decorator was dropped from
it since Kraken's CancelOrder does not accept multiple txids. The websocket
`send_message` docstrings gain `cl_ord_id` examples (it is a raw passthrough, so
no code change is needed).

`User.get_orders_info` (QueryOrders) is intentionally left out: `cl_ord_id` is a
response field there, not a request parameter.

Closes #415