### PR TITLE
Add unit/integration/e2e test-type markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,10 @@ asyncio_default_fixture_loop_scope = "function"
 markers = [
   "wip: Used to run a specific test by hand.",
   "flaky: Flaky tests",
+  # Test-type axis (orthogonal to the domain markers below).
+  "unit: Offline test — no network, no API keys, deterministic.",
+  "integration: Live test hitting the Kraken REST/Websocket API.",
+  "e2e: End-to-end test driving the CLI binary / full auth flows.",
   "spot: Spot endpoint.",
   "xstocks: Spot xStocks endpoint.",
   "spot_auth: Private Spot endpoint.",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module implementing unit tests for the command-line interface"""
+"""Module implementing end-to-end tests for the command-line interface"""
 
 from __future__ import annotations
 
@@ -18,12 +18,14 @@ if TYPE_CHECKING:
 import pytest
 
 
+@pytest.mark.e2e
 @pytest.mark.spot
 def test_cli_version(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(cli, ["--version"], catch_exceptions=False)
     assert result.exit_code == 0
 
 
+@pytest.mark.e2e
 @pytest.mark.spot
 @pytest.mark.parametrize(
     "args",
@@ -67,6 +69,7 @@ def test_cli_spot_public(cli_runner: CliRunner, args: list[str]) -> None:
     assert result.exit_code == 0
 
 
+@pytest.mark.e2e
 @pytest.mark.usefixtures("with_spot_secrets")
 @pytest.mark.spot
 @pytest.mark.spot_auth
@@ -103,6 +106,7 @@ def test_cli_spot_private(cli_runner: CliRunner, args: list[str]) -> None:
     assert result.exit_code == 0
 
 
+@pytest.mark.e2e
 @pytest.mark.futures
 @pytest.mark.parametrize(
     "args",
@@ -122,6 +126,7 @@ def test_cli_futures_public(cli_runner: CliRunner, args: list[str]) -> None:
     assert result.exit_code == 0
 
 
+@pytest.mark.e2e
 @pytest.mark.usefixtures("with_futures_secrets")
 @pytest.mark.futures
 @pytest.mark.futures_auth
@@ -143,6 +148,7 @@ def test_cli_futures_private(cli_runner: CliRunner, args: list[str]) -> None:
     assert result.exit_code == 0
 
 
+@pytest.mark.unit
 @pytest.mark.spot
 @pytest.mark.parametrize(
     ("url", "expected"),
@@ -206,6 +212,7 @@ def test_get_base_url(url: str, expected: str) -> None:
     assert _get_base_url(url) == expected
 
 
+@pytest.mark.unit
 @pytest.mark.spot
 @pytest.mark.parametrize(
     ("url", "expected"),

--- a/tests/futures/test_futures_base_api.py
+++ b/tests/futures/test_futures_base_api.py
@@ -21,6 +21,7 @@ from kraken.futures import Funding, Market, Trade, User
 from .helper import is_success
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 class TestFuturesBaseAPI:
     """Test class for Futures Base API functionality."""
@@ -75,6 +76,7 @@ class TestFuturesBaseAPI:
 # Futures async client
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 class TestFuturesBaseAPIAsync:
     """Test class for Futures Base API async functionality."""
@@ -130,8 +132,8 @@ class TestFuturesBaseAPIAsync:
         run(check())
 
 
+@pytest.mark.integration
 @pytest.mark.futures
-@pytest.mark.futures_market
 @pytest.mark.futures_market
 class TestProxyPyEmbedded(TestCase, IsolatedAsyncioTestCase):
     def get_proxy_str(self: Self) -> str:

--- a/tests/futures/test_futures_funding.py
+++ b/tests/futures/test_futures_funding.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Futures funding client."""
+"""Module that implements the integration tests for the Futures funding client."""
 
 from typing import Self
 
@@ -16,6 +16,7 @@ from kraken.futures import Funding
 from .helper import is_success
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.futures_funding

--- a/tests/futures/test_futures_market.py
+++ b/tests/futures/test_futures_market.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Futures market client."""
+"""Module that implements the integration tests for the Futures market client."""
 
 from typing import Any, Self
 
@@ -16,6 +16,7 @@ from kraken.futures import Market
 from .helper import is_not_error, is_success
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_market
 class TestFuturesMarket:

--- a/tests/futures/test_futures_trade.py
+++ b/tests/futures/test_futures_trade.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Futures trade client"""
+"""Module that implements the integration tests for the Futures trade client"""
 
 from collections.abc import Generator
 from contextlib import suppress
@@ -34,6 +34,7 @@ def _run_before_and_after_tests(futures_demo_trade: Trade) -> Generator:
     sleep(0.25)
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.futures_trade

--- a/tests/futures/test_futures_user.py
+++ b/tests/futures/test_futures_user.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Futures user client."""
+"""Module that implements the integration tests for the Futures user client."""
 
 import random
 import tempfile
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     import requests
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.futures_user

--- a/tests/futures/test_futures_websocket.py
+++ b/tests/futures/test_futures_websocket.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Futures websocket client"""
+"""Module that implements the unit and integration tests for the Futures websocket client"""
 
 from __future__ import annotations
 
@@ -23,6 +23,7 @@ import pytest
 from .helper import FuturesWebsocketClientTestWrapper
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_websocket
 def test_create_public_client(caplog: pytest.LogCaptureFixture) -> None:
@@ -44,6 +45,7 @@ def test_create_public_client(caplog: pytest.LogCaptureFixture) -> None:
     assert "{'event': 'info', 'version': 1}" in caplog.text
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.futures_websocket
@@ -70,6 +72,7 @@ def test_create_private_client(
     assert "{'event': 'info', 'version': 1}" in caplog.text
 
 
+@pytest.mark.unit
 @pytest.mark.futures
 @pytest.mark.futures_websocket
 def test_get_available_public_subscriptions() -> None:
@@ -90,6 +93,7 @@ def test_get_available_public_subscriptions() -> None:
     )
 
 
+@pytest.mark.unit
 @pytest.mark.futures
 @pytest.mark.futures_websocket
 def test_get_available_private_subscriptions() -> None:
@@ -114,6 +118,7 @@ def test_get_available_private_subscriptions() -> None:
     )
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_websocket
 def test_subscribe_public(caplog: pytest.LogCaptureFixture) -> None:
