### PR TITLE
Pin astral-sh/setup-uv to a full commit SHA

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -51,7 +51,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Check git status (not Windows)
         if: runner.os != 'Windows'

--- a/.github/workflows/_build_doc.yaml
+++ b/.github/workflows/_build_doc.yaml
@@ -40,7 +40,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/_test_futures_private.yaml
+++ b/.github/workflows/_test_futures_private.yaml
@@ -83,7 +83,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install package (Linux or macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/_test_futures_public.yaml
+++ b/.github/workflows/_test_futures_public.yaml
@@ -70,7 +70,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install package (Linux or macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/_test_spot_private.yaml
+++ b/.github/workflows/_test_spot_private.yaml
@@ -85,7 +85,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install package (Linux or macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/_test_spot_public.yaml
+++ b/.github/workflows/_test_spot_public.yaml
@@ -71,7 +71,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install package (Linux or macOS)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Replace the mutable `@v7` tag with the v7.6.0 commit SHA across the six workflows that still resolve it by tag, closing the remaining code-scanning pinning alerts. The version comment is retained so Dependabot continues to track updates.

--- 
> NOTE: The change in coverage by this PR is due to the flaky nature of the tests. Here, during this run (compared to the current master) there was no pending process that needed to be canceled when the websocket connection reconnects or terminates, see https://app.codecov.io/gh/btschwertfeger/python-kraken-sdk/pull/440/blob/src/kraken/spot/websocket/connectors.py?dropdown=coverage#L256 (this PR) vs https://app.codecov.io/gh/btschwertfeger/python-kraken-sdk/commit/c0a4f1e07518766e6e7a538ce82f87f6cafc4fc9/blob/src/kraken/spot/websocket/connectors.py?dropdown=coverage#L258 (current master).