### PR TITLE
Resolve "Attest build provenance"

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -109,3 +109,32 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+
+      # Generate a CycloneDX SBOM from an environment that has the freshly built
+      # wheel installed, so the manifest captures the full transitive dependency
+      # tree. Kept out of dist/ so the publish job never uploads it to PyPI. The
+      # release job attests it and attaches it to the GitHub Release.
+      - name: Generate CycloneDX SBOM
+        if: runner.os == 'linux' && inputs.python-version == '3.11'
+        run: |
+          uv venv .venv-sbom
+          uv pip install --python .venv-sbom/bin/python dist/python_kraken_sdk*.whl
+          uvx --from cyclonedx-bom cyclonedx-py environment .venv-sbom/bin/python \
+            --pyproject pyproject.toml \
+            --output-format JSON \
+            --output-file sbom.cdx.json
+          # setuptools_scm makes the version dynamic, so --pyproject reads no version
+          # from pyproject.toml. Inject the built version (from the wheel filename) into
+          # the SBOM's root component so the manifest carries the released version.
+          VERSION="$(ls dist/python_kraken_sdk-*.whl | sed -E 's|.*python_kraken_sdk-(.+)-py3-none-any\.whl|\1|')"
+          jq --arg v "$VERSION" \
+            '.metadata.component.version = $v
+             | .metadata.component.purl = ("pkg:pypi/python-kraken-sdk@" + $v)' \
+            sbom.cdx.json > sbom.cdx.tmp && mv sbom.cdx.tmp sbom.cdx.json
+
+      - name: Store the SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: runner.os == 'linux' && inputs.python-version == '3.11'
+        with:
+          name: sbom
+          path: sbom.cdx.json

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -265,8 +265,9 @@ jobs:
     # https://github.com/pypi/warehouse/issues/11096
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # attach the SBOM as a release asset
       id-token: write # mandatory for OIDC Trusted Publishing
+      attestations: write # write build-provenance and SBOM attestations
     environment:
       name: pypi
       url: https://pypi.org/p/python-kraken-sdk
@@ -295,7 +296,33 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+      - name: Download the SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+          path: .
+
+      # SLSA build provenance for the wheel and sdist, written to GitHub's
+      # attestation store and verifiable with `gh attestation verify`.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: "dist/*"
+
+      # Bind the CycloneDX SBOM to the same distributions, verifiable with
+      # `gh attestation verify --predicate-type https://cyclonedx.org/bom`.
+      - name: Attest SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: "dist/*"
+          sbom-path: sbom.cdx.json
+
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           repository-url: https://upload.pypi.org/legacy/
+
+      - name: Attach the SBOM to the GitHub Release
+        run: gh release upload "${{ github.event.release.tag_name }}" sbom.cdx.json --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -57,11 +57,15 @@ doc/_build/
 # Environments
 .env
 .venv
+.venv-sbom/
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Generated SBOM (built in CI, not committed)
+sbom.cdx.json
 
 # mkdocs documentation
 /site


### PR DESCRIPTION
Attests SLSA build provenance and binds a CycloneDX SBOM to the wheel and sdist in the release publish job, then attaches the SBOM to the GitHub Release.

Closes #420.