@@ -151,6 +156,7 @@ def test_subscribe_public(caplog: pytest.LogCaptureFixture) -> None:
         assert expected in caplog.text
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.futures_websocket
@@ -193,6 +199,7 @@ def test_subscribe_private(
         assert expected in caplog.text
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_websocket
 def test_unsubscribe_public(caplog: pytest.LogCaptureFixture) -> None:
@@ -229,6 +236,7 @@ def test_unsubscribe_public(caplog: pytest.LogCaptureFixture) -> None:
         assert expected in caplog.text
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.futures_websocket
@@ -269,6 +277,7 @@ def test_unsubscribe_private(
         assert expected in caplog.text
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_websocket
 def test_get_active_subscriptions(caplog: pytest.LogCaptureFixture) -> None:
@@ -297,6 +306,7 @@ def test_get_active_subscriptions(caplog: pytest.LogCaptureFixture) -> None:
         assert expected in caplog.text
 
 
+@pytest.mark.integration
 @pytest.mark.futures
 @pytest.mark.futures_auth
 @pytest.mark.futures_websocket

--- a/tests/spot/conftest.py
+++ b/tests/spot/conftest.py
@@ -6,7 +6,7 @@
 #
 
 """
-Module providing fixtures used for the unit tests regarding the Kraken Spot API.
+Module providing fixtures used for the tests regarding the Kraken Spot API.
 """
 
 import os

--- a/tests/spot/helper.py
+++ b/tests/spot/helper.py
@@ -6,8 +6,8 @@
 #
 
 """
-Module that implements the unit tests for the Kraken Spot Websocket API v2
-client.
+Module that implements helpers for the Kraken Spot Websocket API v2
+client tests.
 """
 
 from __future__ import annotations
@@ -95,7 +95,7 @@ class SpotOrderBookClientWrapper(SpotOrderBookClient):
         """
         Ensures that the messages are logged.
         Into a file for debugging and general to the log
-        to read the logs within the unit tests.
+        to read the logs within the tests.
         """
         cls.LOG.info(json.dumps(content))
 

--- a/tests/spot/test_spot_base_api.py
+++ b/tests/spot/test_spot_base_api.py
@@ -31,6 +31,7 @@ from typing import Self
 from .helper import is_not_error
 
 
+@pytest.mark.integration
 @pytest.mark.spot
 class TestSpotBaseAPI:
     """Test class for Spot Base API functionality."""
@@ -213,6 +214,7 @@ class TestProxyPyEmbedded(TestCase, IsolatedAsyncioTestCase):
     def get_proxy_str(self: Self) -> str:
         return f"http://127.0.0.1:{self.PROXY.flags.port}"
 
+    @pytest.mark.integration
     @pytest.mark.spot
     @pytest.mark.spot_market
     def test_spot_rest_proxies(self: Self) -> None:
@@ -229,6 +231,7 @@ class TestProxyPyEmbedded(TestCase, IsolatedAsyncioTestCase):
             ),
         )
 
