### PR TITLE
Publish via OIDC Trusted Publishing and set a read-only default token

### DIFF
--- a/.github/workflows/_pypi_publish.yaml
+++ b/.github/workflows/_pypi_publish.yaml
@@ -11,11 +11,9 @@ name: PyPI Publish
 
 on:
   workflow_call:
-    secrets:
-      API_TOKEN:
-        required: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   publish-to-pypi:
@@ -53,5 +51,4 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          password: ${{ secrets.API_TOKEN }}
           repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/_pypi_test_publish.yaml
+++ b/.github/workflows/_pypi_test_publish.yaml
@@ -11,11 +11,9 @@ name: PyPI Publish
 
 on:
   workflow_call:
-    secrets:
-      API_TOKEN:
-        required: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   publish-to-test-pypi:
@@ -52,5 +50,4 @@ jobs:
       - name: Publish package distributions to Test PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          password: ${{ secrets.API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -66,6 +66,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Restrict the default token to read-only; jobs opt into more as needed.
+permissions:
+  contents: read
+
 jobs:
   ## ===========================================================================
   ##    Checks the code logic, style and more
@@ -77,6 +81,10 @@ jobs:
   ##  Discover vulnerabilities
   ##
   CodeQL:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: ./.github/workflows/_codeql.yaml
 
   ## ===========================================================================
@@ -196,9 +204,10 @@ jobs:
       - Test-Spot-Private
       - Test-Spot-Public
     name: Upload development version to Test PyPI
+    permissions:
+      contents: read
+      id-token: write # mandatory for OIDC Trusted Publishing
     uses: ./.github/workflows/_pypi_test_publish.yaml
-    secrets:
-      API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
   ## ===========================================================================
   ##    Upload the python-kraken-sdk to Production PyPI
@@ -217,6 +226,7 @@ jobs:
       - Test-Spot-Private
       - Test-Spot-Public
     name: Upload release to PyPI
+    permissions:
+      contents: read
+      id-token: write # mandatory for OIDC Trusted Publishing
     uses: ./.github/workflows/_pypi_publish.yaml
-    secrets:
-      API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Replaces the long-lived PyPI API tokens with OIDC Trusted Publishing and restricts the default workflow token to read-only.

## Reasoning behind the changes

- Drop `password: ${{ secrets.API_TOKEN }}` from both publish workflows. Publishing now authenticates through the trusted publishers registered on pypi.org and test.pypi.org (workflow `cicd.yaml`, environments `pypi`/`testpypi`). This also enables PEP 740 attestations, which `gh-action-pypi-publish` uploads automatically under Trusted Publishing.
- Add a top-level `permissions: contents: read` default, so a job added without its own block no longer inherits the repository's write-all default.
- Grant each job only the scopes it needs: CodeQL `actions: read` + `security-events: write`; both publish jobs `id-token: write`.
- Tighten the reusable publish workflows from `permissions: read-all` to `contents: read`.

The read-only default is what #441 attempted on its own and could not merge since the publish jobs still requesting `id-token: write` and the reusable workflows declaring `read-all`, the permission chain was rejected at startup. Scoping the publish jobs to `id-token: write` and tightening the reusable workflows to `contents: read` is is considered as more secure.

Related: #420
