### PR TITLE
Set a read-only default token permission in cicd.yaml

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -66,6 +66,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Restrict the default token to read-only; jobs opt into more as needed.
+permissions:
+  contents: read
+
 jobs:
   ## ===========================================================================
   ##    Checks the code logic, style and more
@@ -77,6 +81,10 @@ jobs:
   ##  Discover vulnerabilities
   ##
   CodeQL:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: ./.github/workflows/_codeql.yaml
 
   ## ===========================================================================


### PR DESCRIPTION
Add a top-level `permissions: contents: read` default to the CI/CD workflow so a job added without its own block no longer inherits the repository's write-all default. The CodeQL job re-grants the `security-events: write` and `actions: read` scopes its reusable workflow needs.

This test proved that in this CI setup, a global permission does not work, since the cicd.yaml is only the orchestrator that restricts permissions of downstream workflow files.

The workflow did not start a job and resulted in:
> [Invalid workflow file: .github/workflows/cicd.yaml#L192](https://github.com/btschwertfeger/python-kraken-sdk/actions/runs/28423312612/workflow)
The workflow is not valid. .github/workflows/cicd.yaml (Line: 192, Col: 3): Error calling workflow 'btschwertfeger/python-kraken-sdk/.github/workflows/_pypi_test_publish.yaml@17d071ab08d741a7a8dea8900495deba166b6bbc'. The workflow is requesting 'actions: read, artifact-metadata: read, attestations: read, checks: read, code-quality: read, deployments: read, discussions: read, issues: read, models: read, vulnerability-alerts: read, packages: read, pages: read, pull-requests: read, repository-projects: read, statuses: read, [...] .github/workflows/cicd.yaml (Line: 192, Col: 3): Error calling workflow 'btschwertfeger/python-kraken-sdk/.github/workflows/_pypi_test_publish.yaml@17d071ab08d741a7a8dea8900495deba166b6bbc'. The nested job 'publish-to-test-pypi' is requesting 'id-token: write', but is only allowed 'id-token: none'.