+    @pytest.mark.integration
     @pytest.mark.spot
     @pytest.mark.spot_market
     @pytest.mark.asyncio

--- a/tests/spot/test_spot_earn.py
+++ b/tests/spot/test_spot_earn.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Spot Earn client."""
+"""Module that implements the integration tests for the Spot Earn client."""
 
 from typing import Any, Self
 
@@ -16,6 +16,7 @@ from kraken.spot import Earn
 from .helper import is_not_error
 
 
+@pytest.mark.integration
 @pytest.mark.spot
 @pytest.mark.spot_auth
 @pytest.mark.spot_earn

--- a/tests/spot/test_spot_funding.py
+++ b/tests/spot/test_spot_funding.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Spot funding client."""
+"""Module that implements the integration tests for the Spot funding client."""
 
 from typing import Any, Self
 
@@ -17,6 +17,7 @@ from kraken.spot import Funding
 from .helper import is_not_error
 
 
+@pytest.mark.integration
 @pytest.mark.spot
 @pytest.mark.spot_auth
 @pytest.mark.spot_funding

--- a/tests/spot/test_spot_market.py
+++ b/tests/spot/test_spot_market.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Spot market client."""
+"""Module that implements the integration tests for the Spot market client."""
 
 from time import sleep
 from typing import Any, Self
@@ -17,6 +17,7 @@ from kraken.spot import Market
 from .helper import is_not_error
 
 
+@pytest.mark.integration
 @pytest.mark.spot
 @pytest.mark.spot_market
 class TestSpotMarket:

--- a/tests/spot/test_spot_orderbook.py
+++ b/tests/spot/test_spot_orderbook.py
@@ -6,7 +6,8 @@
 #
 
 """
-Module that implements the unit tests regarding the Spot Orderbook client.
+Module that implements the unit and integration tests regarding the Spot
+Orderbook client.
 """
 
 from __future__ import annotations
@@ -41,6 +42,7 @@ class TestSpotOrderBook:
     TEST_PAIR_BTCEUR = "BTC/EUR"
     TEST_DEPTH = 10
 
+    @pytest.mark.integration
     def test_create_public_bot(self: Self, caplog: pytest.LogCaptureFixture) -> None:
         """
         Checks if the websocket client can be instantiated.
@@ -61,6 +63,7 @@ class TestSpotOrderBook:
         ):
             assert expected in caplog.text
 
+    @pytest.mark.unit
     def test_get_first(self) -> None:
         """
         Checks the ``get_first`` method.
@@ -71,6 +74,7 @@ class TestSpotOrderBook:
             == SpotOrderBookClientWrapper.get_first((10, 5))
         )
 
+    @pytest.mark.unit
     @mock.patch("kraken.spot.orderbook.SpotWSClient", return_value=None)
     @mock.patch(
         "kraken.spot.orderbook.SpotOrderBookClient.remove_book",
@@ -124,6 +128,7 @@ class TestSpotOrderBook:
 
         asyncio.run(assign())
 
+    @pytest.mark.integration
     def test_add_book(self: Self, caplog: pytest.LogCaptureFixture) -> None:
         """
         Checks if the orderbook client is able to add a book by subscribing.
@@ -168,6 +173,7 @@ class TestSpotOrderBook:
         ):
             assert expected in caplog.text
 
+    @pytest.mark.integration
     def test_remove_book(self: Self, caplog: pytest.LogCaptureFixture) -> None:
         """
         Checks if the orderbook client is able to add a book by subscribing to a book

--- a/tests/spot/test_spot_trade.py
+++ b/tests/spot/test_spot_trade.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Spot trade client."""
+"""Module that implements the integration tests for the Spot trade client."""
 
 from datetime import UTC, datetime, timedelta
 from time import sleep
@@ -17,6 +17,7 @@ from kraken.exceptions import KrakenPermissionDeniedError
 from kraken.spot import Trade
 
 
+@pytest.mark.integration
 @pytest.mark.spot
 @pytest.mark.spot_trade
 class TestSpotTrade:

