### PR TITLE
Drop SBOM release-asset upload under immutable releases

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -265,7 +265,7 @@ jobs:
     # https://github.com/pypi/warehouse/issues/11096
     runs-on: ubuntu-latest
     permissions:
-      contents: write # attach the SBOM as a release asset
+      contents: read
       id-token: write # mandatory for OIDC Trusted Publishing
       attestations: write # write build-provenance and SBOM attestations
     environment:
@@ -288,7 +288,6 @@ jobs:
             timestamp.sigstore.dev
             tuf-repo-cdn.sigstore.dev
             upload.pypi.org
-            uploads.github.com:443
 
       - name: Download all the distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -321,8 +320,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           repository-url: https://upload.pypi.org/legacy/
-
-      - name: Attach the SBOM to the GitHub Release
-        run: gh release upload "${{ github.event.release.tag_name }}" sbom.cdx.json --clobber
-        env:
-          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
`UploadPyPI` attached the SBOM with `gh release upload`, but immutable releases reject asset changes after publish and the job runs on `release: created`, which fires only once the release is already published. The step could never attach the SBOM. The SBOM still ships as a digest-bound attestation, and PEP 770 will embed it in the wheel once `setuptools` supports it.

Dropping the step also returns the job to `contents: read`, clearing Scorecard alert https://github.com/btschwertfeger/python-kraken-sdk/security/code-scanning/160.