--- a/tests/spot/test_spot_user.py
+++ b/tests/spot/test_spot_user.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Spot user client."""
+"""Module that implements the unit and integration tests for the Spot user client."""
 
 import random
 import tempfile
@@ -24,6 +24,37 @@ from kraken.spot import User
 from .helper import is_not_error
 
 
+@pytest.mark.unit
+@pytest.mark.spot
+@pytest.mark.spot_user
+class TestSpotUserUnit:
+    """Offline unit tests for the Spot User client."""
+
+    def test_get_balance(self: Self) -> None:
+        """
+        Checks the ``get_balance`` function by mocking the internal API call
+        (``get_balances``, covered by the integration test) and checking the
+        return value.
+        """
+        with mock.patch.object(
+            User,
+            "get_balances",
+            return_value={
+                "XXLM": {"balance": "0.00000000", "hold_trade": "0.00000000"},
+                "ZEUR": {"balance": "500.0000", "hold_trade": "0.0000"},
+                "XXBT": {"balance": "2.1031709100", "hold_trade": "0.1401000000"},
+                "KFEE": {"balance": "7407.73", "hold_trade": "0.00"},
+            },
+        ):
+            result: dict = User().get_balance(currency="XBT")
+            assert result == {
+                "currency": "XXBT",
+                "balance": 2.1031709100,
+                "available_balance": 1.96307091,
+            }
+
+
+@pytest.mark.integration
 @pytest.mark.spot
 @pytest.mark.spot_auth
 @pytest.mark.spot_user
@@ -51,29 +82,6 @@ class TestSpotUser:
         result: dict = spot_auth_user.get_balances()
         assert isinstance(result, dict)
         assert is_not_error(result)
-
-    def test_get_balance(self: Self, spot_auth_user: User) -> None:
-        """
-        Checks the ``get_balances`` function by mocking the internal API call
-        (which is already covered by :func:`test_get_balances`) and checking the
-        return value.
-        """
-        with mock.patch.object(
-            User,
-            "get_balances",
-            return_value={
-                "XXLM": {"balance": "0.00000000", "hold_trade": "0.00000000"},
-                "ZEUR": {"balance": "500.0000", "hold_trade": "0.0000"},
-                "XXBT": {"balance": "2.1031709100", "hold_trade": "0.1401000000"},
-                "KFEE": {"balance": "7407.73", "hold_trade": "0.00"},
-            },
-        ):
-            result: dict = spot_auth_user.get_balance(currency="XBT")
-            assert result == {
-                "currency": "XXBT",
-                "balance": 2.1031709100,
-                "available_balance": 1.96307091,
-            }
 
     def test_get_trade_balance(self: Self, spot_auth_user: User) -> None:
         """

--- a/tests/spot/test_spot_websocket.py
+++ b/tests/spot/test_spot_websocket.py
@@ -46,6 +46,7 @@ class TestSpotWebSocket:
     TEST_SYMBOL_BTCUSD = "BTC/USD"
     TEST_REQ_ID = 123456789
 
+    @pytest.mark.integration
     def test_create_public_client(self, caplog: pytest.LogCaptureFixture) -> None:
         """
         Checks if the websocket client can be instantiated.
@@ -67,6 +68,7 @@ class TestSpotWebSocket:
         ):
             assert expected in caplog.text
 
+    @pytest.mark.integration
     def test_create_public_client_as_context_manager(
         self,
         caplog: pytest.LogCaptureFixture,
@@ -89,6 +91,7 @@ class TestSpotWebSocket:
         ):
             assert expected in caplog.text
 
+    @pytest.mark.integration
     def test_access_public_client_attributes(self) -> None:
         """
         Checks the ``access_public_client_attributes`` function
@@ -114,6 +117,7 @@ class TestSpotWebSocket:
 
         asyncio_run(check_access())
 
+    @pytest.mark.unit
     def test_access_public_subscriptions_no_conn_failing(self) -> None:
         """
         Checks if ``active_public_subscriptions`` fails, because there is no
@@ -131,6 +135,7 @@ class TestSpotWebSocket:
 
         asyncio_run(check_access())
 
+    @pytest.mark.integration
     @pytest.mark.spot_auth
     def test_access_private_client_attributes(
         self,
@@ -154,6 +159,7 @@ class TestSpotWebSocket:
 
         asyncio_run(check_access())
 
+    @pytest.mark.integration
     def test_send_message_missing_method_failing(self) -> None:
         """
         Checks if the send_message function fails when specific keys or values
@@ -184,6 +190,7 @@ class TestSpotWebSocket:
 
         asyncio_run(create_client())
 
+    @pytest.mark.integration
     def test_send_message_raw(self, caplog: pytest.LogCaptureFixture) -> None:
         """
         Checks if the send_message function fails when the socket is not available.
@@ -202,6 +209,7 @@ class TestSpotWebSocket:
         assert '{"method": "pong", "req_id": 123456789' in caplog.text
         assert '"success": false' not in caplog.text
 
+    @pytest.mark.integration
     def test_public_subscribe(self, caplog: pytest.LogCaptureFixture) -> None:
         """
         Function that checks if the websocket client is able to subscribe to public
@@ -225,6 +233,7 @@ class TestSpotWebSocket:
         )
         assert '"success": false' not in caplog.text
 
+    @pytest.mark.integration
     @pytest.mark.spot_auth
     def test_private_subscribe_failing_on_public_connection(self) -> None:
         """
@@ -244,6 +253,7 @@ class TestSpotWebSocket:
 
         asyncio_run(test_subscription())
 
+    @pytest.mark.integration
     @pytest.mark.spot_auth
     def test_private_subscribe(
         self,
@@ -276,6 +286,7 @@ class TestSpotWebSocket:
         )
         assert '"success": false' not in caplog.text
 
+    @pytest.mark.integration
     def test_public_unsubscribe(self, caplog: pytest.LogCaptureFixture) -> None:
         """
         Checks if the websocket client can unsubscribe from public feeds.
@@ -300,6 +311,7 @@ class TestSpotWebSocket:
             assert expected in caplog.text
         assert '"success": false' not in caplog.text
 
+    @pytest.mark.integration
     def test_public_unsubscribe_failure(self, caplog: pytest.LogCaptureFixture) -> None:
         """
         Checks if the websocket client responses with failures
@@ -324,6 +336,7 @@ class TestSpotWebSocket:
             in caplog.text
         )
 
+    @pytest.mark.integration
     @pytest.mark.spot_auth
     def test_private_unsubscribe(
         self,
@@ -363,6 +376,7 @@ class TestSpotWebSocket:
             assert expected in caplog.text
         assert '"success": false' not in caplog.text
 
+    @pytest.mark.unit
     def test___transform_subscription(self) -> None:
         """
         Checks if the subscription transformation works properly by checking
@@ -398,6 +412,7 @@ class TestSpotWebSocket:
                 == target_subscription
             )
 
+    @pytest.mark.unit
     def test___transform_subscription_no_change(self) -> None:
         """
         Similar to the test above -- but verifying that messages that don't need an
@@ -430,6 +445,7 @@ class TestSpotWebSocket:
                 == incoming_subscription
             )
 
+    @pytest.mark.integration
     @pytest.mark.spot_auth
     def test_reconnect(
         self,

--- a/tests/spot/test_spot_websocket_internals.py
+++ b/tests/spot/test_spot_websocket_internals.py
@@ -18,6 +18,7 @@ import pytest
 from kraken.spot.websocket import SpotWSClientBase
 
 
+@pytest.mark.unit
 @pytest.mark.spot
 @pytest.mark.spot_websocket
 class TestSpotWebSocketInternals:

--- a/tests/spot/test_xstocks_basic.py
+++ b/tests/spot/test_xstocks_basic.py
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-"""Module that implements the unit tests for the Spot xStocks features."""
+"""Module that implements the integration tests for the Spot xStocks features."""
 
 from typing import ClassVar, Self
 
@@ -15,6 +15,7 @@ from kraken.exceptions import KrakenPermissionDeniedError
 from kraken.spot import Market, SpotClient, Trade
 
 
+@pytest.mark.integration
 @pytest.mark.spot
 @pytest.mark.xstocks
 @pytest.mark.skip(reason="xStocks is only available in certain regions!")


### PR DESCRIPTION
# Summary

Adds a test-type marker axis on top of the existing domain markers, so the suite can be sliced by how a test runs rather than only by what it covers.

- Register `unit`, `integration`, and `e2e` markers in `pyproject.toml`.
- Tag every test with one type marker alongside its domain markers. Mixed files use per-test markers, because class and module markers are additive. The single offline Spot user test moves into a new `TestSpotUserUnit` class.
- Fix docstrings that called the live-API tests "unit tests".

The `unit` lane runs offline without any API keys.